### PR TITLE
fix: Update slide 2 overall progress to 15%

### DIFF
--- a/presentation/roadmap-slides.md
+++ b/presentation/roadmap-slides.md
@@ -47,7 +47,7 @@ class: text-center
 
 🎉 **v1.0.1 Released** - Production-ready CLI
 
-📊 **Progress**: 7/60 items complete (11%)
+📊 **Progress**: 9/60 items complete (15%)
 
 ✅ **Release Blockers**: 0
 


### PR DESCRIPTION
## Summary

Fixes missed update in PR #259. Slide 2 still showed old overall progress.

## Change

**Slide 2 - "Where We Are Today"**:
- **Before**: 7/60 items complete (11%)
- **After**: 9/60 items complete (15%)

## Context

PR #259 updated:
- v1.1.0: 6% → 7%  
- v2.0.0: 28% → 38%
- Progress dashboard slide: 11% → 15%

But missed updating the early "Where We Are Today" slide which also shows overall progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the progress value on Slide 2 (“Where We Are Today”) to reflect the updated overall progress. Now shows 9/60 items complete (15%) instead of 7/60 (11%).

<sup>Written for commit d5e1d889cffd811cd82968b2ec0eb9c434a8fd6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

