### PR TITLE
Add Vercel deployment for Slidev presentations

### DIFF
--- a/.claude/memory/git-workflow-never-commit-to-main.md
+++ b/.claude/memory/git-workflow-never-commit-to-main.md
@@ -1,0 +1,123 @@
+# Git Workflow: NEVER Commit Directly to Main
+
+## ⚠️ Critical Rule
+
+**NEVER commit directly to `main` branch.** Always use feature branches for ALL changes.
+
+## ✅ Proper Workflow
+
+### 1. Branch
+Create feature branch from main:
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/descriptive-name
+```
+
+### 2. Commit
+Make changes and commit to feature branch:
+```bash
+git add <files>
+git commit -m "descriptive message"
+```
+
+### 3. Push
+Push feature branch to remote:
+```bash
+git push origin feature/descriptive-name
+```
+
+### 4. PR
+Create pull request via GitHub:
+```bash
+gh pr create --title "Title" --body "Description"
+```
+
+### 5. Test
+Wait for CI/CD checks to pass on the PR.
+
+### 6. Merge
+Merge PR after approval:
+```bash
+gh pr merge --squash  # or --merge, --rebase
+```
+
+## Branch Naming Conventions
+
+- `feature/add-roadmap-presentation` - New features
+- `fix/correct-milestone-dates` - Bug fixes
+- `docs/update-readme` - Documentation
+- `refactor/improve-safety-module` - Code refactoring
+- `test/add-integration-tests` - Test additions
+- `chore/update-dependencies` - Maintenance
+- `release/vX.Y.Z` - Release preparation (use `/caro.release.*` skills)
+
+## Why This Matters
+
+- **Code Review**: PRs allow team review before merge
+- **CI/CD**: Automated tests run on PRs before merge
+- **History**: Clean git history with descriptive PR titles
+- **Rollback**: Easier to revert entire features
+- **Collaboration**: Multiple people can work without conflicts
+- **Safety**: Protects main branch from accidental breaks
+
+## ❌ Exceptions
+
+**NONE.** Even for:
+- "Quick fixes"
+- "Just documentation"
+- "Small typo fixes"
+- "Urgent hotfixes" (use `/caro.release.hotfix` instead)
+
+**Always use a feature branch.**
+
+## 🔍 Pre-Work Checklist
+
+Before starting ANY work:
+
+1. **Check current branch**:
+   ```bash
+   git branch --show-current
+   ```
+
+2. **If on `main`, STOP and create feature branch immediately**:
+   ```bash
+   git checkout -b feature/my-work
+   ```
+
+3. **Only merge via PR, never commit directly to main**
+
+## 🎯 This Applies To
+
+- Code changes
+- Documentation updates
+- Configuration files
+- Presentations
+- Scripts
+- Dependencies
+- **Everything**
+
+## 🚨 If You Accidentally Committed to Main
+
+If you realize you committed directly to main:
+
+```bash
+# DON'T PUSH! First undo the commit
+git reset --soft HEAD~1
+
+# Create feature branch
+git checkout -b feature/my-work
+
+# Recommit on feature branch
+git commit -m "message"
+
+# Push feature branch and create PR
+git push origin feature/my-work
+gh pr create
+```
+
+## 📝 Memory Created
+
+**Date**: December 29, 2025
+**Reason**: Committed roadmap presentation directly to main instead of using feature branch
+**Lesson**: ALWAYS use feature branches, no exceptions

--- a/presentation/DEPLOYMENT.md
+++ b/presentation/DEPLOYMENT.md
@@ -1,0 +1,206 @@
+# Slidev Presentation Deployment Guide
+
+This guide explains how to deploy the Caro Slidev presentations to Vercel.
+
+## Overview
+
+The project contains two Slidev presentations:
+- **Main Presentation** (`slides.md`) - Technical overview of Caro
+- **Roadmap Presentation** (`roadmap-slides.md`) - 2026 development roadmap
+
+Both presentations are built and deployed together on Vercel.
+
+## Deployment URLs
+
+When deployed to Vercel:
+- Main presentation: `https://your-domain.vercel.app/`
+- Roadmap presentation: `https://your-domain.vercel.app/roadmap/`
+
+## Build Process
+
+### Local Build
+
+Build both presentations locally:
+
+```bash
+cd presentation
+npm install
+npm run build:all
+```
+
+This will:
+1. Build the main presentation to `dist/`
+2. Build the roadmap presentation to `dist-roadmap/` with base path `/roadmap/`
+3. Copy roadmap build to `dist/roadmap/`
+4. Clean up temporary `dist-roadmap/` directory
+
+### Output Structure
+
+```
+dist/
+├── index.html          # Main presentation
+├── assets/             # Main presentation assets
+├── roadmap/
+│   ├── index.html     # Roadmap presentation
+│   └── assets/        # Roadmap presentation assets
+└── ...
+```
+
+## Vercel Configuration
+
+The project is configured via `vercel.json` at the repository root:
+
+```json
+{
+  "buildCommand": "cd presentation && npm install && npm run build:all",
+  "outputDirectory": "presentation/dist",
+  "installCommand": "cd presentation && npm install"
+}
+```
+
+### Key Configuration Details
+
+- **buildCommand**: Runs the `build:all` script to build both presentations
+- **outputDirectory**: Points to `presentation/dist` where the built files are
+- **installCommand**: Installs npm dependencies in the `presentation/` directory
+
+## Manual Deployment to Vercel
+
+### First-Time Setup
+
+1. **Install Vercel CLI**:
+   ```bash
+   npm install -g vercel
+   ```
+
+2. **Login to Vercel**:
+   ```bash
+   vercel login
+   ```
+
+3. **Link Project**:
+   ```bash
+   vercel link
+   ```
+   - Choose your team/account
+   - Confirm the project name
+   - Link to the repository
+
+### Deploy to Production
+
+From the repository root:
+
+```bash
+vercel --prod
+```
+
+This will:
+1. Build both presentations using the `build:all` script
+2. Deploy the `presentation/dist/` directory
+3. Provide deployment URLs
+
+### Deploy to Preview
+
+For testing before production:
+
+```bash
+vercel
+```
+
+This creates a preview deployment with a unique URL.
+
+## Continuous Deployment
+
+### GitHub Integration
+
+When connected to GitHub, Vercel automatically:
+- Deploys **production** on pushes to `main` branch
+- Creates **preview deployments** for pull requests
+
+### Environment Variables
+
+No environment variables are required for the presentations.
+
+### Custom Domain
+
+To add a custom domain:
+
+1. Go to Vercel Dashboard → Project Settings → Domains
+2. Add your domain (e.g., `slides.caro.sh`)
+3. Configure DNS records as instructed
+
+## Build Scripts Reference
+
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Dev server for main presentation |
+| `npm run build` | Build main presentation only |
+| `npm run roadmap` | Dev server for roadmap presentation |
+| `npm run build:roadmap` | Build roadmap presentation only |
+| `npm run build:all` | Build both presentations (for deployment) |
+| `npm run export` | Export main presentation to PDF |
+| `npm run roadmap:export` | Export roadmap to PDF |
+
+## Troubleshooting
+
+### Build Fails on Vercel
+
+Check the build logs:
+1. Go to Vercel Dashboard → Deployments
+2. Click on the failed deployment
+3. View the build logs
+
+Common issues:
+- **Missing dependencies**: Run `npm install` locally to verify
+- **Build script fails**: Test `npm run build:all` locally
+- **Wrong output directory**: Verify `vercel.json` points to `presentation/dist`
+
+### Presentations Not Loading
+
+1. Check that both presentations built successfully:
+   ```bash
+   ls -la presentation/dist/
+   ls -la presentation/dist/roadmap/
+   ```
+
+2. Verify base paths:
+   - Main: No base path (root)
+   - Roadmap: `--base /roadmap/`
+
+3. Check browser console for asset loading errors
+
+### Local Build Issues
+
+Clean and rebuild:
+
+```bash
+cd presentation
+rm -rf dist dist-roadmap node_modules
+npm install
+npm run build:all
+```
+
+## Development Workflow
+
+1. Make changes to `slides.md` or `roadmap-slides.md`
+2. Test locally with `npm run dev` or `npm run roadmap`
+3. Build and test with `npm run build:all`
+4. Commit to feature branch
+5. Create PR
+6. Vercel creates preview deployment automatically
+7. Review preview deployment
+8. Merge PR → Auto-deploy to production
+
+## Additional Resources
+
+- [Slidev Documentation](https://sli.dev/)
+- [Vercel Documentation](https://vercel.com/docs)
+- [Vercel CLI Reference](https://vercel.com/docs/cli)
+- [Slidev Theme: Seriph](https://github.com/slidevjs/themes/tree/main/packages/theme-seriph)
+
+## Notes
+
+- Both presentations use the `seriph` theme
+- Presentations include Mermaid diagrams for visualization
+- The Caro mascot (`mascot.gif`) is shared between both presentations
+- All presentations are static sites (no server-side rendering needed)

--- a/presentation/README.md
+++ b/presentation/README.md
@@ -1,8 +1,11 @@
-# cmdai Presentation
+# Caro Presentations
 
-Slidev presentation showcasing cmdai's capabilities, roadmap, and call to action for contributors.
+Slidev presentations for the Caro project (formerly cmdai):
 
-**Featuring Caro** 🐕 - The friendly Shiba Inu mascot representing cmdai's mission to make shell commands safe and accessible!
+- **Main Presentation** (`slides.md`) - Technical overview and capabilities
+- **Roadmap Presentation** (`roadmap-slides.md`) - 2026 development roadmap
+
+**Featuring Caro** 🐕 - The friendly Shiba Inu mascot representing Caro's mission to make shell commands safe and accessible!
 
 ## Setup
 
@@ -10,7 +13,9 @@ Slidev presentation showcasing cmdai's capabilities, roadmap, and call to action
 npm install
 ```
 
-## Run Presentation
+## Run Presentations
+
+### Main Presentation
 
 ```bash
 # Development mode with hot reload
@@ -20,8 +25,41 @@ npm run dev
 npm run build
 
 # Export as PDF
-npm run export-pdf
+npm run export
 ```
+
+### Roadmap Presentation
+
+```bash
+# Development mode with hot reload
+npm run roadmap
+
+# Build for production
+npm run roadmap:build
+
+# Export as PDF
+npm run roadmap:export
+```
+
+### Build Both (for Deployment)
+
+```bash
+# Build both presentations to dist/
+npm run build:all
+```
+
+## Deployment
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for complete Vercel deployment instructions.
+
+**Quick Deploy**:
+```bash
+vercel --prod
+```
+
+Deployment structure:
+- Main presentation: `/` (root)
+- Roadmap presentation: `/roadmap/`
 
 ## Presentation Structure
 

--- a/presentation/package.json
+++ b/presentation/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "slidev slides.md",
-    "build": "slidev build slides.md",
+    "build": "slidev build slides.md --out dist",
+    "build:roadmap": "slidev build roadmap-slides.md --out dist-roadmap --base /roadmap/",
+    "build:all": "npm run build && npm run build:roadmap && mkdir -p dist/roadmap && cp -r dist-roadmap/* dist/roadmap/ && rm -rf dist-roadmap",
     "export": "slidev export slides.md",
     "roadmap": "slidev roadmap-slides.md",
     "roadmap:build": "slidev build roadmap-slides.md",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd presentation && npm install && npm run build:all",
+  "outputDirectory": "presentation/dist",
+  "devCommand": "cd presentation && npm run dev",
+  "installCommand": "cd presentation && npm install",
+  "framework": null,
+  "rewrites": [
+    {
+      "source": "/roadmap/:path*",
+      "destination": "/roadmap/:path*"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Configure Vercel deployment for both Slidev presentations (main and roadmap) with proper build pipeline and directory structure.

## Changes

### New Files
- ✅ `vercel.json` - Vercel deployment configuration
  - Builds both presentations with `npm run build:all`
  - Outputs to `presentation/dist/`
  - Security headers configured
- ✅ `presentation/DEPLOYMENT.md` - Complete deployment guide
  - Vercel setup instructions
  - Build process documentation
  - Troubleshooting guide
- ✅ `.claude/memory/git-workflow-never-commit-to-main.md` - Git workflow reminder

### Updated Files
- ✅ `presentation/package.json` - Enhanced build scripts
  - `build:all` - Builds both presentations
  - `build:roadmap` - Builds roadmap with `/roadmap/` base path
  - Combines outputs: main at `/`, roadmap at `/roadmap/`
- ✅ `presentation/README.md` - Updated documentation
  - Roadmap presentation commands
  - Deployment instructions

## Deployment Structure

```
dist/
├── index.html          # Main presentation (root)
├── assets/             # Main assets
├── roadmap/
│   ├── index.html     # Roadmap presentation
│   └── assets/        # Roadmap assets
└── ...
```

## URLs

- **Main**: `https://your-domain.vercel.app/`
- **Roadmap**: `https://your-domain.vercel.app/roadmap/`

## Testing

- ✅ Verified local build with `npm run build:all`
- ✅ Confirmed directory structure and base paths
- ✅ Both presentations build successfully (3.9s total)
- ✅ Output structure correct with roadmap subdirectory

## Usage

### Deploy to Vercel
```bash
vercel --prod
```

### Local Build
```bash
cd presentation
npm run build:all
```

### Development
```bash
npm run dev        # Main presentation
npm run roadmap    # Roadmap presentation
```

## Related

- Built on top of #[roadmap-pr-number] (Roadmap presentation)
- Implements deployment request from user

## Checklist

- [x] Vercel configuration created and tested
- [x] Build scripts updated and working
- [x] Documentation written (DEPLOYMENT.md)
- [x] README updated with deployment info
- [x] Local build tested successfully
- [x] Git workflow memory created
- [ ] Vercel project connected (manual step)
- [ ] Production deployment verified (post-merge)

## Notes

This PR sets up the infrastructure for deploying both Slidev presentations. After merging, the Vercel project needs to be connected to the repository for automatic deployments.

The build process is optimized to create a unified output structure where both presentations are accessible from a single deployment at different paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure Vercel to deploy both Slidev presentations from a single build, serving the main deck at / and the roadmap at /roadmap. Adds build scripts and docs so deploys work with one command and Vercel previews/production.

- **New Features**
  - vercel.json with build/install/dev commands, outputDirectory set to presentation/dist, and security headers.
  - Updated build scripts: build:all builds main and roadmap (roadmap with base /roadmap) and merges outputs into dist/roadmap.
  - Added DEPLOYMENT.md and updated README with commands and Vercel instructions.

- **Migration**
  - Link the repo to Vercel, then deploy with: vercel --prod.
  - No env vars needed; verify locally with: cd presentation && npm run build:all.

<sup>Written for commit 0632db105b2248370266e5549de0df47652f2298. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

