### PR TITLE
feat(devrel): Add Seattle AI Startup Summit 2026 landing page

### DIFF
--- a/apps/devrel/app/globals.css
+++ b/apps/devrel/app/globals.css
@@ -35,6 +35,23 @@
 
   /* Grid pattern for retro feel */
   --grid-size: 8px;
+
+  /* Summit Professional Color Palette */
+  --summit-primary: #0f172a;
+  --summit-secondary: #1e293b;
+  --summit-tertiary: #334155;
+  --summit-accent-teal: #14b8a6;
+  --summit-accent-blue: #3b82f6;
+  --summit-accent-purple: #8b5cf6;
+  --summit-accent-orange: #f97316;
+  --summit-text-primary: #f8fafc;
+  --summit-text-secondary: #94a3b8;
+  --summit-text-muted: #64748b;
+  --summit-success: #22c55e;
+  --summit-warning: #eab308;
+  --summit-error: #ef4444;
+  --summit-gradient-start: #0f172a;
+  --summit-gradient-end: #1e293b;
 }
 
 @theme inline {
@@ -61,6 +78,21 @@
   --font-pixel: 'Press Start 2P', cursive;
   --font-sans: ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Monaco, Consolas, 'Courier New', monospace;
+
+  /* Summit Colors */
+  --color-summit-primary: var(--summit-primary);
+  --color-summit-secondary: var(--summit-secondary);
+  --color-summit-tertiary: var(--summit-tertiary);
+  --color-summit-accent-teal: var(--summit-accent-teal);
+  --color-summit-accent-blue: var(--summit-accent-blue);
+  --color-summit-accent-purple: var(--summit-accent-purple);
+  --color-summit-accent-orange: var(--summit-accent-orange);
+  --color-summit-text-primary: var(--summit-text-primary);
+  --color-summit-text-secondary: var(--summit-text-secondary);
+  --color-summit-text-muted: var(--summit-text-muted);
+  --color-summit-success: var(--summit-success);
+  --color-summit-warning: var(--summit-warning);
+  --color-summit-error: var(--summit-error);
 }
 
 * {
@@ -280,4 +312,364 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--terminal-green);
+}
+
+/* ================================
+   SUMMIT LANDING PAGE STYLES
+   ================================ */
+
+/* Summit base styling */
+.summit-page {
+  font-family: var(--font-sans);
+  background: linear-gradient(180deg, var(--summit-primary) 0%, var(--summit-secondary) 100%);
+  color: var(--summit-text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Summit button styles */
+.summit-btn-primary {
+  background: linear-gradient(135deg, var(--summit-accent-teal) 0%, var(--summit-accent-blue) 100%);
+  color: white;
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 16px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 15px rgba(20, 184, 166, 0.3);
+}
+
+.summit-btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(20, 184, 166, 0.4);
+}
+
+.summit-btn-secondary {
+  background: transparent;
+  color: var(--summit-accent-teal);
+  padding: 14px 30px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 16px;
+  border: 2px solid var(--summit-accent-teal);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.summit-btn-secondary:hover {
+  background: rgba(20, 184, 166, 0.1);
+  transform: translateY(-2px);
+}
+
+/* Summit card styles */
+.summit-card {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 32px;
+  backdrop-filter: blur(12px);
+  transition: all 0.3s ease;
+}
+
+.summit-card:hover {
+  border-color: var(--summit-accent-teal);
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+/* Summit gradient text */
+.summit-gradient-text {
+  background: linear-gradient(135deg, var(--summit-accent-teal) 0%, var(--summit-accent-blue) 50%, var(--summit-accent-purple) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Summit section backgrounds */
+.summit-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.summit-section::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--summit-accent-teal), transparent);
+}
+
+/* Summit accordion */
+.summit-accordion-item {
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.summit-accordion-item:hover {
+  border-color: rgba(20, 184, 166, 0.3);
+}
+
+.summit-accordion-trigger {
+  width: 100%;
+  padding: 20px 24px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--summit-text-primary);
+  font-size: 16px;
+  font-weight: 500;
+  text-align: left;
+  transition: all 0.2s ease;
+}
+
+.summit-accordion-trigger:hover {
+  background: rgba(20, 184, 166, 0.05);
+}
+
+.summit-accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease-out;
+}
+
+.summit-accordion-content.open {
+  max-height: 500px;
+}
+
+.summit-accordion-content-inner {
+  padding: 0 24px 20px 24px;
+  color: var(--summit-text-secondary);
+  line-height: 1.7;
+}
+
+/* Summit checklist */
+.summit-checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.summit-checklist-item:hover {
+  border-color: rgba(20, 184, 166, 0.3);
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.summit-checklist-item.checked {
+  border-color: var(--summit-success);
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.summit-checklist-checkbox {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--summit-text-muted);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.summit-checklist-item.checked .summit-checklist-checkbox {
+  background: var(--summit-success);
+  border-color: var(--summit-success);
+}
+
+/* Summit timeline */
+.summit-timeline {
+  position: relative;
+  padding-left: 32px;
+}
+
+.summit-timeline::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, var(--summit-accent-teal), var(--summit-accent-purple));
+}
+
+.summit-timeline-item {
+  position: relative;
+  padding-bottom: 32px;
+}
+
+.summit-timeline-item::before {
+  content: "";
+  position: absolute;
+  left: -38px;
+  top: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--summit-accent-teal);
+  border: 3px solid var(--summit-primary);
+  box-shadow: 0 0 0 3px var(--summit-accent-teal);
+}
+
+/* Summit stats */
+.summit-stat {
+  text-align: center;
+}
+
+.summit-stat-value {
+  font-size: 48px;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--summit-accent-teal), var(--summit-accent-blue));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
+}
+
+.summit-stat-label {
+  font-size: 14px;
+  color: var(--summit-text-muted);
+  margin-top: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* Summit badge */
+.summit-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.summit-badge-teal {
+  background: rgba(20, 184, 166, 0.15);
+  color: var(--summit-accent-teal);
+  border: 1px solid rgba(20, 184, 166, 0.3);
+}
+
+.summit-badge-blue {
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--summit-accent-blue);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+.summit-badge-purple {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--summit-accent-purple);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+.summit-badge-orange {
+  background: rgba(249, 115, 22, 0.15);
+  color: var(--summit-accent-orange);
+  border: 1px solid rgba(249, 115, 22, 0.3);
+}
+
+/* Countdown timer */
+.summit-countdown {
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+}
+
+.summit-countdown-unit {
+  text-align: center;
+}
+
+.summit-countdown-value {
+  font-size: 42px;
+  font-weight: 700;
+  color: var(--summit-text-primary);
+  line-height: 1;
+}
+
+.summit-countdown-label {
+  font-size: 12px;
+  color: var(--summit-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-top: 8px;
+}
+
+/* Background decorations */
+.summit-glow-teal {
+  position: absolute;
+  width: 600px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(20, 184, 166, 0.15) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.summit-glow-purple {
+  position: absolute;
+  width: 500px;
+  height: 500px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(139, 92, 246, 0.12) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+/* Summit navigation */
+.summit-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  transition: all 0.3s ease;
+}
+
+.summit-nav-scrolled {
+  background: rgba(15, 23, 42, 0.98);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .summit-card {
+    padding: 24px;
+  }
+
+  .summit-stat-value {
+    font-size: 36px;
+  }
+
+  .summit-countdown {
+    gap: 16px;
+  }
+
+  .summit-countdown-value {
+    font-size: 32px;
+  }
+
+  .summit-btn-primary,
+  .summit-btn-secondary {
+    width: 100%;
+    text-align: center;
+  }
 }

--- a/apps/devrel/app/summit/layout.tsx
+++ b/apps/devrel/app/summit/layout.tsx
@@ -1,39 +1,44 @@
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
-  title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
-  description: "Showcase your AI startup to Fortune 500 leaders at the Seattle AI Startup Summit 2026. Apply for demo day, connect with investors, and get media coverage.",
+  title: "Caro | Natural Language to Safe Shell Commands",
+  description: "Transform natural language into safe, POSIX-compliant shell commands using local AI. Built with Rust for blazing-fast performance and safety-first design.",
   keywords: [
-    "Seattle AI Summit",
-    "AI startup demo day",
-    "AI investors",
-    "startup pitch",
-    "AI conference Seattle",
-    "Fortune 500",
-    "startup funding",
-    "AI demo",
-    "tech conference 2026"
+    "Caro",
+    "CLI",
+    "shell commands",
+    "AI",
+    "LLM",
+    "Rust",
+    "terminal",
+    "POSIX",
+    "safety",
+    "local AI",
+    "natural language",
+    "command line",
+    "DevOps",
+    "SRE"
   ],
-  authors: [{ name: "Seattle AI Startup Summit" }],
+  authors: [{ name: "Caro Team" }],
   openGraph: {
-    title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
-    description: "Showcase your AI startup to Fortune 500 leaders. Apply for demo day, connect with investors, and get media coverage.",
+    title: "Caro | Natural Language to Safe Shell Commands",
+    description: "Transform natural language into safe shell commands using local AI. 100% private, 52+ safety patterns.",
     type: "website",
-    url: "https://cmdai.dev/summit",
-    siteName: "Seattle AI Startup Summit 2026",
+    url: "https://caro.sh/summit",
+    siteName: "Caro",
     images: [
       {
         url: "/summit/og-image.png",
         width: 1200,
         height: 630,
-        alt: "Seattle AI Startup Summit 2026",
+        alt: "Caro - Natural Language to Safe Shell Commands",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
-    description: "Showcase your AI startup to Fortune 500 leaders. Apply now!",
+    title: "Caro | Natural Language to Safe Shell Commands",
+    description: "Transform natural language into safe shell commands using local AI.",
     images: ["/summit/og-image.png"],
   },
   robots: {
@@ -55,43 +60,41 @@ export const viewport: Viewport = {
   themeColor: "#0f172a",
 };
 
-// JSON-LD structured data for the event
+// JSON-LD structured data for the software application
 const jsonLd = {
   "@context": "https://schema.org",
-  "@type": "Event",
-  name: "Seattle AI Startup Summit 2026",
-  description: "The premier event for AI startups to showcase their innovations to Fortune 500 leaders, investors, and media.",
-  startDate: "2026-06-15T09:00:00-07:00",
-  endDate: "2026-06-16T18:00:00-07:00",
-  eventStatus: "https://schema.org/EventScheduled",
-  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
-  location: {
-    "@type": "Place",
-    name: "Washington State Convention Center",
-    address: {
-      "@type": "PostalAddress",
-      streetAddress: "705 Pike St",
-      addressLocality: "Seattle",
-      addressRegion: "WA",
-      postalCode: "98101",
-      addressCountry: "US",
-    },
-  },
-  image: ["/summit/og-image.png"],
-  organizer: {
-    "@type": "Organization",
-    name: "Seattle AI Startup Summit",
-    url: "https://cmdai.dev/summit",
-  },
+  "@type": "SoftwareApplication",
+  name: "Caro",
+  description: "AI-powered CLI tool that converts natural language into safe, POSIX-compliant shell commands using local LLMs.",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: ["macOS", "Linux", "Windows"],
   offers: {
     "@type": "Offer",
-    name: "Demo Day Application",
-    url: "https://cmdai.dev/summit#apply",
-    availability: "https://schema.org/InStock",
-    validFrom: "2026-01-01T00:00:00-08:00",
-    priceCurrency: "USD",
     price: "0",
+    priceCurrency: "USD",
   },
+  author: {
+    "@type": "Organization",
+    name: "Caro Team",
+    url: "https://caro.sh",
+  },
+  license: "https://www.gnu.org/licenses/agpl-3.0.html",
+  programmingLanguage: "Rust",
+  softwareVersion: "0.1.0",
+  downloadUrl: "https://github.com/anthropics/caro/releases",
+  sameAs: [
+    "https://github.com/anthropics/caro",
+    "https://crates.io/crates/caro"
+  ],
+  featureList: [
+    "Natural language to shell commands",
+    "52+ safety patterns for dangerous command detection",
+    "100% local inference - no cloud dependencies",
+    "Multi-backend support (MLX, Ollama, vLLM)",
+    "Cross-platform (macOS, Linux, Windows)",
+    "Platform-aware command generation",
+    "Sub-2-second inference on Apple Silicon"
+  ],
 };
 
 export default function SummitLayout({

--- a/apps/devrel/app/summit/layout.tsx
+++ b/apps/devrel/app/summit/layout.tsx
@@ -1,0 +1,111 @@
+import type { Metadata, Viewport } from "next";
+
+export const metadata: Metadata = {
+  title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
+  description: "Showcase your AI startup to Fortune 500 leaders at the Seattle AI Startup Summit 2026. Apply for demo day, connect with investors, and get media coverage.",
+  keywords: [
+    "Seattle AI Summit",
+    "AI startup demo day",
+    "AI investors",
+    "startup pitch",
+    "AI conference Seattle",
+    "Fortune 500",
+    "startup funding",
+    "AI demo",
+    "tech conference 2026"
+  ],
+  authors: [{ name: "Seattle AI Startup Summit" }],
+  openGraph: {
+    title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
+    description: "Showcase your AI startup to Fortune 500 leaders. Apply for demo day, connect with investors, and get media coverage.",
+    type: "website",
+    url: "https://cmdai.dev/summit",
+    siteName: "Seattle AI Startup Summit 2026",
+    images: [
+      {
+        url: "/summit/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Seattle AI Startup Summit 2026",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Seattle AI Startup Summit 2026 | Demo Day Applications",
+    description: "Showcase your AI startup to Fortune 500 leaders. Apply now!",
+    images: ["/summit/og-image.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#0f172a",
+};
+
+// JSON-LD structured data for the event
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: "Seattle AI Startup Summit 2026",
+  description: "The premier event for AI startups to showcase their innovations to Fortune 500 leaders, investors, and media.",
+  startDate: "2026-06-15T09:00:00-07:00",
+  endDate: "2026-06-16T18:00:00-07:00",
+  eventStatus: "https://schema.org/EventScheduled",
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  location: {
+    "@type": "Place",
+    name: "Washington State Convention Center",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "705 Pike St",
+      addressLocality: "Seattle",
+      addressRegion: "WA",
+      postalCode: "98101",
+      addressCountry: "US",
+    },
+  },
+  image: ["/summit/og-image.png"],
+  organizer: {
+    "@type": "Organization",
+    name: "Seattle AI Startup Summit",
+    url: "https://cmdai.dev/summit",
+  },
+  offers: {
+    "@type": "Offer",
+    name: "Demo Day Application",
+    url: "https://cmdai.dev/summit#apply",
+    availability: "https://schema.org/InStock",
+    validFrom: "2026-01-01T00:00:00-08:00",
+    priceCurrency: "USD",
+    price: "0",
+  },
+};
+
+export default function SummitLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/apps/devrel/app/summit/page.tsx
+++ b/apps/devrel/app/summit/page.tsx
@@ -1,0 +1,47 @@
+import {
+  SummitNavigation,
+  SummitHero,
+  WhatWereLookingFor,
+  ApplicationFAQ,
+  TimelineProcess,
+  SuccessStories,
+  PreparationChecklist,
+  ApplicationCTA,
+  SummitFooter,
+} from '@/components/summit';
+
+export default function SummitPage() {
+  return (
+    <div className="summit-page min-h-screen">
+      {/* Navigation */}
+      <SummitNavigation />
+
+      {/* Main Content */}
+      <main>
+        {/* Hero Section */}
+        <SummitHero />
+
+        {/* What We're Looking For */}
+        <WhatWereLookingFor />
+
+        {/* Application FAQ */}
+        <ApplicationFAQ />
+
+        {/* Timeline & Process */}
+        <TimelineProcess />
+
+        {/* Success Stories */}
+        <SuccessStories />
+
+        {/* Preparation Checklist */}
+        <PreparationChecklist />
+
+        {/* Application CTA */}
+        <ApplicationCTA />
+      </main>
+
+      {/* Footer */}
+      <SummitFooter />
+    </div>
+  );
+}

--- a/apps/devrel/components/summit/ApplicationCTA.tsx
+++ b/apps/devrel/components/summit/ApplicationCTA.tsx
@@ -2,88 +2,147 @@
 
 import React from 'react';
 
+const installMethods = [
+  {
+    name: 'Homebrew',
+    platform: 'macOS',
+    command: 'brew install caro',
+    icon: '🍺',
+  },
+  {
+    name: 'Cargo',
+    platform: 'All platforms',
+    command: 'cargo install caro',
+    icon: '📦',
+  },
+  {
+    name: 'Download',
+    platform: 'Binary',
+    command: 'curl -fsSL https://caro.sh/install.sh | sh',
+    icon: '⬇️',
+  },
+];
+
 export const ApplicationCTA: React.FC = () => {
   return (
-    <section id="apply" className="summit-section py-20 md:py-32 relative overflow-hidden">
+    <section id="get-started" className="summit-section py-20 md:py-32 relative overflow-hidden">
       {/* Background decorations */}
       <div className="summit-glow-teal top-0 left-1/4" />
       <div className="summit-glow-purple bottom-0 right-1/4" />
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-        <div className="summit-card text-center py-12 md:py-16">
+        <div className="text-center">
           {/* Badge */}
           <span className="summit-badge summit-badge-teal mb-6 inline-block">
-            Limited Slots Available
+            Open Source
           </span>
 
           {/* Headline */}
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            Ready to Showcase Your
-            <br />
-            <span className="summit-gradient-text">AI Innovation?</span>
+            Stop Googling.<br />
+            <span className="summit-gradient-text">Start Shipping.</span>
           </h2>
 
-          {/* Description */}
-          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto mb-8">
-            Join 50 carefully selected AI startups presenting to Fortune 500 executives,
-            top-tier investors, and industry media. Your 10-minute demo could change
-            the trajectory of your company.
+          {/* Subheadline */}
+          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto mb-12">
+            Install Caro in seconds and transform how you work with the terminal.
+            100% local, 100% private, 100% safe.
           </p>
 
-          {/* Key Benefits */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-2xl mx-auto mb-10">
-            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
-              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          {/* Install Methods */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-12">
+            {installMethods.map((method) => (
+              <div
+                key={method.name}
+                className="summit-card text-left"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="text-2xl">{method.icon}</span>
+                  <div>
+                    <div className="font-semibold text-summit-text-primary">{method.name}</div>
+                    <div className="text-xs text-summit-text-muted">{method.platform}</div>
+                  </div>
+                </div>
+                <div className="bg-summit-primary rounded-lg p-3 font-mono text-sm text-summit-accent-teal overflow-x-auto">
+                  {method.command}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Primary CTAs */}
+          <div className="flex flex-col sm:flex-row justify-center gap-4 mb-12">
+            <a
+              href="https://github.com/anthropics/caro"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="summit-btn-primary text-lg inline-flex items-center justify-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+              </svg>
+              View on GitHub
+            </a>
+            <a
+              href="https://caro.sh/docs"
+              className="summit-btn-secondary text-lg inline-flex items-center justify-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+              Read Documentation
+            </a>
+          </div>
+
+          {/* Quick Stats */}
+          <div className="flex flex-wrap justify-center gap-8 text-sm text-summit-text-muted">
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
-              Free to Apply
+              AGPL-3.0 License
             </div>
-            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
-              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
-              10-15 min form
+              No cloud dependencies
             </div>
-            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
-              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
-              Rolling Review
+              Community-driven
             </div>
           </div>
 
-          {/* CTA Button */}
-          <a
-            href="https://forms.google.com/your-form-id"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="summit-btn-primary text-lg inline-flex items-center gap-3 mb-6"
-          >
-            Apply Now
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-            </svg>
-          </a>
-
-          {/* Deadline */}
-          <p className="text-sm text-summit-text-muted">
-            Application Deadline: <span className="text-summit-warning font-medium">March 31, 2026</span>
-          </p>
-
           {/* Support */}
-          <div className="mt-8 pt-8 border-t border-summit-tertiary/30">
-            <p className="text-summit-text-muted text-sm mb-2">
-              Have questions before applying?
+          <div className="mt-12 pt-8 border-t border-summit-tertiary/30">
+            <p className="text-summit-text-muted mb-4">
+              Questions? Feedback? We&apos;d love to hear from you.
             </p>
-            <a
-              href="mailto:summit@cmdai.dev"
-              className="text-summit-accent-teal hover:text-summit-accent-blue transition-colors inline-flex items-center gap-2"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-              summit@cmdai.dev
-            </a>
+            <div className="flex flex-wrap justify-center gap-4">
+              <a
+                href="https://github.com/anthropics/caro/issues"
+                className="text-summit-accent-teal hover:underline"
+              >
+                Open an issue
+              </a>
+              <span className="text-summit-tertiary">•</span>
+              <a
+                href="https://github.com/anthropics/caro/discussions"
+                className="text-summit-accent-teal hover:underline"
+              >
+                Join discussions
+              </a>
+              <span className="text-summit-tertiary">•</span>
+              <a
+                href="mailto:hello@caro.sh"
+                className="text-summit-accent-teal hover:underline"
+              >
+                Contact us
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/devrel/components/summit/ApplicationCTA.tsx
+++ b/apps/devrel/components/summit/ApplicationCTA.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React from 'react';
+
+export const ApplicationCTA: React.FC = () => {
+  return (
+    <section id="apply" className="summit-section py-20 md:py-32 relative overflow-hidden">
+      {/* Background decorations */}
+      <div className="summit-glow-teal top-0 left-1/4" />
+      <div className="summit-glow-purple bottom-0 right-1/4" />
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+        <div className="summit-card text-center py-12 md:py-16">
+          {/* Badge */}
+          <span className="summit-badge summit-badge-teal mb-6 inline-block">
+            Limited Slots Available
+          </span>
+
+          {/* Headline */}
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            Ready to Showcase Your
+            <br />
+            <span className="summit-gradient-text">AI Innovation?</span>
+          </h2>
+
+          {/* Description */}
+          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto mb-8">
+            Join 50 carefully selected AI startups presenting to Fortune 500 executives,
+            top-tier investors, and industry media. Your 10-minute demo could change
+            the trajectory of your company.
+          </p>
+
+          {/* Key Benefits */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-2xl mx-auto mb-10">
+            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
+              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              Free to Apply
+            </div>
+            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
+              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              10-15 min form
+            </div>
+            <div className="flex items-center justify-center gap-2 text-summit-text-secondary">
+              <svg className="w-5 h-5 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              Rolling Review
+            </div>
+          </div>
+
+          {/* CTA Button */}
+          <a
+            href="https://forms.google.com/your-form-id"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="summit-btn-primary text-lg inline-flex items-center gap-3 mb-6"
+          >
+            Apply Now
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+            </svg>
+          </a>
+
+          {/* Deadline */}
+          <p className="text-sm text-summit-text-muted">
+            Application Deadline: <span className="text-summit-warning font-medium">March 31, 2026</span>
+          </p>
+
+          {/* Support */}
+          <div className="mt-8 pt-8 border-t border-summit-tertiary/30">
+            <p className="text-summit-text-muted text-sm mb-2">
+              Have questions before applying?
+            </p>
+            <a
+              href="mailto:summit@cmdai.dev"
+              className="text-summit-accent-teal hover:text-summit-accent-blue transition-colors inline-flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              summit@cmdai.dev
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/ApplicationFAQ.tsx
+++ b/apps/devrel/components/summit/ApplicationFAQ.tsx
@@ -1,142 +1,179 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 
-const faqItems = [
+const features = [
   {
-    question: 'What company information do I need ready?',
-    answer: 'You\'ll need your company name, website URL, LinkedIn company profile, year founded, current employee count, and a concise 100-word company description. Make sure your website is polished and your LinkedIn profile is up-to-date before applying.',
-    category: 'Company Info',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+    title: 'Safety-First Validation',
+    description: '52+ pre-compiled patterns detect dangerous commands like rm -rf /, fork bombs, and privilege escalation attempts.',
+    details: [
+      'Multi-level risk assessment (Safe/Moderate/High/Critical)',
+      'Blocks system destruction patterns automatically',
+      'Configurable confirmation modes',
+      '0% false positive rate on critical patterns',
+    ],
   },
   {
-    question: 'What financial metrics will be requested?',
-    answer: 'We\'ll ask for your current Annual Recurring Revenue (ARR) estimate, total amount raised to date, and your top investors (if applicable). Be prepared to share your funding stage (pre-seed, seed, Series A, etc.) and any notable revenue milestones.',
-    category: 'Financials',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+      </svg>
+    ),
+    title: '100% Local Inference',
+    description: 'All AI processing happens on your machine. No cloud APIs, no data exfiltration, no network dependencies.',
+    details: [
+      'Embedded Qwen2.5-Coder-1.5B model',
+      'MLX optimization for Apple Silicon (<2s inference)',
+      'CPU fallback for cross-platform support',
+      'Works in air-gapped environments',
+    ],
   },
   {
-    question: 'What strategic questions should I prepare for?',
-    answer: 'The application covers: the specific problem you solve, your target customer profile (industry, company size, buyer persona), your largest customers to date, top 3 competitors, your unique competitive advantage, and current challenges you\'re facing. Think through these before starting.',
-    category: 'Strategy',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+    ),
+    title: 'Platform-Aware Generation',
+    description: 'Automatically detects your OS, shell, and available tools to generate commands that work the first time.',
+    details: [
+      'macOS (Intel + Apple Silicon), Linux, Windows',
+      'Handles GNU vs BSD command differences',
+      'Shell-specific syntax (bash, zsh, fish, PowerShell)',
+      '2-iteration refinement for accuracy',
+    ],
   },
   {
-    question: 'Do I need a video demo?',
-    answer: 'While optional, we highly recommend including a 2-3 minute demo video showcasing your product. Videos significantly increase your chances of selection. Use Loom, YouTube (unlisted), or any video platform. Focus on the core value proposition and real product functionality.',
-    category: 'Demo',
-  },
-  {
-    question: 'Who should submit the application?',
-    answer: 'The CEO or Co-Founder should ideally submit the application. However, team members can submit on their behalf - we\'ll ask for both the submitter\'s email and the CEO/Founder\'s email. The founder should be available for follow-up questions.',
-    category: 'Process',
-  },
-  {
-    question: 'Is there an exhibition opportunity?',
-    answer: 'Yes! Beyond the demo stage, you can indicate interest in purchasing an exhibit table during the summit. Exhibit tables ($2,500) include a 6ft table, 2 chairs, power, WiFi, and 2 attendee badges. This is separate from demo selection.',
-    category: 'Exhibit',
-  },
-  {
-    question: 'What happens after I apply?',
-    answer: 'We review applications on a rolling basis. You\'ll receive an acknowledgment email within 24 hours. Selected companies are notified 6-8 weeks before the event. If selected, you\'ll receive demo guidelines, time slot options, and preparation materials.',
-    category: 'Process',
-  },
-  {
-    question: 'Can I apply if we\'re pre-revenue?',
-    answer: 'Yes! We welcome pre-revenue companies with strong traction signals like user growth, waitlist size, pilot programs, or significant technical milestones. Focus your application on your validation story and why your solution matters.',
-    category: 'Eligibility',
-  },
-  {
-    question: 'What makes a strong application?',
-    answer: 'Strong applications have: a clear problem statement, specific customer examples, quantifiable traction metrics, a compelling demo video, and honest self-assessment. Avoid buzzwords and focus on concrete details that demonstrate product-market fit progress.',
-    category: 'Tips',
-  },
-  {
-    question: 'Is there an application fee?',
-    answer: 'No, the demo day application is completely free. There are no fees for applying or being selected to present. The only optional cost is the exhibit table if you choose to purchase one.',
-    category: 'Fees',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+      </svg>
+    ),
+    title: 'Multi-Backend Architecture',
+    description: 'Flexible backend system supports embedded models, Ollama, vLLM, and future integrations.',
+    details: [
+      'Embedded MLX (default for Apple Silicon)',
+      'Ollama integration with auto-fallback',
+      'vLLM for enterprise deployments',
+      'Extensible trait system for new backends',
+    ],
   },
 ];
 
-const ChevronIcon: React.FC<{ isOpen: boolean }> = ({ isOpen }) => (
-  <svg
-    className={`w-5 h-5 text-summit-text-muted transition-transform duration-300 ${
-      isOpen ? 'rotate-180' : ''
-    }`}
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-  </svg>
-);
+const workflowSteps = [
+  {
+    step: 1,
+    title: 'Describe What You Need',
+    description: 'Type a natural language description of what you want to accomplish.',
+    example: '$ caro "find all log files modified in the last hour"',
+  },
+  {
+    step: 2,
+    title: 'AI Generates Command',
+    description: 'Caro uses context-aware AI to generate a platform-specific command.',
+    example: 'find /var/log -name "*.log" -mmin -60',
+  },
+  {
+    step: 3,
+    title: 'Safety Validation',
+    description: 'Every command is checked against 52+ safety patterns before execution.',
+    example: '✓ SAFE - No dangerous patterns detected',
+  },
+  {
+    step: 4,
+    title: 'Review & Execute',
+    description: 'You always maintain control. Approve, modify, or reject before running.',
+    example: 'Execute this command? (y/N)',
+  },
+];
 
 export const ApplicationFAQ: React.FC = () => {
-  const [openIndex, setOpenIndex] = useState<number | null>(0);
-
-  const toggleItem = (index: number) => {
-    setOpenIndex(openIndex === index ? null : index);
-  };
-
   return (
-    <section id="faq" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section id="solution" className="summit-section py-20 md:py-32">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <div className="text-center max-w-3xl mx-auto mb-16">
           <span className="summit-badge summit-badge-blue mb-4 inline-block">
-            Application Guide
+            The Solution
           </span>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            Application Requirements FAQ
+            How Caro Works
           </h2>
-          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto">
-            Everything you need to know before you start your application.
-            Review these questions to prepare your information in advance.
+          <p className="text-lg text-summit-text-secondary">
+            A 2-iteration agentic loop that combines context awareness with smart refinement,
+            wrapped in comprehensive safety validation.
           </p>
         </div>
 
-        {/* FAQ Accordion */}
-        <div className="space-y-3">
-          {faqItems.map((item, index) => (
-            <div
-              key={index}
-              className="summit-accordion-item"
-            >
-              <button
-                className="summit-accordion-trigger"
-                onClick={() => toggleItem(index)}
-                aria-expanded={openIndex === index}
-              >
-                <div className="flex items-center gap-3">
-                  <span className="text-xs text-summit-accent-teal font-medium uppercase tracking-wider min-w-[80px] text-left">
-                    {item.category}
-                  </span>
-                  <span className="text-summit-text-primary">{item.question}</span>
+        {/* Workflow Steps */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-20">
+          {workflowSteps.map((step) => (
+            <div key={step.step} className="relative">
+              <div className="summit-card h-full">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center text-white font-bold mb-4">
+                  {step.step}
                 </div>
-                <ChevronIcon isOpen={openIndex === index} />
-              </button>
-              <div
-                className={`summit-accordion-content ${openIndex === index ? 'open' : ''}`}
-              >
-                <div className="summit-accordion-content-inner">
-                  {item.answer}
+                <h3 className="text-lg font-semibold text-summit-text-primary mb-2">
+                  {step.title}
+                </h3>
+                <p className="text-sm text-summit-text-secondary mb-4">
+                  {step.description}
+                </p>
+                <div className="bg-summit-primary/50 rounded-lg p-3 font-mono text-xs text-summit-accent-teal">
+                  {step.example}
                 </div>
               </div>
+              {step.step < 4 && (
+                <div className="hidden lg:block absolute top-1/2 -right-3 transform -translate-y-1/2 z-10">
+                  <svg className="w-6 h-6 text-summit-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+              )}
             </div>
           ))}
         </div>
 
-        {/* Additional Help */}
-        <div className="mt-12 text-center">
-          <p className="text-summit-text-muted mb-4">
-            Still have questions about the application?
-          </p>
-          <a
-            href="mailto:summit@cmdai.dev"
-            className="inline-flex items-center gap-2 text-summit-accent-teal hover:text-summit-accent-blue transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-            </svg>
-            Contact us at summit@cmdai.dev
-          </a>
+        {/* Core Features Grid */}
+        <div className="text-center mb-12">
+          <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+            Core Capabilities
+          </h3>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {features.map((feature, index) => (
+            <div key={index} className="summit-card">
+              <div className="flex items-start gap-4">
+                <div className="w-12 h-12 rounded-xl bg-summit-accent-teal/10 flex items-center justify-center text-summit-accent-teal flex-shrink-0">
+                  {feature.icon}
+                </div>
+                <div className="flex-1">
+                  <h4 className="text-lg font-semibold text-summit-text-primary mb-2">
+                    {feature.title}
+                  </h4>
+                  <p className="text-summit-text-secondary mb-4">
+                    {feature.description}
+                  </p>
+                  <ul className="space-y-2">
+                    {feature.details.map((detail, i) => (
+                      <li key={i} className="flex items-center gap-2 text-sm text-summit-text-muted">
+                        <svg className="w-4 h-4 text-summit-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                        {detail}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/apps/devrel/components/summit/ApplicationFAQ.tsx
+++ b/apps/devrel/components/summit/ApplicationFAQ.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useState } from 'react';
+
+const faqItems = [
+  {
+    question: 'What company information do I need ready?',
+    answer: 'You\'ll need your company name, website URL, LinkedIn company profile, year founded, current employee count, and a concise 100-word company description. Make sure your website is polished and your LinkedIn profile is up-to-date before applying.',
+    category: 'Company Info',
+  },
+  {
+    question: 'What financial metrics will be requested?',
+    answer: 'We\'ll ask for your current Annual Recurring Revenue (ARR) estimate, total amount raised to date, and your top investors (if applicable). Be prepared to share your funding stage (pre-seed, seed, Series A, etc.) and any notable revenue milestones.',
+    category: 'Financials',
+  },
+  {
+    question: 'What strategic questions should I prepare for?',
+    answer: 'The application covers: the specific problem you solve, your target customer profile (industry, company size, buyer persona), your largest customers to date, top 3 competitors, your unique competitive advantage, and current challenges you\'re facing. Think through these before starting.',
+    category: 'Strategy',
+  },
+  {
+    question: 'Do I need a video demo?',
+    answer: 'While optional, we highly recommend including a 2-3 minute demo video showcasing your product. Videos significantly increase your chances of selection. Use Loom, YouTube (unlisted), or any video platform. Focus on the core value proposition and real product functionality.',
+    category: 'Demo',
+  },
+  {
+    question: 'Who should submit the application?',
+    answer: 'The CEO or Co-Founder should ideally submit the application. However, team members can submit on their behalf - we\'ll ask for both the submitter\'s email and the CEO/Founder\'s email. The founder should be available for follow-up questions.',
+    category: 'Process',
+  },
+  {
+    question: 'Is there an exhibition opportunity?',
+    answer: 'Yes! Beyond the demo stage, you can indicate interest in purchasing an exhibit table during the summit. Exhibit tables ($2,500) include a 6ft table, 2 chairs, power, WiFi, and 2 attendee badges. This is separate from demo selection.',
+    category: 'Exhibit',
+  },
+  {
+    question: 'What happens after I apply?',
+    answer: 'We review applications on a rolling basis. You\'ll receive an acknowledgment email within 24 hours. Selected companies are notified 6-8 weeks before the event. If selected, you\'ll receive demo guidelines, time slot options, and preparation materials.',
+    category: 'Process',
+  },
+  {
+    question: 'Can I apply if we\'re pre-revenue?',
+    answer: 'Yes! We welcome pre-revenue companies with strong traction signals like user growth, waitlist size, pilot programs, or significant technical milestones. Focus your application on your validation story and why your solution matters.',
+    category: 'Eligibility',
+  },
+  {
+    question: 'What makes a strong application?',
+    answer: 'Strong applications have: a clear problem statement, specific customer examples, quantifiable traction metrics, a compelling demo video, and honest self-assessment. Avoid buzzwords and focus on concrete details that demonstrate product-market fit progress.',
+    category: 'Tips',
+  },
+  {
+    question: 'Is there an application fee?',
+    answer: 'No, the demo day application is completely free. There are no fees for applying or being selected to present. The only optional cost is the exhibit table if you choose to purchase one.',
+    category: 'Fees',
+  },
+];
+
+const ChevronIcon: React.FC<{ isOpen: boolean }> = ({ isOpen }) => (
+  <svg
+    className={`w-5 h-5 text-summit-text-muted transition-transform duration-300 ${
+      isOpen ? 'rotate-180' : ''
+    }`}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+);
+
+export const ApplicationFAQ: React.FC = () => {
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  const toggleItem = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <section id="faq" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Section Header */}
+        <div className="text-center mb-16">
+          <span className="summit-badge summit-badge-blue mb-4 inline-block">
+            Application Guide
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            Application Requirements FAQ
+          </h2>
+          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto">
+            Everything you need to know before you start your application.
+            Review these questions to prepare your information in advance.
+          </p>
+        </div>
+
+        {/* FAQ Accordion */}
+        <div className="space-y-3">
+          {faqItems.map((item, index) => (
+            <div
+              key={index}
+              className="summit-accordion-item"
+            >
+              <button
+                className="summit-accordion-trigger"
+                onClick={() => toggleItem(index)}
+                aria-expanded={openIndex === index}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-xs text-summit-accent-teal font-medium uppercase tracking-wider min-w-[80px] text-left">
+                    {item.category}
+                  </span>
+                  <span className="text-summit-text-primary">{item.question}</span>
+                </div>
+                <ChevronIcon isOpen={openIndex === index} />
+              </button>
+              <div
+                className={`summit-accordion-content ${openIndex === index ? 'open' : ''}`}
+              >
+                <div className="summit-accordion-content-inner">
+                  {item.answer}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Additional Help */}
+        <div className="mt-12 text-center">
+          <p className="text-summit-text-muted mb-4">
+            Still have questions about the application?
+          </p>
+          <a
+            href="mailto:summit@cmdai.dev"
+            className="inline-flex items-center gap-2 text-summit-accent-teal hover:text-summit-accent-blue transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+            Contact us at summit@cmdai.dev
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/PreparationChecklist.tsx
+++ b/apps/devrel/components/summit/PreparationChecklist.tsx
@@ -1,176 +1,198 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 
-const checklistItems = [
+const visionPillars = [
   {
-    id: 'website',
-    label: 'Company website is live and polished',
-    description: 'Ensure your website clearly communicates your value proposition and product.',
-    tip: 'Check mobile responsiveness and page load times.',
+    title: 'Layer 2 Agent Architecture',
+    description: 'Caro is designed as a specialized sub-agent that works alongside AI orchestrators like Claude and ChatGPT.',
+    details: [
+      'Big agents handle high-level orchestration',
+      'Caro handles specialized terminal operations',
+      'Each layer maintains its own safety validation',
+      'Modular expertise that compounds over time',
+    ],
+    icon: (
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+      </svg>
+    ),
   },
   {
-    id: 'linkedin',
-    label: 'Founder LinkedIn profile is complete and professional',
-    description: 'Update your photo, headline, and recent company updates.',
-    tip: 'Add recent posts about your company progress.',
+    title: 'Skills Marketplace',
+    description: 'Domain-specific skills that extend Caro\'s capabilities for specialized use cases.',
+    details: [
+      'SRE & incident response skills',
+      'Database administration patterns',
+      'Cloud infrastructure management',
+      'Security auditing workflows',
+    ],
+    icon: (
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+      </svg>
+    ),
   },
   {
-    id: 'description',
-    label: '100-word company description drafted',
-    description: 'Concise, clear description of what you do and for whom.',
-    tip: 'Focus on the problem you solve, not technical features.',
-  },
-  {
-    id: 'financials',
-    label: 'Financial metrics compiled (ARR, funding)',
-    description: 'Have your current ARR, total raised, and funding stage ready.',
-    tip: 'Include growth rate if impressive (e.g., "3x YoY").',
-  },
-  {
-    id: 'customers',
-    label: 'Customer list and achievements documented',
-    description: 'Prepare a list of notable customers and key metrics.',
-    tip: 'Get logo usage permission from customers in advance.',
-  },
-  {
-    id: 'competitive',
-    label: 'Competitive analysis prepared',
-    description: 'Know your top 3 competitors and your differentiation.',
-    tip: 'Be honest about competitors; reviewers know the market.',
-  },
-  {
-    id: 'video',
-    label: 'Video demo recorded (optional but recommended)',
-    description: '2-3 minute product demo showcasing core functionality.',
-    tip: 'Use Loom or YouTube (unlisted). Focus on real use cases.',
-  },
-  {
-    id: 'advisors',
-    label: 'Advisor/investor list ready',
-    description: 'Names and affiliations of notable backers.',
-    tip: 'Include angel investors and strategic advisors.',
+    title: 'Community-Driven Safety',
+    description: 'Every safety pattern contributed helps someone else work more confidently with their command line.',
+    details: [
+      'Crowdsourced danger patterns',
+      'Community-reviewed best practices',
+      'Collective terminal expertise',
+      'Open source knowledge base',
+    ],
+    icon: (
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
   },
 ];
 
-const CheckIcon: React.FC = () => (
-  <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-  </svg>
-);
+const mcpIntegration = {
+  title: 'Model Context Protocol (MCP)',
+  description: 'First-class integration with AI assistants through the Model Context Protocol.',
+  benefits: [
+    {
+      title: 'Claude Desktop',
+      description: 'Official Caro skill for Claude Desktop integration',
+    },
+    {
+      title: 'VS Code Copilot',
+      description: 'Enhanced terminal commands in your IDE',
+    },
+    {
+      title: 'Custom Agents',
+      description: 'Build your own AI workflows with Caro as a tool',
+    },
+  ],
+};
+
+const roadmapItems = [
+  { phase: 'Now', items: ['Core CLI', 'Safety validation', 'Multi-backend', 'Cross-platform'] },
+  { phase: 'Next', items: ['MCP integration', 'Skills framework', 'Web Hub beta', 'Telemetry dashboard'] },
+  { phase: 'Future', items: ['Skills marketplace', 'Enterprise features', 'Professional guilds', 'Mobile companion'] },
+];
 
 export const PreparationChecklist: React.FC = () => {
-  const [checkedItems, setCheckedItems] = useState<Set<string>>(new Set());
-
-  const toggleItem = (id: string) => {
-    const newChecked = new Set(checkedItems);
-    if (newChecked.has(id)) {
-      newChecked.delete(id);
-    } else {
-      newChecked.add(id);
-    }
-    setCheckedItems(newChecked);
-  };
-
-  const progress = (checkedItems.size / checklistItems.length) * 100;
-
   return (
-    <section id="checklist" className="summit-section py-20 md:py-32">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section id="vision" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-12">
+        <div className="text-center max-w-3xl mx-auto mb-16">
           <span className="summit-badge summit-badge-teal mb-4 inline-block">
-            Get Ready
+            The Vision
           </span>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            Preparation Checklist
+            More Than a CLI Tool
           </h2>
-          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto">
-            Use this interactive checklist to prepare everything you need before
-            starting your application. Being prepared will help you submit a stronger application.
+          <p className="text-lg text-summit-text-secondary">
+            Caro is a living system with skills, tools, rules, and most importantly,
+            a community who cares about making terminals safer for everyone.
           </p>
         </div>
 
-        {/* Progress Bar */}
-        <div className="mb-10">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm text-summit-text-secondary">Preparation Progress</span>
-            <span className="text-sm font-medium text-summit-accent-teal">
-              {checkedItems.size} of {checklistItems.length} complete
-            </span>
-          </div>
-          <div className="h-3 bg-summit-tertiary rounded-full overflow-hidden">
-            <div
-              className="h-full bg-gradient-to-r from-summit-accent-teal to-summit-accent-blue rounded-full transition-all duration-500"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          {progress === 100 && (
-            <p className="text-center text-summit-success text-sm mt-3 flex items-center justify-center gap-2">
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              You&apos;re ready to apply!
-            </p>
-          )}
-        </div>
-
-        {/* Checklist Items */}
-        <div className="space-y-3">
-          {checklistItems.map((item) => {
-            const isChecked = checkedItems.has(item.id);
-            return (
-              <div
-                key={item.id}
-                className={`summit-checklist-item ${isChecked ? 'checked' : ''}`}
-                onClick={() => toggleItem(item.id)}
-                role="checkbox"
-                aria-checked={isChecked}
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    toggleItem(item.id);
-                  }
-                }}
-              >
-                <div className="summit-checklist-checkbox">
-                  {isChecked && <CheckIcon />}
-                </div>
-                <div className="flex-1">
-                  <div className={`font-medium ${isChecked ? 'text-summit-success' : 'text-summit-text-primary'} mb-1`}>
-                    {item.label}
-                  </div>
-                  <div className="text-sm text-summit-text-muted">
-                    {item.description}
-                  </div>
-                  {!isChecked && (
-                    <div className="text-xs text-summit-accent-teal mt-2 flex items-center gap-1">
-                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      Tip: {item.tip}
-                    </div>
-                  )}
-                </div>
+        {/* Vision Pillars */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-20">
+          {visionPillars.map((pillar, index) => (
+            <div key={index} className="summit-card">
+              <div className="w-16 h-16 rounded-xl bg-summit-accent-teal/10 flex items-center justify-center text-summit-accent-teal mb-6">
+                {pillar.icon}
               </div>
-            );
-          })}
+              <h3 className="text-xl font-semibold text-summit-text-primary mb-3">
+                {pillar.title}
+              </h3>
+              <p className="text-summit-text-secondary mb-4">
+                {pillar.description}
+              </p>
+              <ul className="space-y-2">
+                {pillar.details.map((detail, i) => (
+                  <li key={i} className="flex items-center gap-2 text-sm text-summit-text-muted">
+                    <svg className="w-4 h-4 text-summit-accent-teal flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                    {detail}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
 
-        {/* Time Estimate */}
-        <div className="mt-10 p-6 rounded-xl bg-summit-tertiary/30 border border-summit-tertiary/50 text-center">
-          <div className="flex items-center justify-center gap-3 mb-2">
-            <svg className="w-6 h-6 text-summit-accent-teal" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <span className="text-summit-text-primary font-semibold">
-              Estimated Application Time: 10-15 minutes
-            </span>
+        {/* MCP Integration */}
+        <div className="summit-card mb-20">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+            <div>
+              <span className="summit-badge summit-badge-purple mb-4 inline-block">
+                Integration
+              </span>
+              <h3 className="text-2xl font-bold text-summit-text-primary mb-4">
+                {mcpIntegration.title}
+              </h3>
+              <p className="text-summit-text-secondary mb-6">
+                {mcpIntegration.description}
+              </p>
+              <div className="bg-summit-primary/50 rounded-lg p-4 font-mono text-sm">
+                <div className="text-summit-text-muted mb-2"># Example: Using Caro as a Claude skill</div>
+                <div className="text-summit-accent-teal">@caro &quot;find all Docker containers using more than 1GB memory&quot;</div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              {mcpIntegration.benefits.map((benefit, index) => (
+                <div key={index} className="bg-summit-primary/30 rounded-xl p-4 border border-summit-tertiary/30">
+                  <h4 className="text-lg font-semibold text-summit-text-primary mb-1">
+                    {benefit.title}
+                  </h4>
+                  <p className="text-sm text-summit-text-secondary">
+                    {benefit.description}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
-          <p className="text-sm text-summit-text-muted">
-            If you have all the items above prepared, the application form should take about 10-15 minutes to complete.
-          </p>
+        </div>
+
+        {/* Roadmap */}
+        <div>
+          <div className="text-center mb-12">
+            <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+              Product Roadmap
+            </h3>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {roadmapItems.map((phase, index) => (
+              <div
+                key={index}
+                className={`rounded-xl p-6 border-2 ${
+                  index === 0 ? 'border-summit-accent-teal bg-summit-accent-teal/5' :
+                  index === 1 ? 'border-summit-accent-blue/50 bg-summit-accent-blue/5' :
+                  'border-summit-tertiary/50 bg-summit-tertiary/10'
+                }`}
+              >
+                <div className={`text-lg font-bold mb-4 ${
+                  index === 0 ? 'text-summit-accent-teal' :
+                  index === 1 ? 'text-summit-accent-blue' :
+                  'text-summit-text-muted'
+                }`}>
+                  {phase.phase}
+                </div>
+                <ul className="space-y-2">
+                  {phase.items.map((item, i) => (
+                    <li key={i} className="flex items-center gap-2 text-sm text-summit-text-secondary">
+                      <svg className={`w-4 h-4 flex-shrink-0 ${
+                        index === 0 ? 'text-summit-success' : 'text-summit-text-muted'
+                      }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/apps/devrel/components/summit/PreparationChecklist.tsx
+++ b/apps/devrel/components/summit/PreparationChecklist.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useState } from 'react';
+
+const checklistItems = [
+  {
+    id: 'website',
+    label: 'Company website is live and polished',
+    description: 'Ensure your website clearly communicates your value proposition and product.',
+    tip: 'Check mobile responsiveness and page load times.',
+  },
+  {
+    id: 'linkedin',
+    label: 'Founder LinkedIn profile is complete and professional',
+    description: 'Update your photo, headline, and recent company updates.',
+    tip: 'Add recent posts about your company progress.',
+  },
+  {
+    id: 'description',
+    label: '100-word company description drafted',
+    description: 'Concise, clear description of what you do and for whom.',
+    tip: 'Focus on the problem you solve, not technical features.',
+  },
+  {
+    id: 'financials',
+    label: 'Financial metrics compiled (ARR, funding)',
+    description: 'Have your current ARR, total raised, and funding stage ready.',
+    tip: 'Include growth rate if impressive (e.g., "3x YoY").',
+  },
+  {
+    id: 'customers',
+    label: 'Customer list and achievements documented',
+    description: 'Prepare a list of notable customers and key metrics.',
+    tip: 'Get logo usage permission from customers in advance.',
+  },
+  {
+    id: 'competitive',
+    label: 'Competitive analysis prepared',
+    description: 'Know your top 3 competitors and your differentiation.',
+    tip: 'Be honest about competitors; reviewers know the market.',
+  },
+  {
+    id: 'video',
+    label: 'Video demo recorded (optional but recommended)',
+    description: '2-3 minute product demo showcasing core functionality.',
+    tip: 'Use Loom or YouTube (unlisted). Focus on real use cases.',
+  },
+  {
+    id: 'advisors',
+    label: 'Advisor/investor list ready',
+    description: 'Names and affiliations of notable backers.',
+    tip: 'Include angel investors and strategic advisors.',
+  },
+];
+
+const CheckIcon: React.FC = () => (
+  <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+export const PreparationChecklist: React.FC = () => {
+  const [checkedItems, setCheckedItems] = useState<Set<string>>(new Set());
+
+  const toggleItem = (id: string) => {
+    const newChecked = new Set(checkedItems);
+    if (newChecked.has(id)) {
+      newChecked.delete(id);
+    } else {
+      newChecked.add(id);
+    }
+    setCheckedItems(newChecked);
+  };
+
+  const progress = (checkedItems.size / checklistItems.length) * 100;
+
+  return (
+    <section id="checklist" className="summit-section py-20 md:py-32">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Section Header */}
+        <div className="text-center mb-12">
+          <span className="summit-badge summit-badge-teal mb-4 inline-block">
+            Get Ready
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            Preparation Checklist
+          </h2>
+          <p className="text-lg text-summit-text-secondary max-w-2xl mx-auto">
+            Use this interactive checklist to prepare everything you need before
+            starting your application. Being prepared will help you submit a stronger application.
+          </p>
+        </div>
+
+        {/* Progress Bar */}
+        <div className="mb-10">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm text-summit-text-secondary">Preparation Progress</span>
+            <span className="text-sm font-medium text-summit-accent-teal">
+              {checkedItems.size} of {checklistItems.length} complete
+            </span>
+          </div>
+          <div className="h-3 bg-summit-tertiary rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-summit-accent-teal to-summit-accent-blue rounded-full transition-all duration-500"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          {progress === 100 && (
+            <p className="text-center text-summit-success text-sm mt-3 flex items-center justify-center gap-2">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              You&apos;re ready to apply!
+            </p>
+          )}
+        </div>
+
+        {/* Checklist Items */}
+        <div className="space-y-3">
+          {checklistItems.map((item) => {
+            const isChecked = checkedItems.has(item.id);
+            return (
+              <div
+                key={item.id}
+                className={`summit-checklist-item ${isChecked ? 'checked' : ''}`}
+                onClick={() => toggleItem(item.id)}
+                role="checkbox"
+                aria-checked={isChecked}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleItem(item.id);
+                  }
+                }}
+              >
+                <div className="summit-checklist-checkbox">
+                  {isChecked && <CheckIcon />}
+                </div>
+                <div className="flex-1">
+                  <div className={`font-medium ${isChecked ? 'text-summit-success' : 'text-summit-text-primary'} mb-1`}>
+                    {item.label}
+                  </div>
+                  <div className="text-sm text-summit-text-muted">
+                    {item.description}
+                  </div>
+                  {!isChecked && (
+                    <div className="text-xs text-summit-accent-teal mt-2 flex items-center gap-1">
+                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      Tip: {item.tip}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Time Estimate */}
+        <div className="mt-10 p-6 rounded-xl bg-summit-tertiary/30 border border-summit-tertiary/50 text-center">
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <svg className="w-6 h-6 text-summit-accent-teal" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="text-summit-text-primary font-semibold">
+              Estimated Application Time: 10-15 minutes
+            </span>
+          </div>
+          <p className="text-sm text-summit-text-muted">
+            If you have all the items above prepared, the application form should take about 10-15 minutes to complete.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/SuccessStories.tsx
+++ b/apps/devrel/components/summit/SuccessStories.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+
+const testimonials = [
+  {
+    quote: "Presenting at the Seattle AI Summit was a turning point for us. We closed our Series A within 60 days of the event. The quality of investors and enterprise buyers in the room was exceptional.",
+    author: "Sarah Chen",
+    role: "CEO & Co-founder",
+    company: "NeuralFlow AI",
+    outcome: "$8M Series A",
+    avatar: "SC",
+  },
+  {
+    quote: "We came to the summit with a working prototype and left with three enterprise pilot contracts. The 10-minute demo format forced us to crystallize our value proposition perfectly.",
+    author: "Marcus Williams",
+    role: "Founder",
+    company: "DataMesh Labs",
+    outcome: "3 Enterprise Pilots",
+    avatar: "MW",
+  },
+  {
+    quote: "The connections we made at demo day led to a strategic partnership with a Fortune 100 company. That partnership became our primary go-to-market channel.",
+    author: "Priya Sharma",
+    role: "CTO",
+    company: "AI Catalyst",
+    outcome: "Fortune 100 Partner",
+    avatar: "PS",
+  },
+];
+
+const outcomes = [
+  {
+    value: '$50M+',
+    label: 'Total Funding Raised',
+    description: 'By demo day participants in the year following the event',
+  },
+  {
+    value: '40+',
+    label: 'Enterprise Deals Closed',
+    description: 'Direct connections made during the summit',
+  },
+  {
+    value: '85%',
+    label: 'Still Operating',
+    description: 'Of past demo companies still active after 3 years',
+  },
+  {
+    value: '12',
+    label: 'Acquisitions',
+    description: 'Demo day alumni acquired by larger companies',
+  },
+];
+
+const companyLogos = [
+  'TechVentures AI',
+  'CloudMind',
+  'DataPilot',
+  'AIFirst Labs',
+  'NeuralScale',
+  'Synapse.io',
+  'Cortex Systems',
+  'DeepQuery',
+];
+
+export const SuccessStories: React.FC = () => {
+  return (
+    <section id="success-stories" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Section Header */}
+        <div className="text-center max-w-3xl mx-auto mb-16">
+          <span className="summit-badge summit-badge-orange mb-4 inline-block">
+            Social Proof
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            Past Success Stories
+          </h2>
+          <p className="text-lg text-summit-text-secondary">
+            Don&apos;t just take our word for it. Here&apos;s what previous demo day participants
+            achieved after presenting at the Seattle AI Summit.
+          </p>
+        </div>
+
+        {/* Outcomes Grid */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16">
+          {outcomes.map((outcome) => (
+            <div key={outcome.label} className="summit-card text-center">
+              <div className="summit-stat-value text-3xl md:text-4xl mb-2">
+                {outcome.value}
+              </div>
+              <div className="text-summit-text-primary font-medium mb-1">
+                {outcome.label}
+              </div>
+              <div className="text-xs text-summit-text-muted">
+                {outcome.description}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Testimonials */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
+          {testimonials.map((testimonial, index) => (
+            <div key={index} className="summit-card flex flex-col">
+              {/* Quote */}
+              <div className="flex-1">
+                <svg
+                  className="w-8 h-8 text-summit-accent-teal/30 mb-4"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h3.983v10h-9.983z" />
+                </svg>
+                <p className="text-summit-text-secondary leading-relaxed mb-6">
+                  {testimonial.quote}
+                </p>
+              </div>
+
+              {/* Author */}
+              <div className="flex items-center gap-4 pt-4 border-t border-summit-tertiary/30">
+                <div className="w-12 h-12 rounded-full bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center text-white font-semibold">
+                  {testimonial.avatar}
+                </div>
+                <div className="flex-1">
+                  <div className="text-summit-text-primary font-medium">
+                    {testimonial.author}
+                  </div>
+                  <div className="text-sm text-summit-text-muted">
+                    {testimonial.role}, {testimonial.company}
+                  </div>
+                </div>
+                <div className="summit-badge summit-badge-teal text-xs">
+                  {testimonial.outcome}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Company Logos */}
+        <div className="text-center">
+          <p className="text-summit-text-muted text-sm mb-8 uppercase tracking-wider">
+            Previous Demo Day Participants
+          </p>
+          <div className="flex flex-wrap justify-center gap-6 md:gap-10">
+            {companyLogos.map((company) => (
+              <div
+                key={company}
+                className="px-4 py-2 text-summit-text-muted text-sm font-medium opacity-60 hover:opacity-100 transition-opacity"
+              >
+                {company}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/SuccessStories.tsx
+++ b/apps/devrel/components/summit/SuccessStories.tsx
@@ -2,153 +2,183 @@
 
 import React from 'react';
 
-const testimonials = [
+const achievements = [
   {
-    quote: "Presenting at the Seattle AI Summit was a turning point for us. We closed our Series A within 60 days of the event. The quality of investors and enterprise buyers in the room was exceptional.",
-    author: "Sarah Chen",
-    role: "CEO & Co-founder",
-    company: "NeuralFlow AI",
-    outcome: "$8M Series A",
-    avatar: "SC",
+    metric: '52+',
+    label: 'Safety Patterns',
+    description: 'Pre-compiled dangerous command patterns with 0% false positive rate',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
   },
   {
-    quote: "We came to the summit with a working prototype and left with three enterprise pilot contracts. The 10-minute demo format forced us to crystallize our value proposition perfectly.",
-    author: "Marcus Williams",
-    role: "Founder",
-    company: "DataMesh Labs",
-    outcome: "3 Enterprise Pilots",
-    avatar: "MW",
+    metric: '6',
+    label: 'Backend Integrations',
+    description: 'MLX, CPU, Ollama, vLLM, OpenAI, and Anthropic backends',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+      </svg>
+    ),
   },
   {
-    quote: "The connections we made at demo day led to a strategic partnership with a Fortune 100 company. That partnership became our primary go-to-market channel.",
-    author: "Priya Sharma",
-    role: "CTO",
-    company: "AI Catalyst",
-    outcome: "Fortune 100 Partner",
-    avatar: "PS",
-  },
-];
-
-const outcomes = [
-  {
-    value: '$50M+',
-    label: 'Total Funding Raised',
-    description: 'By demo day participants in the year following the event',
+    metric: '3',
+    label: 'Platforms',
+    description: 'macOS (Intel + Apple Silicon), Linux, and Windows support',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+    ),
   },
   {
-    value: '40+',
-    label: 'Enterprise Deals Closed',
-    description: 'Direct connections made during the summit',
-  },
-  {
-    value: '85%',
-    label: 'Still Operating',
-    description: 'Of past demo companies still active after 3 years',
-  },
-  {
-    value: '12',
-    label: 'Acquisitions',
-    description: 'Demo day alumni acquired by larger companies',
+    metric: '<2s',
+    label: 'Inference Time',
+    description: 'Sub-2-second command generation on Apple Silicon',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
   },
 ];
 
-const companyLogos = [
-  'TechVentures AI',
-  'CloudMind',
-  'DataPilot',
-  'AIFirst Labs',
-  'NeuralScale',
-  'Synapse.io',
-  'Cortex Systems',
-  'DeepQuery',
+const milestones = [
+  {
+    title: 'Core CLI Complete',
+    status: 'completed',
+    items: ['Natural language parsing', 'Command generation', 'Safety validation', 'Multi-backend support'],
+  },
+  {
+    title: 'Safety System',
+    status: 'completed',
+    items: ['52+ danger patterns', 'Risk level classification', 'Confirmation workflows', 'Fork bomb detection'],
+  },
+  {
+    title: 'Platform Support',
+    status: 'completed',
+    items: ['macOS (Intel + ARM)', 'Linux distributions', 'Windows support', 'Platform detection'],
+  },
+  {
+    title: 'Open Source Launch',
+    status: 'in_progress',
+    items: ['AGPL-3.0 license', 'Community contribution guide', 'GitHub repository', 'Documentation'],
+  },
+];
+
+const integrations = [
+  { name: 'Claude Desktop', status: 'available', description: 'Official MCP skill' },
+  { name: 'VS Code', status: 'available', description: 'Extension integration' },
+  { name: 'Terminal.app', status: 'available', description: 'Native macOS' },
+  { name: 'iTerm2', status: 'available', description: 'Native macOS' },
+  { name: 'Warp', status: 'planned', description: 'Modern terminal' },
+  { name: 'Alacritty', status: 'available', description: 'Cross-platform' },
 ];
 
 export const SuccessStories: React.FC = () => {
   return (
-    <section id="success-stories" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
+    <section id="traction" className="summit-section py-20 md:py-32">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center max-w-3xl mx-auto mb-16">
           <span className="summit-badge summit-badge-orange mb-4 inline-block">
-            Social Proof
+            Traction
           </span>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            Past Success Stories
+            What We&apos;ve Built
           </h2>
           <p className="text-lg text-summit-text-secondary">
-            Don&apos;t just take our word for it. Here&apos;s what previous demo day participants
-            achieved after presenting at the Seattle AI Summit.
+            A production-ready CLI tool with comprehensive safety validation,
+            multi-platform support, and extensible architecture.
           </p>
         </div>
 
-        {/* Outcomes Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16">
-          {outcomes.map((outcome) => (
-            <div key={outcome.label} className="summit-card text-center">
-              <div className="summit-stat-value text-3xl md:text-4xl mb-2">
-                {outcome.value}
+        {/* Key Metrics */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-20">
+          {achievements.map((achievement, index) => (
+            <div key={index} className="summit-card text-center">
+              <div className="w-12 h-12 mx-auto rounded-xl bg-summit-accent-orange/10 flex items-center justify-center text-summit-accent-orange mb-4">
+                {achievement.icon}
               </div>
-              <div className="text-summit-text-primary font-medium mb-1">
-                {outcome.label}
+              <div className="text-3xl font-bold summit-gradient-text mb-2">
+                {achievement.metric}
               </div>
-              <div className="text-xs text-summit-text-muted">
-                {outcome.description}
+              <div className="text-lg font-semibold text-summit-text-primary mb-2">
+                {achievement.label}
               </div>
+              <p className="text-sm text-summit-text-muted">
+                {achievement.description}
+              </p>
             </div>
           ))}
         </div>
 
-        {/* Testimonials */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
-          {testimonials.map((testimonial, index) => (
-            <div key={index} className="summit-card flex flex-col">
-              {/* Quote */}
-              <div className="flex-1">
-                <svg
-                  className="w-8 h-8 text-summit-accent-teal/30 mb-4"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h3.983v10h-9.983z" />
-                </svg>
-                <p className="text-summit-text-secondary leading-relaxed mb-6">
-                  {testimonial.quote}
-                </p>
-              </div>
+        {/* Development Milestones */}
+        <div className="mb-20">
+          <div className="text-center mb-12">
+            <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+              Development Progress
+            </h3>
+          </div>
 
-              {/* Author */}
-              <div className="flex items-center gap-4 pt-4 border-t border-summit-tertiary/30">
-                <div className="w-12 h-12 rounded-full bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center text-white font-semibold">
-                  {testimonial.avatar}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {milestones.map((milestone, index) => (
+              <div key={index} className="summit-card">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className={`w-3 h-3 rounded-full ${
+                    milestone.status === 'completed' ? 'bg-summit-success' : 'bg-summit-warning animate-pulse'
+                  }`} />
+                  <span className={`text-xs font-medium uppercase tracking-wider ${
+                    milestone.status === 'completed' ? 'text-summit-success' : 'text-summit-warning'
+                  }`}>
+                    {milestone.status === 'completed' ? 'Complete' : 'In Progress'}
+                  </span>
                 </div>
-                <div className="flex-1">
-                  <div className="text-summit-text-primary font-medium">
-                    {testimonial.author}
-                  </div>
-                  <div className="text-sm text-summit-text-muted">
-                    {testimonial.role}, {testimonial.company}
-                  </div>
-                </div>
-                <div className="summit-badge summit-badge-teal text-xs">
-                  {testimonial.outcome}
-                </div>
+                <h4 className="text-lg font-semibold text-summit-text-primary mb-4">
+                  {milestone.title}
+                </h4>
+                <ul className="space-y-2">
+                  {milestone.items.map((item, i) => (
+                    <li key={i} className="flex items-center gap-2 text-sm text-summit-text-secondary">
+                      <svg className="w-4 h-4 text-summit-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
 
-        {/* Company Logos */}
-        <div className="text-center">
-          <p className="text-summit-text-muted text-sm mb-8 uppercase tracking-wider">
-            Previous Demo Day Participants
-          </p>
-          <div className="flex flex-wrap justify-center gap-6 md:gap-10">
-            {companyLogos.map((company) => (
+        {/* Integration Partners */}
+        <div>
+          <div className="text-center mb-12">
+            <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+              Integration Ecosystem
+            </h3>
+            <p className="text-summit-text-secondary">
+              Works with your existing tools and workflows
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+            {integrations.map((integration) => (
               <div
-                key={company}
-                className="px-4 py-2 text-summit-text-muted text-sm font-medium opacity-60 hover:opacity-100 transition-opacity"
+                key={integration.name}
+                className="bg-summit-tertiary/30 rounded-xl p-4 text-center border border-summit-tertiary/50 hover:border-summit-accent-teal/30 transition-colors"
               >
-                {company}
+                <div className="text-sm font-medium text-summit-text-primary mb-1">
+                  {integration.name}
+                </div>
+                <div className={`text-xs ${
+                  integration.status === 'available' ? 'text-summit-success' : 'text-summit-text-muted'
+                }`}>
+                  {integration.status === 'available' ? 'Available' : 'Planned'}
+                </div>
               </div>
             ))}
           </div>

--- a/apps/devrel/components/summit/SummitFooter.tsx
+++ b/apps/devrel/components/summit/SummitFooter.tsx
@@ -4,30 +4,30 @@ import React from 'react';
 
 const footerLinks = [
   {
-    title: 'Event',
+    title: 'Product',
     links: [
-      { label: 'About', href: '#criteria' },
-      { label: 'Timeline', href: '#timeline' },
-      { label: 'FAQ', href: '#faq' },
-      { label: 'Apply', href: '#apply' },
+      { label: 'Features', href: '#solution' },
+      { label: 'Safety', href: '#advantages' },
+      { label: 'Roadmap', href: '#vision' },
+      { label: 'Changelog', href: 'https://github.com/anthropics/caro/releases' },
     ],
   },
   {
     title: 'Resources',
     links: [
-      { label: 'Success Stories', href: '#success-stories' },
-      { label: 'Checklist', href: '#checklist' },
-      { label: 'Past Events', href: '#' },
-      { label: 'Media Kit', href: '#' },
+      { label: 'Documentation', href: 'https://caro.sh/docs' },
+      { label: 'Getting Started', href: '#get-started' },
+      { label: 'API Reference', href: 'https://caro.sh/docs/api' },
+      { label: 'Examples', href: 'https://github.com/anthropics/caro/tree/main/examples' },
     ],
   },
   {
-    title: 'Connect',
+    title: 'Community',
     links: [
-      { label: 'Twitter', href: 'https://twitter.com/seattleaisummit' },
-      { label: 'LinkedIn', href: 'https://linkedin.com/company/seattleaisummit' },
-      { label: 'Contact', href: 'mailto:summit@cmdai.dev' },
-      { label: 'Newsletter', href: '#' },
+      { label: 'GitHub', href: 'https://github.com/anthropics/caro' },
+      { label: 'Discussions', href: 'https://github.com/anthropics/caro/discussions' },
+      { label: 'Twitter', href: 'https://twitter.com/caro_cli' },
+      { label: 'Discord', href: 'https://discord.gg/caro' },
     ],
   },
 ];
@@ -44,32 +44,31 @@ export const SummitFooter: React.FC = () => {
           <div className="lg:col-span-1">
             <div className="flex items-center gap-3 mb-4">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center">
-                <span className="text-white font-bold">AI</span>
+                <span className="text-white font-bold">C</span>
               </div>
               <div>
                 <div className="text-summit-text-primary font-semibold">
-                  Seattle AI Summit
+                  Caro
                 </div>
-                <div className="text-xs text-summit-text-muted">2026</div>
+                <div className="text-xs text-summit-text-muted">Your loyal shell companion</div>
               </div>
             </div>
             <p className="text-sm text-summit-text-secondary leading-relaxed mb-4">
-              The premier event connecting AI startups with Fortune 500 leaders,
-              investors, and media in the Pacific Northwest.
+              Transform natural language into safe, POSIX-compliant shell commands
+              using local AI. Built with Rust for safety and performance.
             </p>
             <div className="text-sm text-summit-text-muted">
               <div className="flex items-center gap-2 mb-1">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                 </svg>
-                Seattle, WA
+                52+ safety patterns
               </div>
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
-                June 15-16, 2026
+                100% local inference
               </div>
             </div>
           </div>
@@ -104,16 +103,16 @@ export const SummitFooter: React.FC = () => {
         {/* Bottom Bar */}
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
           <div className="text-sm text-summit-text-muted">
-            &copy; {currentYear} Seattle AI Startup Summit. All rights reserved.
+            &copy; {currentYear} Caro. AGPL-3.0 License. Made with Rust.
           </div>
           <div className="flex items-center gap-6">
-            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
-              Privacy Policy
+            <a href="https://github.com/anthropics/caro/blob/main/LICENSE" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+              License
             </a>
-            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
-              Terms of Service
+            <a href="https://github.com/anthropics/caro/blob/main/CONTRIBUTING.md" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+              Contributing
             </a>
-            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+            <a href="https://github.com/anthropics/caro/blob/main/CODE_OF_CONDUCT.md" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
               Code of Conduct
             </a>
           </div>

--- a/apps/devrel/components/summit/SummitFooter.tsx
+++ b/apps/devrel/components/summit/SummitFooter.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React from 'react';
+
+const footerLinks = [
+  {
+    title: 'Event',
+    links: [
+      { label: 'About', href: '#criteria' },
+      { label: 'Timeline', href: '#timeline' },
+      { label: 'FAQ', href: '#faq' },
+      { label: 'Apply', href: '#apply' },
+    ],
+  },
+  {
+    title: 'Resources',
+    links: [
+      { label: 'Success Stories', href: '#success-stories' },
+      { label: 'Checklist', href: '#checklist' },
+      { label: 'Past Events', href: '#' },
+      { label: 'Media Kit', href: '#' },
+    ],
+  },
+  {
+    title: 'Connect',
+    links: [
+      { label: 'Twitter', href: 'https://twitter.com/seattleaisummit' },
+      { label: 'LinkedIn', href: 'https://linkedin.com/company/seattleaisummit' },
+      { label: 'Contact', href: 'mailto:summit@cmdai.dev' },
+      { label: 'Newsletter', href: '#' },
+    ],
+  },
+];
+
+export const SummitFooter: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="bg-summit-primary border-t border-summit-tertiary/30">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        {/* Main Footer Content */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12">
+          {/* Brand Column */}
+          <div className="lg:col-span-1">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center">
+                <span className="text-white font-bold">AI</span>
+              </div>
+              <div>
+                <div className="text-summit-text-primary font-semibold">
+                  Seattle AI Summit
+                </div>
+                <div className="text-xs text-summit-text-muted">2026</div>
+              </div>
+            </div>
+            <p className="text-sm text-summit-text-secondary leading-relaxed mb-4">
+              The premier event connecting AI startups with Fortune 500 leaders,
+              investors, and media in the Pacific Northwest.
+            </p>
+            <div className="text-sm text-summit-text-muted">
+              <div className="flex items-center gap-2 mb-1">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Seattle, WA
+              </div>
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                June 15-16, 2026
+              </div>
+            </div>
+          </div>
+
+          {/* Link Columns */}
+          {footerLinks.map((column) => (
+            <div key={column.title}>
+              <h4 className="text-summit-text-primary font-semibold mb-4">
+                {column.title}
+              </h4>
+              <ul className="space-y-3">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors"
+                      target={link.href.startsWith('http') ? '_blank' : undefined}
+                      rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className="h-px bg-summit-tertiary/30 mb-8" />
+
+        {/* Bottom Bar */}
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+          <div className="text-sm text-summit-text-muted">
+            &copy; {currentYear} Seattle AI Startup Summit. All rights reserved.
+          </div>
+          <div className="flex items-center gap-6">
+            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+              Privacy Policy
+            </a>
+            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+              Terms of Service
+            </a>
+            <a href="#" className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors">
+              Code of Conduct
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/apps/devrel/components/summit/SummitHero.tsx
+++ b/apps/devrel/components/summit/SummitHero.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+const stats = [
+  { value: '500+', label: 'Attendees' },
+  { value: '50', label: 'Demo Slots' },
+  { value: '$10M+', label: 'Funding Raised' },
+  { value: '30+', label: 'Investors' },
+];
+
+// Calculate days until June 15, 2026
+const calculateTimeLeft = () => {
+  const deadline = new Date('2026-06-15T09:00:00-07:00');
+  const now = new Date();
+  const difference = deadline.getTime() - now.getTime();
+
+  if (difference <= 0) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+  }
+
+  return {
+    days: Math.floor(difference / (1000 * 60 * 60 * 24)),
+    hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
+    minutes: Math.floor((difference / 1000 / 60) % 60),
+    seconds: Math.floor((difference / 1000) % 60),
+  };
+};
+
+export const SummitHero: React.FC = () => {
+  const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTimeLeft(calculateTimeLeft());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <section className="relative min-h-screen flex items-center pt-16 overflow-hidden">
+      {/* Background decorations */}
+      <div className="summit-glow-teal -top-40 -right-40" />
+      <div className="summit-glow-purple top-1/3 -left-60" />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24 relative z-10">
+        <div className="text-center max-w-4xl mx-auto">
+          {/* Badge */}
+          <div className="inline-flex items-center gap-2 summit-badge summit-badge-teal mb-8">
+            <span className="w-2 h-2 bg-summit-accent-teal rounded-full animate-pulse" />
+            Applications Open - Limited Slots Available
+          </div>
+
+          {/* Main Headline */}
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
+            <span className="text-summit-text-primary">Showcase Your AI Startup to</span>
+            <br />
+            <span className="summit-gradient-text">Fortune 500 Leaders</span>
+          </h1>
+
+          {/* Subheadline */}
+          <p className="text-lg md:text-xl text-summit-text-secondary max-w-2xl mx-auto mb-8 leading-relaxed">
+            Present your AI innovation to enterprise decision-makers, connect with
+            top-tier investors, and gain media coverage at Seattle&apos;s premier AI startup event.
+          </p>
+
+          {/* Value Props */}
+          <div className="flex flex-wrap justify-center gap-4 mb-10">
+            <span className="summit-badge summit-badge-blue">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+              10-Min Demo Opportunity
+            </span>
+            <span className="summit-badge summit-badge-purple">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Investment Connections
+            </span>
+            <span className="summit-badge summit-badge-orange">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+              </svg>
+              Media Coverage
+            </span>
+          </div>
+
+          {/* CTAs */}
+          <div className="flex flex-col sm:flex-row justify-center gap-4 mb-16">
+            <a href="#apply" className="summit-btn-primary text-lg">
+              Apply for Demo Day
+            </a>
+            <a href="#criteria" className="summit-btn-secondary text-lg">
+              View Requirements
+            </a>
+          </div>
+
+          {/* Countdown */}
+          <div className="mb-16">
+            <p className="text-summit-text-muted text-sm mb-4 uppercase tracking-wider">
+              Event Date: June 15-16, 2026
+            </p>
+            <div className="summit-countdown">
+              <div className="summit-countdown-unit">
+                <div className="summit-countdown-value">{timeLeft.days}</div>
+                <div className="summit-countdown-label">Days</div>
+              </div>
+              <div className="summit-countdown-unit">
+                <div className="summit-countdown-value">{timeLeft.hours}</div>
+                <div className="summit-countdown-label">Hours</div>
+              </div>
+              <div className="summit-countdown-unit">
+                <div className="summit-countdown-value">{timeLeft.minutes}</div>
+                <div className="summit-countdown-label">Minutes</div>
+              </div>
+              <div className="summit-countdown-unit">
+                <div className="summit-countdown-value">{timeLeft.seconds}</div>
+                <div className="summit-countdown-label">Seconds</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-3xl mx-auto">
+            {stats.map((stat) => (
+              <div key={stat.label} className="summit-stat">
+                <div className="summit-stat-value">{stat.value}</div>
+                <div className="summit-stat-label">{stat.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Scroll indicator */}
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+          <svg
+            className="w-6 h-6 text-summit-text-muted"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 14l-7 7m0 0l-7-7m7 7V3"
+            />
+          </svg>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/SummitHero.tsx
+++ b/apps/devrel/components/summit/SummitHero.tsx
@@ -1,43 +1,15 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 const stats = [
-  { value: '500+', label: 'Attendees' },
-  { value: '50', label: 'Demo Slots' },
-  { value: '$10M+', label: 'Funding Raised' },
-  { value: '30+', label: 'Investors' },
+  { value: '52+', label: 'Safety Patterns' },
+  { value: '<2s', label: 'Inference Time' },
+  { value: '100%', label: 'Local & Private' },
+  { value: '6', label: 'Backends Supported' },
 ];
 
-// Calculate days until June 15, 2026
-const calculateTimeLeft = () => {
-  const deadline = new Date('2026-06-15T09:00:00-07:00');
-  const now = new Date();
-  const difference = deadline.getTime() - now.getTime();
-
-  if (difference <= 0) {
-    return { days: 0, hours: 0, minutes: 0, seconds: 0 };
-  }
-
-  return {
-    days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-    hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
-    minutes: Math.floor((difference / 1000 / 60) % 60),
-    seconds: Math.floor((difference / 1000) % 60),
-  };
-};
-
 export const SummitHero: React.FC = () => {
-  const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setTimeLeft(calculateTimeLeft());
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, []);
-
   return (
     <section className="relative min-h-screen flex items-center pt-16 overflow-hidden">
       {/* Background decorations */}
@@ -49,77 +21,83 @@ export const SummitHero: React.FC = () => {
           {/* Badge */}
           <div className="inline-flex items-center gap-2 summit-badge summit-badge-teal mb-8">
             <span className="w-2 h-2 bg-summit-accent-teal rounded-full animate-pulse" />
-            Applications Open - Limited Slots Available
+            Seattle AI Startup Summit 2026 - Demo Showcase
           </div>
 
           {/* Main Headline */}
           <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
-            <span className="text-summit-text-primary">Showcase Your AI Startup to</span>
+            <span className="text-summit-text-primary">Natural Language to</span>
             <br />
-            <span className="summit-gradient-text">Fortune 500 Leaders</span>
+            <span className="summit-gradient-text">Safe Shell Commands</span>
           </h1>
 
           {/* Subheadline */}
           <p className="text-lg md:text-xl text-summit-text-secondary max-w-2xl mx-auto mb-8 leading-relaxed">
-            Present your AI innovation to enterprise decision-makers, connect with
-            top-tier investors, and gain media coverage at Seattle&apos;s premier AI startup event.
+            Caro is an AI-powered CLI tool that converts plain English into validated,
+            platform-aware shell commands. Built with Rust. Runs 100% locally.
+            Never sends your data to the cloud.
           </p>
 
           {/* Value Props */}
           <div className="flex flex-wrap justify-center gap-4 mb-10">
             <span className="summit-badge summit-badge-blue">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
               </svg>
-              10-Min Demo Opportunity
+              Safety-First AI
             </span>
             <span className="summit-badge summit-badge-purple">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
               </svg>
-              Investment Connections
+              100% Local & Private
             </span>
             <span className="summit-badge summit-badge-orange">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
-              Media Coverage
+              Rust-Powered Performance
             </span>
+          </div>
+
+          {/* Terminal Demo Preview */}
+          <div className="max-w-2xl mx-auto mb-12 text-left">
+            <div className="bg-summit-primary border border-summit-tertiary rounded-xl overflow-hidden shadow-2xl">
+              <div className="flex items-center gap-2 px-4 py-3 bg-summit-secondary border-b border-summit-tertiary">
+                <div className="w-3 h-3 rounded-full bg-red-500" />
+                <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                <div className="w-3 h-3 rounded-full bg-green-500" />
+                <span className="ml-2 text-sm text-summit-text-muted font-mono">Terminal</span>
+              </div>
+              <div className="p-6 font-mono text-sm">
+                <div className="text-summit-text-muted mb-2">$ caro &quot;list all PDF files larger than 10MB&quot;</div>
+                <div className="text-summit-text-secondary mb-4">
+                  <span className="text-summit-accent-teal">Generated command:</span>
+                  <br />
+                  <span className="text-summit-text-primary ml-2">find ~/Downloads -name &quot;*.pdf&quot; -size +10M -ls</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center gap-1 px-2 py-1 rounded bg-green-500/20 text-green-400 text-xs">
+                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    SAFE
+                  </span>
+                  <span className="text-summit-text-muted">Execute this command? (y/N)</span>
+                  <span className="text-summit-accent-teal animate-pulse">▌</span>
+                </div>
+              </div>
+            </div>
           </div>
 
           {/* CTAs */}
           <div className="flex flex-col sm:flex-row justify-center gap-4 mb-16">
-            <a href="#apply" className="summit-btn-primary text-lg">
-              Apply for Demo Day
+            <a href="#problem" className="summit-btn-primary text-lg">
+              See the Problem We Solve
             </a>
-            <a href="#criteria" className="summit-btn-secondary text-lg">
-              View Requirements
+            <a href="https://github.com/anthropics/caro" target="_blank" rel="noopener noreferrer" className="summit-btn-secondary text-lg">
+              View on GitHub
             </a>
-          </div>
-
-          {/* Countdown */}
-          <div className="mb-16">
-            <p className="text-summit-text-muted text-sm mb-4 uppercase tracking-wider">
-              Event Date: June 15-16, 2026
-            </p>
-            <div className="summit-countdown">
-              <div className="summit-countdown-unit">
-                <div className="summit-countdown-value">{timeLeft.days}</div>
-                <div className="summit-countdown-label">Days</div>
-              </div>
-              <div className="summit-countdown-unit">
-                <div className="summit-countdown-value">{timeLeft.hours}</div>
-                <div className="summit-countdown-label">Hours</div>
-              </div>
-              <div className="summit-countdown-unit">
-                <div className="summit-countdown-value">{timeLeft.minutes}</div>
-                <div className="summit-countdown-label">Minutes</div>
-              </div>
-              <div className="summit-countdown-unit">
-                <div className="summit-countdown-value">{timeLeft.seconds}</div>
-                <div className="summit-countdown-label">Seconds</div>
-              </div>
-            </div>
           </div>
 
           {/* Stats */}

--- a/apps/devrel/components/summit/SummitNavigation.tsx
+++ b/apps/devrel/components/summit/SummitNavigation.tsx
@@ -3,11 +3,11 @@
 import React, { useState, useEffect } from 'react';
 
 const navLinks = [
-  { href: '#criteria', label: 'Criteria' },
-  { href: '#faq', label: 'FAQ' },
-  { href: '#timeline', label: 'Timeline' },
-  { href: '#success-stories', label: 'Success Stories' },
-  { href: '#checklist', label: 'Checklist' },
+  { href: '#problem', label: 'Problem' },
+  { href: '#solution', label: 'Solution' },
+  { href: '#advantages', label: 'Why Caro' },
+  { href: '#traction', label: 'Traction' },
+  { href: '#vision', label: 'Vision' },
 ];
 
 export const SummitNavigation: React.FC = () => {
@@ -30,11 +30,14 @@ export const SummitNavigation: React.FC = () => {
           {/* Logo */}
           <a href="#" className="flex items-center gap-3">
             <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center">
-              <span className="text-white font-bold text-sm">AI</span>
+              <span className="text-white font-bold text-sm">C</span>
             </div>
-            <span className="text-summit-text-primary font-semibold hidden sm:block">
-              Seattle AI Summit 2026
-            </span>
+            <div>
+              <span className="text-summit-text-primary font-semibold">Caro</span>
+              <span className="hidden sm:inline text-summit-text-muted text-sm ml-2">
+                AI Summit 2026
+              </span>
+            </div>
           </a>
 
           {/* Desktop Navigation */}
@@ -43,52 +46,35 @@ export const SummitNavigation: React.FC = () => {
               <a
                 key={link.href}
                 href={link.href}
-                className="text-summit-text-secondary hover:text-summit-accent-teal transition-colors text-sm font-medium"
+                className="text-sm text-summit-text-secondary hover:text-summit-accent-teal transition-colors"
               >
                 {link.label}
               </a>
             ))}
-          </div>
-
-          {/* CTA Button */}
-          <div className="flex items-center gap-4">
             <a
-              href="#apply"
-              className="summit-btn-primary text-sm py-2 px-4 hidden sm:inline-block"
+              href="#get-started"
+              className="summit-btn-primary text-sm py-2 px-4"
             >
-              Apply Now
+              Get Started
             </a>
-
-            {/* Mobile Menu Button */}
-            <button
-              className="md:hidden p-2 text-summit-text-secondary hover:text-summit-text-primary"
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              aria-label="Toggle menu"
-            >
-              <svg
-                className="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                {isMobileMenuOpen ? (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                ) : (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                )}
-              </svg>
-            </button>
           </div>
+
+          {/* Mobile Menu Button */}
+          <button
+            className="md:hidden p-2 text-summit-text-secondary hover:text-summit-text-primary"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            aria-label="Toggle menu"
+          >
+            {isMobileMenuOpen ? (
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
+          </button>
         </div>
 
         {/* Mobile Menu */}
@@ -99,18 +85,18 @@ export const SummitNavigation: React.FC = () => {
                 <a
                   key={link.href}
                   href={link.href}
-                  className="text-summit-text-secondary hover:text-summit-accent-teal transition-colors text-sm font-medium py-2"
+                  className="text-summit-text-secondary hover:text-summit-accent-teal transition-colors py-2"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   {link.label}
                 </a>
               ))}
               <a
-                href="#apply"
-                className="summit-btn-primary text-sm py-3 px-4 text-center mt-2"
+                href="#get-started"
+                className="summit-btn-primary text-center py-3 mt-2"
                 onClick={() => setIsMobileMenuOpen(false)}
               >
-                Apply Now
+                Get Started
               </a>
             </div>
           </div>

--- a/apps/devrel/components/summit/SummitNavigation.tsx
+++ b/apps/devrel/components/summit/SummitNavigation.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+const navLinks = [
+  { href: '#criteria', label: 'Criteria' },
+  { href: '#faq', label: 'FAQ' },
+  { href: '#timeline', label: 'Timeline' },
+  { href: '#success-stories', label: 'Success Stories' },
+  { href: '#checklist', label: 'Checklist' },
+];
+
+export const SummitNavigation: React.FC = () => {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 50);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <nav className={`summit-nav ${isScrolled ? 'summit-nav-scrolled' : ''}`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo */}
+          <a href="#" className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-summit-accent-teal to-summit-accent-blue flex items-center justify-center">
+              <span className="text-white font-bold text-sm">AI</span>
+            </div>
+            <span className="text-summit-text-primary font-semibold hidden sm:block">
+              Seattle AI Summit 2026
+            </span>
+          </a>
+
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex items-center gap-8">
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="text-summit-text-secondary hover:text-summit-accent-teal transition-colors text-sm font-medium"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+
+          {/* CTA Button */}
+          <div className="flex items-center gap-4">
+            <a
+              href="#apply"
+              className="summit-btn-primary text-sm py-2 px-4 hidden sm:inline-block"
+            >
+              Apply Now
+            </a>
+
+            {/* Mobile Menu Button */}
+            <button
+              className="md:hidden p-2 text-summit-text-secondary hover:text-summit-text-primary"
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+              aria-label="Toggle menu"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                {isMobileMenuOpen ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                )}
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile Menu */}
+        {isMobileMenuOpen && (
+          <div className="md:hidden py-4 border-t border-summit-tertiary/30">
+            <div className="flex flex-col gap-4">
+              {navLinks.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className="text-summit-text-secondary hover:text-summit-accent-teal transition-colors text-sm font-medium py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {link.label}
+                </a>
+              ))}
+              <a
+                href="#apply"
+                className="summit-btn-primary text-sm py-3 px-4 text-center mt-2"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Apply Now
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+};

--- a/apps/devrel/components/summit/TimelineProcess.tsx
+++ b/apps/devrel/components/summit/TimelineProcess.tsx
@@ -2,191 +2,173 @@
 
 import React from 'react';
 
-const timelineItems = [
+const advantages = [
   {
-    date: 'Now - March 31',
-    title: 'Applications Open',
-    description: 'Submit your application through our online form. Early applications are encouraged as we review on a rolling basis.',
-    status: 'active',
+    title: 'vs Cloud AI Tools',
+    competitor: 'ChatGPT, Claude, GitHub Copilot',
+    caroAdvantage: [
+      '100% local - no data leaves your machine',
+      'Works in air-gapped networks',
+      'No API costs or rate limits',
+      'No internet dependency',
+    ],
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
       </svg>
     ),
   },
   {
-    date: 'April 1 - April 30',
-    title: 'Application Review',
-    description: 'Our selection committee reviews all applications. We may reach out for additional information or clarification.',
-    status: 'upcoming',
+    title: 'vs Shell Wrappers',
+    competitor: 'thefuck, tldr, explainshell',
+    caroAdvantage: [
+      'AI-powered natural language understanding',
+      'Generates commands, not just corrections',
+      'Platform-aware generation',
+      'Comprehensive safety validation',
+    ],
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
       </svg>
     ),
   },
   {
-    date: 'May 1',
-    title: 'Selection Notifications',
-    description: 'Selected startups receive confirmation emails with demo slot assignments, guidelines, and preparation materials.',
-    status: 'upcoming',
+    title: 'vs Other AI CLIs',
+    competitor: 'aichat, shell-gpt, ask-cli',
+    caroAdvantage: [
+      '52+ safety patterns (most have zero)',
+      'Embedded model - no setup required',
+      'Single binary distribution',
+      'Multi-backend architecture',
+    ],
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-      </svg>
-    ),
-  },
-  {
-    date: 'May 1 - June 14',
-    title: 'Demo Preparation',
-    description: 'Work with our team to polish your presentation. Includes optional coaching sessions and tech checks.',
-    status: 'upcoming',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-      </svg>
-    ),
-  },
-  {
-    date: 'June 15-16, 2026',
-    title: 'Summit Demo Day',
-    description: 'Present your AI startup to 500+ attendees including Fortune 500 executives, investors, and media.',
-    status: 'upcoming',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
       </svg>
     ),
   },
 ];
 
-const demoFormat = [
-  { label: 'Demo Duration', value: '10 minutes' },
-  { label: 'Q&A Session', value: '5 minutes' },
-  { label: 'Audience Size', value: '500+ attendees' },
-  { label: 'Live Stream', value: 'Yes (optional)' },
+const techStack = [
+  { name: 'Rust', description: 'Systems language for performance & safety', color: 'orange' },
+  { name: 'MLX', description: 'Apple Silicon optimization', color: 'blue' },
+  { name: 'GGUF', description: 'Quantized model format', color: 'purple' },
+  { name: 'AGPL-3.0', description: 'Open source license', color: 'teal' },
+];
+
+const safetyLevels = [
+  { level: 'Safe', color: 'green', description: 'Normal operations, no confirmation needed', example: 'ls, pwd, echo' },
+  { level: 'Moderate', color: 'yellow', description: 'Requires confirmation in strict mode', example: 'cp, mv, chmod' },
+  { level: 'High', color: 'orange', description: 'Requires confirmation in moderate mode', example: 'rm, kill, sudo' },
+  { level: 'Critical', color: 'red', description: 'Blocked in strict mode', example: 'rm -rf /, :(){ :|:& };:' },
 ];
 
 export const TimelineProcess: React.FC = () => {
   return (
-    <section id="timeline" className="summit-section py-20 md:py-32">
+    <section id="advantages" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center max-w-3xl mx-auto mb-16">
           <span className="summit-badge summit-badge-purple mb-4 inline-block">
-            Selection Process
+            Competitive Edge
           </span>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            Timeline & Process
+            Why Caro Wins
           </h2>
           <p className="text-lg text-summit-text-secondary">
-            From application to demo day, here&apos;s what to expect throughout the selection process.
+            The only AI CLI tool that combines local inference, comprehensive safety,
+            and multi-platform support in a single binary.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 lg:gap-16">
-          {/* Timeline */}
-          <div className="lg:col-span-2">
-            <div className="summit-timeline">
-              {timelineItems.map((item, index) => (
-                <div
-                  key={index}
-                  className="summit-timeline-item"
-                  style={{
-                    opacity: item.status === 'active' ? 1 : 0.7,
-                  }}
-                >
-                  <div className="flex items-start gap-4">
-                    <div
-                      className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${
-                        item.status === 'active'
-                          ? 'bg-summit-accent-teal text-white'
-                          : 'bg-summit-tertiary text-summit-text-muted'
-                      }`}
-                    >
-                      {item.icon}
-                    </div>
-                    <div className="flex-1">
-                      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2">
-                        <h3 className="text-lg font-semibold text-summit-text-primary">
-                          {item.title}
-                        </h3>
-                        {item.status === 'active' && (
-                          <span className="summit-badge summit-badge-teal text-xs">
-                            Current Phase
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-sm text-summit-accent-teal font-medium mb-2">
-                        {item.date}
-                      </p>
-                      <p className="text-summit-text-secondary leading-relaxed">
-                        {item.description}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              ))}
+        {/* Competitive Comparison */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-20">
+          {advantages.map((adv, index) => (
+            <div key={index} className="summit-card">
+              <div className="w-12 h-12 rounded-xl bg-summit-accent-purple/10 flex items-center justify-center text-summit-accent-purple mb-4">
+                {adv.icon}
+              </div>
+              <h3 className="text-lg font-semibold text-summit-text-primary mb-2">
+                {adv.title}
+              </h3>
+              <p className="text-sm text-summit-text-muted mb-4">
+                Compared to: {adv.competitor}
+              </p>
+              <ul className="space-y-2">
+                {adv.caroAdvantage.map((point, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-summit-text-secondary">
+                    <svg className="w-4 h-4 text-summit-success flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    {point}
+                  </li>
+                ))}
+              </ul>
             </div>
+          ))}
+        </div>
+
+        {/* Safety Levels Visualization */}
+        <div className="mb-20">
+          <div className="text-center mb-12">
+            <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+              Multi-Level Safety System
+            </h3>
+            <p className="text-summit-text-secondary max-w-2xl mx-auto">
+              Every command is classified and handled according to its risk level.
+            </p>
           </div>
 
-          {/* Demo Format Sidebar */}
-          <div className="lg:col-span-1">
-            <div className="summit-card sticky top-24">
-              <h3 className="text-xl font-semibold text-summit-text-primary mb-6">
-                Demo Day Format
-              </h3>
-
-              <div className="space-y-4 mb-8">
-                {demoFormat.map((item) => (
-                  <div
-                    key={item.label}
-                    className="flex items-center justify-between py-3 border-b border-summit-tertiary/30 last:border-0"
-                  >
-                    <span className="text-summit-text-secondary">{item.label}</span>
-                    <span className="text-summit-text-primary font-medium">{item.value}</span>
-                  </div>
-                ))}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {safetyLevels.map((level) => (
+              <div
+                key={level.level}
+                className={`p-6 rounded-xl border-2 ${
+                  level.color === 'green' ? 'border-green-500/30 bg-green-500/5' :
+                  level.color === 'yellow' ? 'border-yellow-500/30 bg-yellow-500/5' :
+                  level.color === 'orange' ? 'border-orange-500/30 bg-orange-500/5' :
+                  'border-red-500/30 bg-red-500/5'
+                }`}
+              >
+                <div className={`text-lg font-bold mb-2 ${
+                  level.color === 'green' ? 'text-green-400' :
+                  level.color === 'yellow' ? 'text-yellow-400' :
+                  level.color === 'orange' ? 'text-orange-400' :
+                  'text-red-400'
+                }`}>
+                  {level.level}
+                </div>
+                <p className="text-sm text-summit-text-secondary mb-3">
+                  {level.description}
+                </p>
+                <div className="font-mono text-xs text-summit-text-muted">
+                  {level.example}
+                </div>
               </div>
+            ))}
+          </div>
+        </div>
 
-              <div className="bg-summit-primary/50 rounded-lg p-4">
-                <h4 className="text-summit-text-primary font-medium mb-2">
-                  What&apos;s Included
-                </h4>
-                <ul className="text-sm text-summit-text-secondary space-y-2">
-                  <li className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    Professional AV setup
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    2 presenter badges
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    Investor meetup access
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    Media kit inclusion
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    Recording of your demo
-                  </li>
-                </ul>
+        {/* Tech Stack */}
+        <div>
+          <div className="text-center mb-12">
+            <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+              Built With
+            </h3>
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-4">
+            {techStack.map((tech) => (
+              <div
+                key={tech.name}
+                className={`summit-badge summit-badge-${tech.color} text-base px-6 py-3`}
+              >
+                <span className="font-semibold">{tech.name}</span>
+                <span className="mx-2">•</span>
+                <span className="opacity-80">{tech.description}</span>
               </div>
-            </div>
+            ))}
           </div>
         </div>
       </div>

--- a/apps/devrel/components/summit/TimelineProcess.tsx
+++ b/apps/devrel/components/summit/TimelineProcess.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import React from 'react';
+
+const timelineItems = [
+  {
+    date: 'Now - March 31',
+    title: 'Applications Open',
+    description: 'Submit your application through our online form. Early applications are encouraged as we review on a rolling basis.',
+    status: 'active',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+      </svg>
+    ),
+  },
+  {
+    date: 'April 1 - April 30',
+    title: 'Application Review',
+    description: 'Our selection committee reviews all applications. We may reach out for additional information or clarification.',
+    status: 'upcoming',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+      </svg>
+    ),
+  },
+  {
+    date: 'May 1',
+    title: 'Selection Notifications',
+    description: 'Selected startups receive confirmation emails with demo slot assignments, guidelines, and preparation materials.',
+    status: 'upcoming',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    date: 'May 1 - June 14',
+    title: 'Demo Preparation',
+    description: 'Work with our team to polish your presentation. Includes optional coaching sessions and tech checks.',
+    status: 'upcoming',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    date: 'June 15-16, 2026',
+    title: 'Summit Demo Day',
+    description: 'Present your AI startup to 500+ attendees including Fortune 500 executives, investors, and media.',
+    status: 'upcoming',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      </svg>
+    ),
+  },
+];
+
+const demoFormat = [
+  { label: 'Demo Duration', value: '10 minutes' },
+  { label: 'Q&A Session', value: '5 minutes' },
+  { label: 'Audience Size', value: '500+ attendees' },
+  { label: 'Live Stream', value: 'Yes (optional)' },
+];
+
+export const TimelineProcess: React.FC = () => {
+  return (
+    <section id="timeline" className="summit-section py-20 md:py-32">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Section Header */}
+        <div className="text-center max-w-3xl mx-auto mb-16">
+          <span className="summit-badge summit-badge-purple mb-4 inline-block">
+            Selection Process
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            Timeline & Process
+          </h2>
+          <p className="text-lg text-summit-text-secondary">
+            From application to demo day, here&apos;s what to expect throughout the selection process.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 lg:gap-16">
+          {/* Timeline */}
+          <div className="lg:col-span-2">
+            <div className="summit-timeline">
+              {timelineItems.map((item, index) => (
+                <div
+                  key={index}
+                  className="summit-timeline-item"
+                  style={{
+                    opacity: item.status === 'active' ? 1 : 0.7,
+                  }}
+                >
+                  <div className="flex items-start gap-4">
+                    <div
+                      className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${
+                        item.status === 'active'
+                          ? 'bg-summit-accent-teal text-white'
+                          : 'bg-summit-tertiary text-summit-text-muted'
+                      }`}
+                    >
+                      {item.icon}
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2">
+                        <h3 className="text-lg font-semibold text-summit-text-primary">
+                          {item.title}
+                        </h3>
+                        {item.status === 'active' && (
+                          <span className="summit-badge summit-badge-teal text-xs">
+                            Current Phase
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-summit-accent-teal font-medium mb-2">
+                        {item.date}
+                      </p>
+                      <p className="text-summit-text-secondary leading-relaxed">
+                        {item.description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Demo Format Sidebar */}
+          <div className="lg:col-span-1">
+            <div className="summit-card sticky top-24">
+              <h3 className="text-xl font-semibold text-summit-text-primary mb-6">
+                Demo Day Format
+              </h3>
+
+              <div className="space-y-4 mb-8">
+                {demoFormat.map((item) => (
+                  <div
+                    key={item.label}
+                    className="flex items-center justify-between py-3 border-b border-summit-tertiary/30 last:border-0"
+                  >
+                    <span className="text-summit-text-secondary">{item.label}</span>
+                    <span className="text-summit-text-primary font-medium">{item.value}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="bg-summit-primary/50 rounded-lg p-4">
+                <h4 className="text-summit-text-primary font-medium mb-2">
+                  What&apos;s Included
+                </h4>
+                <ul className="text-sm text-summit-text-secondary space-y-2">
+                  <li className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    Professional AV setup
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    2 presenter badges
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    Investor meetup access
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    Media kit inclusion
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <svg className="w-4 h-4 text-summit-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    Recording of your demo
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/WhatWereLookingFor.tsx
+++ b/apps/devrel/components/summit/WhatWereLookingFor.tsx
@@ -2,171 +2,141 @@
 
 import React from 'react';
 
-const criteriaCategories = [
+const painPoints = [
   {
-    title: 'Company Fundamentals',
     icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
       </svg>
     ),
-    badge: 'Foundation',
-    badgeColor: 'summit-badge-teal',
-    items: [
-      {
-        label: 'Year Founded',
-        description: 'Typically 2020 or later. We prioritize early-stage startups with recent momentum.',
-      },
-      {
-        label: 'Team Size',
-        description: '3-50 employees. We look for lean teams with strong technical capabilities.',
-      },
-      {
-        label: 'ARR Expectations',
-        description: '$100K-$5M ARR preferred. Pre-revenue companies with strong traction also considered.',
-      },
-      {
-        label: 'Funding Stage',
-        description: 'Seed to Series A. We welcome bootstrapped companies with demonstrated growth.',
-      },
-    ],
+    title: 'Dangerous Commands at 3 AM',
+    description: 'One wrong rm -rf command during an incident can cascade into catastrophe. Fatigue-induced errors during on-call shifts have no safety net.',
+    persona: 'SRE / DevOps',
+    color: 'teal',
   },
   {
-    title: 'Strategic Clarity',
     icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    badge: 'Strategy',
-    badgeColor: 'summit-badge-blue',
-    items: [
-      {
-        label: 'Problem Statement',
-        description: 'Clear articulation of the specific pain point you solve. No vague "AI for everything" pitches.',
-      },
-      {
-        label: 'Target Customer Profile',
-        description: 'Well-defined ICP with specific industries, company sizes, and buyer personas.',
-      },
-      {
-        label: 'Competitive Differentiation',
-        description: 'What makes your approach unique? Technology, data, team, or go-to-market strategy.',
-      },
-      {
-        label: 'Business Model',
-        description: 'Clear monetization strategy with pricing rationale and unit economics understanding.',
-      },
-    ],
+    title: 'Cloud AI Data Leakage',
+    description: 'Every command sent to cloud AI tools exposes your infrastructure, credentials, and operational patterns to third parties.',
+    persona: 'Security / CISO',
+    color: 'purple',
   },
   {
-    title: 'Proof Points',
     icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
       </svg>
     ),
-    badge: 'Traction',
-    badgeColor: 'summit-badge-purple',
-    items: [
-      {
-        label: 'Revenue Milestones',
-        description: 'MRR growth rate, customer expansion, or significant POC conversions.',
-      },
-      {
-        label: 'Customer Validation',
-        description: 'Logos, testimonials, case studies, or NPS scores from existing customers.',
-      },
-      {
-        label: 'Partnerships',
-        description: 'Strategic integrations, channel partnerships, or enterprise pilot programs.',
-      },
-      {
-        label: 'Investor Credibility',
-        description: 'Notable angel investors, VCs, or advisors who have backed your vision.',
-      },
-    ],
+    title: 'Platform Command Chaos',
+    description: 'Commands that work on Linux fail on macOS. BSD vs GNU differences. Every environment switch means re-learning syntax.',
+    persona: 'Full-Stack / Platform',
+    color: 'blue',
+  },
+];
+
+const targetCustomers = [
+  {
+    title: 'The 3AM Firefighter',
+    role: 'SRE / DevOps / On-Call',
+    quote: 'Your 2 AM safety net',
+    needs: ['Incident response', 'Production emergencies', 'Zero-margin-for-error ops'],
+  },
+  {
+    title: 'The Privacy Purist',
+    role: 'Security / Compliance / CISO',
+    quote: 'What happens on your machine, stays on your machine',
+    needs: ['Air-gapped networks', 'Compliance audits', 'Data sovereignty'],
+  },
+  {
+    title: 'The New Hire Navigator',
+    role: 'Junior Dev / Bootcamp Graduate',
+    quote: 'Learn the command line without the landmines',
+    needs: ['Knowledge gaps', 'Fear of breaking things', 'Learning safely'],
+  },
+  {
+    title: 'The Cross-Platform Warrior',
+    role: 'Full-Stack / Platform Engineer',
+    quote: 'One command language. Every platform.',
+    needs: ['Multi-environment workflows', 'BSD vs GNU', 'Shell incompatibilities'],
   },
 ];
 
 export const WhatWereLookingFor: React.FC = () => {
   return (
-    <section id="criteria" className="summit-section py-20 md:py-32">
+    <section id="problem" className="summit-section py-20 md:py-32 bg-summit-secondary/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center max-w-3xl mx-auto mb-16">
           <span className="summit-badge summit-badge-teal mb-4 inline-block">
-            Evaluation Criteria
+            The Problem
           </span>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
-            What We&apos;re Looking For
+            The Terminal is Powerful—<br />
+            <span className="summit-gradient-text">And Dangerous</span>
           </h2>
           <p className="text-lg text-summit-text-secondary">
-            We evaluate applications across three core dimensions. Understanding our criteria
-            helps you prepare a stronger application and increases your chances of selection.
+            Every developer, DevOps engineer, and SRE has felt the terror of a command gone wrong.
+            Cloud AI tools promise help, but at what cost to privacy and safety?
           </p>
         </div>
 
-        {/* Criteria Cards */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {criteriaCategories.map((category, index) => (
-            <div
-              key={category.title}
-              className="summit-card group"
-              style={{ animationDelay: `${index * 100}ms` }}
-            >
-              {/* Card Header */}
-              <div className="flex items-center gap-4 mb-6">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-summit-accent-teal/20 to-summit-accent-blue/20 flex items-center justify-center text-summit-accent-teal group-hover:scale-110 transition-transform">
-                  {category.icon}
-                </div>
-                <div>
-                  <span className={`summit-badge ${category.badgeColor} text-xs mb-1`}>
-                    {category.badge}
-                  </span>
-                  <h3 className="text-xl font-semibold text-summit-text-primary">
-                    {category.title}
-                  </h3>
-                </div>
+        {/* Pain Points Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-20">
+          {painPoints.map((point, index) => (
+            <div key={index} className="summit-card group">
+              <div className={`w-16 h-16 rounded-xl bg-summit-accent-${point.color}/10 flex items-center justify-center text-summit-accent-${point.color} mb-6 group-hover:scale-110 transition-transform`}>
+                {point.icon}
               </div>
-
-              {/* Criteria Items */}
-              <div className="space-y-4">
-                {category.items.map((item) => (
-                  <div
-                    key={item.label}
-                    className="border-l-2 border-summit-tertiary pl-4 py-1 hover:border-summit-accent-teal transition-colors"
-                  >
-                    <h4 className="text-summit-text-primary font-medium mb-1">
-                      {item.label}
-                    </h4>
-                    <p className="text-sm text-summit-text-muted leading-relaxed">
-                      {item.description}
-                    </p>
-                  </div>
-                ))}
+              <div className="summit-badge summit-badge-purple text-xs mb-4">
+                {point.persona}
               </div>
+              <h3 className="text-xl font-semibold text-summit-text-primary mb-3">
+                {point.title}
+              </h3>
+              <p className="text-summit-text-secondary leading-relaxed">
+                {point.description}
+              </p>
             </div>
           ))}
         </div>
 
-        {/* Pro Tip */}
-        <div className="mt-12 p-6 rounded-xl bg-gradient-to-r from-summit-accent-teal/10 to-summit-accent-blue/10 border border-summit-accent-teal/20">
-          <div className="flex items-start gap-4">
-            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-summit-accent-teal/20 flex items-center justify-center">
-              <svg className="w-5 h-5 text-summit-accent-teal" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <div>
-              <h4 className="text-summit-text-primary font-semibold mb-1">Pro Tip</h4>
-              <p className="text-summit-text-secondary text-sm leading-relaxed">
-                Don&apos;t have all these criteria covered? That&apos;s okay! We evaluate holistically
-                and understand that early-stage startups are works in progress. Focus on your
-                strongest proof points and be honest about areas you&apos;re still developing.
+        {/* Target Customers */}
+        <div className="text-center mb-12">
+          <h3 className="text-2xl md:text-3xl font-bold text-summit-text-primary mb-4">
+            Built For Those Who Can&apos;t Afford Mistakes
+          </h3>
+          <p className="text-summit-text-secondary max-w-2xl mx-auto">
+            Caro is designed for professionals where a single wrong command can mean
+            downtime, data loss, or security breaches.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {targetCustomers.map((customer, index) => (
+            <div key={index} className="bg-summit-tertiary/30 rounded-xl p-6 border border-summit-tertiary/50 hover:border-summit-accent-teal/30 transition-colors">
+              <h4 className="text-lg font-semibold text-summit-text-primary mb-1">
+                {customer.title}
+              </h4>
+              <p className="text-sm text-summit-accent-teal mb-3">{customer.role}</p>
+              <p className="text-sm text-summit-text-secondary italic mb-4">
+                &ldquo;{customer.quote}&rdquo;
               </p>
+              <ul className="space-y-2">
+                {customer.needs.map((need, i) => (
+                  <li key={i} className="flex items-center gap-2 text-xs text-summit-text-muted">
+                    <svg className="w-3 h-3 text-summit-accent-teal flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    {need}
+                  </li>
+                ))}
+              </ul>
             </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/apps/devrel/components/summit/WhatWereLookingFor.tsx
+++ b/apps/devrel/components/summit/WhatWereLookingFor.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React from 'react';
+
+const criteriaCategories = [
+  {
+    title: 'Company Fundamentals',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+      </svg>
+    ),
+    badge: 'Foundation',
+    badgeColor: 'summit-badge-teal',
+    items: [
+      {
+        label: 'Year Founded',
+        description: 'Typically 2020 or later. We prioritize early-stage startups with recent momentum.',
+      },
+      {
+        label: 'Team Size',
+        description: '3-50 employees. We look for lean teams with strong technical capabilities.',
+      },
+      {
+        label: 'ARR Expectations',
+        description: '$100K-$5M ARR preferred. Pre-revenue companies with strong traction also considered.',
+      },
+      {
+        label: 'Funding Stage',
+        description: 'Seed to Series A. We welcome bootstrapped companies with demonstrated growth.',
+      },
+    ],
+  },
+  {
+    title: 'Strategic Clarity',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+    badge: 'Strategy',
+    badgeColor: 'summit-badge-blue',
+    items: [
+      {
+        label: 'Problem Statement',
+        description: 'Clear articulation of the specific pain point you solve. No vague "AI for everything" pitches.',
+      },
+      {
+        label: 'Target Customer Profile',
+        description: 'Well-defined ICP with specific industries, company sizes, and buyer personas.',
+      },
+      {
+        label: 'Competitive Differentiation',
+        description: 'What makes your approach unique? Technology, data, team, or go-to-market strategy.',
+      },
+      {
+        label: 'Business Model',
+        description: 'Clear monetization strategy with pricing rationale and unit economics understanding.',
+      },
+    ],
+  },
+  {
+    title: 'Proof Points',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+    ),
+    badge: 'Traction',
+    badgeColor: 'summit-badge-purple',
+    items: [
+      {
+        label: 'Revenue Milestones',
+        description: 'MRR growth rate, customer expansion, or significant POC conversions.',
+      },
+      {
+        label: 'Customer Validation',
+        description: 'Logos, testimonials, case studies, or NPS scores from existing customers.',
+      },
+      {
+        label: 'Partnerships',
+        description: 'Strategic integrations, channel partnerships, or enterprise pilot programs.',
+      },
+      {
+        label: 'Investor Credibility',
+        description: 'Notable angel investors, VCs, or advisors who have backed your vision.',
+      },
+    ],
+  },
+];
+
+export const WhatWereLookingFor: React.FC = () => {
+  return (
+    <section id="criteria" className="summit-section py-20 md:py-32">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Section Header */}
+        <div className="text-center max-w-3xl mx-auto mb-16">
+          <span className="summit-badge summit-badge-teal mb-4 inline-block">
+            Evaluation Criteria
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-summit-text-primary mb-6">
+            What We&apos;re Looking For
+          </h2>
+          <p className="text-lg text-summit-text-secondary">
+            We evaluate applications across three core dimensions. Understanding our criteria
+            helps you prepare a stronger application and increases your chances of selection.
+          </p>
+        </div>
+
+        {/* Criteria Cards */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {criteriaCategories.map((category, index) => (
+            <div
+              key={category.title}
+              className="summit-card group"
+              style={{ animationDelay: `${index * 100}ms` }}
+            >
+              {/* Card Header */}
+              <div className="flex items-center gap-4 mb-6">
+                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-summit-accent-teal/20 to-summit-accent-blue/20 flex items-center justify-center text-summit-accent-teal group-hover:scale-110 transition-transform">
+                  {category.icon}
+                </div>
+                <div>
+                  <span className={`summit-badge ${category.badgeColor} text-xs mb-1`}>
+                    {category.badge}
+                  </span>
+                  <h3 className="text-xl font-semibold text-summit-text-primary">
+                    {category.title}
+                  </h3>
+                </div>
+              </div>
+
+              {/* Criteria Items */}
+              <div className="space-y-4">
+                {category.items.map((item) => (
+                  <div
+                    key={item.label}
+                    className="border-l-2 border-summit-tertiary pl-4 py-1 hover:border-summit-accent-teal transition-colors"
+                  >
+                    <h4 className="text-summit-text-primary font-medium mb-1">
+                      {item.label}
+                    </h4>
+                    <p className="text-sm text-summit-text-muted leading-relaxed">
+                      {item.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Pro Tip */}
+        <div className="mt-12 p-6 rounded-xl bg-gradient-to-r from-summit-accent-teal/10 to-summit-accent-blue/10 border border-summit-accent-teal/20">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-summit-accent-teal/20 flex items-center justify-center">
+              <svg className="w-5 h-5 text-summit-accent-teal" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <div>
+              <h4 className="text-summit-text-primary font-semibold mb-1">Pro Tip</h4>
+              <p className="text-summit-text-secondary text-sm leading-relaxed">
+                Don&apos;t have all these criteria covered? That&apos;s okay! We evaluate holistically
+                and understand that early-stage startups are works in progress. Focus on your
+                strongest proof points and be honest about areas you&apos;re still developing.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/devrel/components/summit/index.ts
+++ b/apps/devrel/components/summit/index.ts
@@ -1,0 +1,10 @@
+// Summit Landing Page Components
+export { SummitNavigation } from './SummitNavigation';
+export { SummitHero } from './SummitHero';
+export { WhatWereLookingFor } from './WhatWereLookingFor';
+export { ApplicationFAQ } from './ApplicationFAQ';
+export { TimelineProcess } from './TimelineProcess';
+export { SuccessStories } from './SuccessStories';
+export { PreparationChecklist } from './PreparationChecklist';
+export { ApplicationCTA } from './ApplicationCTA';
+export { SummitFooter } from './SummitFooter';

--- a/apps/devrel/lib/privacy/redactor.ts
+++ b/apps/devrel/lib/privacy/redactor.ts
@@ -255,8 +255,7 @@ export function registerCustomPattern(
   name: string,
   pattern: RedactionPattern
 ): void {
-  // @ts-expect-error - Allow runtime extension of patterns
-  REDACTION_PATTERNS[name] = pattern;
+  (REDACTION_PATTERNS as Record<string, RedactionPattern>)[name] = pattern;
 }
 
 /**

--- a/apps/devrel/types/privacy.ts
+++ b/apps/devrel/types/privacy.ts
@@ -4,6 +4,9 @@
 
 import type { Redaction, SafetyLevel } from './artifacts';
 
+// Re-export for consumers
+export type { Redaction } from './artifacts';
+
 /**
  * Detected sensitive item before redaction
  */


### PR DESCRIPTION
A comprehensive, high-converting landing page for the Seattle AI Startup
Summit 2026 demo day applications, featuring:

**Page Sections:**
- Hero with countdown timer and key event statistics
- "What We're Looking For" - evaluation criteria with company fundamentals,
  strategic clarity, and proof points
- Application FAQ with interactive accordion
- Timeline & Process showing application through demo day
- Success Stories with testimonials and outcome metrics
- Interactive Preparation Checklist with progress tracking
- Final CTA section with application link

**Technical Implementation:**
- Next.js App Router with /summit route
- Professional color palette (blues/teals) with CSS variables
- Mobile-first responsive design using Tailwind CSS 4
- SEO-optimized with proper metadata and JSON-LD schema
- Accessible with WCAG 2.1 compliance
- All client components for interactivity (countdown, accordion, checklist)

**Bug Fixes:**
- Fix Redaction type export in privacy.ts
- Fix unused ts-expect-error in redactor.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Seattle AI Startup Summit 2026 landing page at /summit, now a Caro product showcase with install CTAs and product sections. Also fixes minor type issues in the privacy library.

- **New Features**
  - Caro-focused /summit page with Hero (terminal demo), Problem, Solution, Advantages, Traction, Vision, and Get Started sections.
  - SEO and sharing: Open Graph/Twitter metadata and SoftwareApplication JSON-LD; accessible and mobile-first.
  - Global summit styles with a dedicated palette and reusable components.

- **Bug Fixes**
  - Export Redaction type from types/privacy.ts.
  - Replace ts-expect-error in redactor.ts with a typed pattern registration.

<sup>Written for commit c53dd974d7a7e19b358250928be07f989cb6d445. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

