### PR TITLE
refactor(website): Remove ASCII morphs from blog posts

### DIFF
--- a/website/src/pages/blog/announcing-caro.astro
+++ b/website/src/pages/blog/announcing-caro.astro
@@ -1,7 +1,5 @@
 ---
 import BlogPost from '../../layouts/BlogPost.astro';
-import AsciiMorph from '../../components/AsciiMorph.astro';
-import { blogAnnouncingMorphs } from '../../data/ascii-art';
 ---
 
 <BlogPost
@@ -28,8 +26,6 @@ import { blogAnnouncingMorphs } from '../../data/ascii-art';
 <p>
   <strong>caro</strong> is a single-binary Rust CLI tool that converts natural language descriptions into safe POSIX shell commands using local LLMs. Built with safety-first design and optimized for Apple Silicon via the MLX framework, caro makes complex command-line operations accessible to everyone.
 </p>
-
-<AsciiMorph arts={blogAnnouncingMorphs} width={36} height={33} interval={5000} morphDelay={40} />
 
 <pre><code>$ caro "find all PDF files larger than 10MB in Downloads"
 
@@ -168,10 +164,6 @@ mv ~/.config/cmdai ~/.config/caro</code></pre>
 <p>
   We can't wait to see what you build with caro!
 </p>
-
-<div style="margin: 50px 0;">
-  <AsciiMorph arts={blogAnnouncingMorphs} width={36} height={33} interval={5000} morphDelay={40} />
-</div>
 
 <hr style="margin: 50px 0; border: none; border-top: 1px solid #e0e0e0;">
 

--- a/website/src/pages/blog/why-caro.astro
+++ b/website/src/pages/blog/why-caro.astro
@@ -1,7 +1,5 @@
 ---
 import BlogPost from '../../layouts/BlogPost.astro';
-import AsciiMorph from '../../components/AsciiMorph.astro';
-import { blogWhyCaroMorphs } from '../../data/ascii-art';
 ---
 
 <BlogPost
@@ -20,10 +18,6 @@ import { blogWhyCaroMorphs } from '../../data/ascii-art';
 <p>
   Caro is the digitalization of <a href="https://www.instagram.com/kyaroblackheart/" target="_blank" rel="noopener noreferrer">Kyaro</a> (Kyarorain Kadosh), a Shiba Inu who has been living and breathing technology from day one. Born in 2020 during the midst of the COVID pandemic, Kyaro came into this world as a tiny puppy destined to become an office dog. She was brought home by what might be Israel's most workaholic software engineer—though perhaps I'm giving myself too much credit.
 </p>
-
-<div style="margin: 40px 0;">
-  <AsciiMorph arts={blogWhyCaroMorphs} width={36} height={33} interval={5500} morphDelay={35} />
-</div>
 
 <p>
   From her earliest days, Kyaro was a fixture in the office, visiting multiple days a week. She fell in love with Wix and its office spaces—first at Wix Academy, then at the Tel Aviv port location, later at Namaal, and finally at Wix HQ. But more importantly, she fell in love with the people: the geeks, the developers, the system administrators, and everyone in IT.
@@ -64,10 +58,6 @@ import { blogWhyCaroMorphs } from '../../data/ascii-art';
 </p>
 
 <h2>The Perfect Terminal Companion</h2>
-
-<div style="margin: 40px 0;">
-  <AsciiMorph arts={blogWhyCaroMorphs} width={36} height={33} interval={5500} morphDelay={35} />
-</div>
 
 <p>
   So it's only fitting that she'll be there with developers when they're working side-by-side in their terminals—keeping an eye on them, making sure they're not making mistakes, keeping them safe, giving them sound advice, and fetching those commands.


### PR DESCRIPTION
## Summary
Remove ASCII art morph animations from blog posts, completing the cleanup after replacing the homepage morph with the terminal showcase (PR #266).

## Changes
- ✅ Remove AsciiMorph from `announcing-caro.astro` (2 instances)
- ✅ Remove AsciiMorph from `why-caro.astro` (2 instances)
- ✅ Remove related imports and data references

## Rationale
The ASCII art morphs don't look good and interrupt the flow of the blog content. After replacing the homepage morph with a proper terminal showcase, these remaining blog morphs are inconsistent with the new design direction.

## Testing
- ✅ Verified files compile without errors
- ✅ Blog content flows better without the visual interruptions
- ✅ No broken imports or references

## Related
- Follows up on PR #266: Replace ASCII morph with terminal showcase on homepage
- Part of the design cleanup to improve visual quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed ASCII art morph animations from the Announcing Caro and Why Caro blog posts to improve readability and align with the new terminal showcase direction.

- **Refactors**
  - Removed AsciiMorph from announcing-caro.astro (2) and why-caro.astro (2)
  - Deleted related imports and ascii-art data references

<sup>Written for commit 5fecdb01a2034e2e3beaf24eeb16994b74365641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

