### PR TITLE
Add Linux ARM64 download to website

### DIFF
--- a/website/src/components/Download.astro
+++ b/website/src/components/Download.astro
@@ -17,6 +17,7 @@
       <a href="https://github.com/wildcard/caro/releases/download/v1.0.2/caro-1.0.2-macos-silicon" class="download-link">macOS (Apple Silicon)</a>
       <a href="https://github.com/wildcard/caro/releases/download/v1.0.2/caro-1.0.2-macos-intel" class="download-link">macOS (Intel)</a>
       <a href="https://github.com/wildcard/caro/releases/download/v1.0.2/caro-1.0.2-linux-amd64" class="download-link">Linux (x86_64)</a>
+      <a href="https://github.com/wildcard/caro/releases/download/v1.0.2/caro-1.0.2-linux-arm64" class="download-link">Linux (ARM64)</a>
       <a href="https://github.com/wildcard/caro/releases/download/v1.0.2/caro-1.0.2-windows-amd64.exe" class="download-link">Windows</a>
     </div>
 


### PR DESCRIPTION
## Summary
Adds Linux ARM64 (aarch64) download link to the website's download section, completing the set of all 5 platform binaries built in the release workflow.

## Changes
- Added download link for Linux ARM64 in `website/src/components/Download.astro`
- Link points to v1.0.2 release binary: `caro-1.0.2-linux-arm64`
- Positioned between Linux x86_64 and Windows for logical platform grouping

## Platforms Available
After this change, all 5 platforms are downloadable:
1. macOS (Apple Silicon)
2. macOS (Intel)
3. Linux (x86_64)
4. Linux (ARM64) ✨ **NEW**
5. Windows

## Deployment
- Vercel will auto-deploy to production (caro.sh) once merged
- This will replace the "Coming Soon" state on production with active download links

## Verification
- [x] Download link URL matches GitHub release asset naming
- [x] Link follows existing style and formatting
- [x] All 5 platforms now represented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Linux ARM64 (aarch64) download link to the website so ARM Linux users can install v1.0.2. This completes the set of five platform downloads.

<sup>Written for commit a10cbe042d2072b557b0e407946077a061121867. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

