### PR TITLE
Fix Vercel deployment failure - Root Directory conflict

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd presentation && npm install && npm run build:all",
-  "outputDirectory": "presentation/dist",
-  "devCommand": "cd presentation && npm run dev",
-  "installCommand": "cd presentation && npm install",
+  "buildCommand": "npm install && npm run build:all",
+  "outputDirectory": "dist",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
   "framework": null,
   "rewrites": [
     {


### PR DESCRIPTION
## Problem

Vercel deployments for `cmdai-slides` are failing with:
```
sh: line 1: cd: presentation: No such file or directory
Error: Command "cd presentation && npm install" exited with 1
```

## Root Cause

- Vercel project has **Root Directory set to `presentation/`**
- This makes Vercel automatically execute commands from the `presentation/` directory
- Our `vercel.json` had `cd presentation && ...` in all commands
- This tried to navigate to `presentation/presentation/`, which doesn't exist

## Solution

Remove `cd presentation &&` from all commands in `vercel.json` since Vercel already runs commands from the `presentation/` directory.

## Changes

```diff
{
  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd presentation && npm install && npm run build:all",
+  "buildCommand": "npm install && npm run build:all",
-  "outputDirectory": "presentation/dist",
+  "outputDirectory": "dist",
-  "devCommand": "cd presentation && npm run dev",
+  "devCommand": "npm run dev",
-  "installCommand": "cd presentation && npm install",
+  "installCommand": "npm install",
  "framework": null,
```

## Testing

- ✅ Verified Root Directory setting in Vercel dashboard
- ✅ Reviewed build logs showing failure at `cd presentation` step  
- ✅ Updated paths to be relative to `presentation/` directory
- ⏳ Will verify deployment succeeds after merge

## Deployment URLs (After Fix)

- Main presentation: `https://cmdai-slides-git-main-kadosh-dev.vercel.app/`
- Roadmap presentation: `https://cmdai-slides-git-main-kadosh-dev.vercel.app/roadmap/`

## Related

- Fixes deployment failures in PR #233
- Builds on Slidev presentation infrastructure

## Checklist

- [x] Root cause identified (Root Directory conflict)
- [x] vercel.json commands updated
- [x] Output directory path corrected  
- [x] Commit message explains the fix
- [ ] Deployment verified after merge

---

**Note**: This is a critical fix to unblock Slidev presentation deployments. The configuration now correctly works with Vercel's Root Directory setting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vercel deployment failures by aligning vercel.json with the project's Root Directory (presentation/). Removes redundant cd commands and updates output paths so builds run from the correct folder.

- **Bug Fixes**
  - Removed "cd presentation" from build, install, and dev commands.
  - Changed outputDirectory from "presentation/dist" to "dist".

<sup>Written for commit 69f2d21ba411536ae78c94c720252166daa66b23. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

