### PR TITLE
perf: Add CapabilityProfile caching for faster CLI startup (#443)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -187,8 +187,8 @@ impl CliApp {
         // Detect execution context
         let context = ExecutionContext::detect();
 
-        // Detect platform capabilities for command generation
-        let profile = CapabilityProfile::detect().await;
+        // Detect platform capabilities for command generation (uses cache for fast startup)
+        let profile = CapabilityProfile::detect_or_cached().await;
 
         // Create agent loop with backend, context, and profile
         // If force_llm is true, disable the static matcher

--- a/src/main.rs
+++ b/src/main.rs
@@ -780,7 +780,7 @@ async fn run_evaluation_tests(
     // Create backend (boxed to allow different types)
     let backend: Box<dyn CommandGenerator> = match backend_name {
         "static" => {
-            let profile = CapabilityProfile::detect().await;
+            let profile = CapabilityProfile::detect_or_cached().await;
             Box::new(StaticMatcher::new(profile))
         }
         "embedded" => Box::new(

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -161,7 +161,7 @@ pub fn validate_ubuntu_command(command: &str) -> ValidationResult {
 /// }
 /// ```
 pub async fn detect_capabilities() -> CapabilityProfile {
-    CapabilityProfile::detect().await
+    CapabilityProfile::detect_or_cached().await
 }
 
 /// Generate a shell script that outputs a capability profile


### PR DESCRIPTION
## Summary

- Add caching for CapabilityProfile detection to dramatically reduce CLI startup time
- Cache stored at `~/.cache/caro/capabilities.json`
- Cache invalidated when caro version changes
- Background async cache write to not block startup on first run

## Performance Results

| Scenario | Time |
|----------|------|
| Uncached (full detection) | ~650ms |
| Cached (file read + JSON) | <1ms |
| **Savings** | **~650ms** |

## Implementation Details

- Added `detect_or_cached()` method as primary entry point
- Added `detect_and_cache()` for explicit cache refresh
- Added `clear_cache()` for testing
- Added `CachedProfile` wrapper with version validation
- Added comprehensive tests including performance benchmark

## Test plan

- [x] All 232 unit tests pass
- [x] Clippy clean
- [x] Performance benchmark shows >50ms savings
- [x] Cache roundtrip test passes
- [x] Cache invalidation on version change works

## Files Changed

- `src/prompts/capability_profile.rs`: Add caching logic and tests
- `src/cli/mod.rs`: Use `detect_or_cached()`
- `src/main.rs`: Use `detect_or_cached()`
- `src/prompts/mod.rs`: Use `detect_or_cached()`

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches CapabilityProfile and loads it on startup to avoid repeated environment probes, cutting CLI startup by ~650ms after the first run. Cache is stored at ~/.cache/caro/capabilities.json and auto-invalidates on caro version changes.

- **New Features**
  - Added detect_or_cached() as the default path; detect_and_cache() and clear_cache() helpers.
  - Cache stored at ~/.cache/caro/capabilities.json; invalidates on version change.
  - Writes cache in the background; reads synchronously for fast startup.
  - Updated CLI, main, and prompts to use detect_or_cached().

<sup>Written for commit 22c1b7581d3b2d511bae58a5bf4214ece70b2c91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

