### PR TITLE
i18n: Update fr (French) translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "caro",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "openai": "^6.16.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.16.0.tgz",
+      "integrity": "sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "openai": "^6.16.0"
+  }
+}

--- a/website/src/i18n/locales/fr/common.json
+++ b/website/src/i18n/locales/fr/common.json
@@ -1,5 +1,9 @@
 {
   "common": {
+    "meta": {
+      "title": "Caro - Votre fidèle compagnon de shell",
+      "description": "Caro est un agent compagnon qui vous aide avec les commandes shell POSIX. Disponible en tant que MCP pour Claude et en tant que compétence dédiée."
+    },
     "buttons": {
       "copy": "Copier",
       "copied": "Copié !",
@@ -7,14 +11,59 @@
       "watchDemo": "Voir la démo"
     },
     "status": {
-      "availableNow": "Disponible",
+      "availableNow": "Disponible maintenant",
       "inDevelopment": "En développement",
       "planned": "Prévu",
       "comingSoon": "Bientôt disponible"
     },
     "aria": {
-      "toggleDarkMode": "Basculer le mode sombre",
-      "toggleHolidayTheme": "Basculer le menu des thèmes de fête"
+      "toggleDarkMode": "Activer le mode sombre",
+      "toggleHolidayTheme": "Activer le menu du thème des vacances"
+    },
+    "nav": {
+      "features": "Fonctionnalités",
+      "compare": "Comparer",
+      "resources": "Ressources",
+      "support": "Support",
+      "getStarted": "Commencer",
+      "dropdown": {
+        "overview": "Aperçu",
+        "seeAllComparisons": "Voir toutes les comparaisons",
+        "vsWarp": "contre Warp",
+        "aiNativeTerminal": "Terminal natif IA",
+        "vsGitHubCopilot": "contre GitHub Copilot CLI",
+        "aiPairProgrammer": "Programmeur binôme IA",
+        "vsKiro": "contre Kiro CLI",
+        "awsAssistant": "Assistant IA AWS",
+        "blog": "Blog",
+        "newsAndTutorials": "Actualités & tutoriels",
+        "explore": "Explorer",
+        "interactiveDemo": "Démo interactive",
+        "faq": "FAQ",
+        "commonQuestions": "Questions fréquentes",
+        "roadmap": "Feuille de route",
+        "whatsNext": "Ce qui arrive ensuite",
+        "glossary": "Glossaire",
+        "terminalTerms": "Termes de terminal & Unix",
+        "github": "GitHub",
+        "sourceCode": "Code source"
+      },
+      "mobile": {
+        "allComparisons": "Toutes les comparaisons",
+        "supportCaro": "Soutenir Caro"
+      },
+      "appearance": {
+        "title": "Apparence",
+        "darkMode": "Mode Sombre",
+        "holidayTheme": "Thème des Vacances",
+        "snowEffect": "Effet de Neige",
+        "disableEffects": "Désactiver tous les effets"
+      },
+      "useCases": {
+        "allUseCases": "Tous les cas d'utilisation",
+        "byRole": "Par rôle",
+        "backToHome": "Retour à l'accueil"
+      }
     }
   }
 }

--- a/website/src/i18n/locales/fr/compare.json
+++ b/website/src/i18n/locales/fr/compare.json
@@ -1,0 +1,8 @@
+{
+  "compare": {
+    "title": "",
+    "subtitle": "",
+    "comparison": {}
+  },
+  "_note": "TODO: Extraire les chaînes des pages de comparaison"
+}

--- a/website/src/i18n/locales/fr/download.json
+++ b/website/src/i18n/locales/fr/download.json
@@ -1,0 +1,42 @@
+{
+  "download": {
+    "title": "Commencez avec Caro",
+    "subtitle": "Amenez votre fidèle compagnon de shell dans votre terminal",
+    "installCommand": "bash <(curl --proto '=https' --tlsv1.2 -sSfL https://setup.caro.sh)",
+    "copyButton": "Copier",
+    "copiedButton": "Copié !",
+    "binariesIntro": "Ou téléchargez les binaires pré-construits :",
+    "comingSoonBadge": "Bientôt disponible",
+    "platforms": {
+      "macAppleSilicon": "macOS (Apple Silicon)",
+      "macIntel": "macOS (Intel)",
+      "linuxX64": "Linux (x86_64)",
+      "windows": "Windows"
+    },
+    "usageModes": {
+      "title": "Plusieurs façons d'utiliser Caro",
+      "modes": [
+        {
+          "title": "🔧 CLI autonome",
+          "exampleCommand": "caro \"list files > 100MB\""
+        },
+        {
+          "title": "🔌 MCP pour Claude",
+          "description": "Ajoutez Caro comme serveur MCP à Claude Desktop et laissez-la gérer toutes les commandes shell de manière transparente.",
+          "comingSoon": true
+        },
+        {
+          "title": "✨ Compétence dédiée",
+          "description": "Utilisez Caro comme une Compétence pour déléguer la génération et l'exécution des commandes shell pendant que Claude se concentre sur votre travail.",
+          "comingSoon": true
+        }
+      ]
+    },
+    "quickStart": {
+      "title": "Démarrage rapide",
+      "intro": "Après avoir exécuté le script de configuration ci-dessus, utilisez simplement Caro :",
+      "exampleCommand": "caro \"find all python files modified in the last 7 days\"",
+      "description": "Caro générera la commande et vous gardera en sécurité. Le script de configuration gère tous les prérequis, y compris la compilation Rust."
+    }
+  }
+}

--- a/website/src/i18n/locales/fr/features.json
+++ b/website/src/i18n/locales/fr/features.json
@@ -1,0 +1,45 @@
+{
+  "features": {
+    "title": "Pourquoi Caro ?",
+    "subtitle": "Un agent compagnon conçu pour la sécurité, l'empathie et l'expertise",
+    "alphaNotice": "🚧 Lancement en Alpha — Nous construisons activement avec notre communauté. Rejoignez-nous pour aider à façonner l'avenir de Caro !",
+    "items": [
+      {
+        "icon": "🛡️",
+        "title": "Gardien de la Sécurité",
+        "description": "Une validation complète bloque les commandes dangereuses comme rm -rf /, les fork bombs et les opérations destructrices. 52 modèles de sécurité prédéfinis avec évaluation du niveau de risque.",
+        "statusLabel": "Disponible Maintenant"
+      },
+      {
+        "icon": "🌍",
+        "title": "Expert Multi-Plateformes",
+        "description": "Fonctionne sur macOS, Linux, Windows, GNU et BSD. Comprend les nuances spécifiques à chaque plateforme et respecte votre distribution de choix.",
+        "statusLabel": "Disponible Maintenant"
+      },
+      {
+        "icon": "🧠",
+        "title": "Conscient de la Plateforme",
+        "description": "Fournit des recommandations basées sur les capacités de votre plateforme et les meilleures pratiques. Distingue automatiquement la syntaxe des commandes BSD et GNU.",
+        "statusLabel": "Disponible Maintenant"
+      },
+      {
+        "icon": "✅",
+        "title": "Spécialiste POSIX",
+        "description": "Expert en commandes shell conformes à POSIX qui fonctionnent de manière fiable sur les systèmes. Portable, sûr et optimisé pour votre terminal.",
+        "statusLabel": "Disponible Maintenant"
+      },
+      {
+        "icon": "⚡",
+        "title": "Rapide comme l'éclair",
+        "description": "Objectif : Démarrage en moins de 100ms, inférence en moins de 2s sur Apple Silicon. Intégration du cadre MLX pour l'accélération GPU sur les puces de série M.",
+        "statusLabel": "En Développement"
+      },
+      {
+        "icon": "🤝",
+        "title": "Le Compagnon de Claude",
+        "description": "Vision : Intégration transparente avec Claude en tant que serveur MCP et Compétence, déléguant l'inférence des commandes shell pendant que Claude se concentre sur votre travail plus large.",
+        "statusLabel": "Prévu"
+      }
+    ]
+  }
+}

--- a/website/src/i18n/locales/fr/hero.json
+++ b/website/src/i18n/locales/fr/hero.json
@@ -1,0 +1,13 @@
+{
+  "hero": {
+    "badge": "🐕 Agent Compagnon",
+    "logo": "Caro",
+    "logoAlt": "Caro - art pixel 8-bit",
+    "tagline": "Votre fidèle compagnon de shell",
+    "subtitle": "Un agent de commande shell POSIX spécialisé avec empathie et autonomie. Disponible en tant que MCP pour Claude et en tant que compétence dédiée. Elle vous protège tout en aidant Claude à accomplir sa mission.",
+    "cta": {
+      "getStarted": "Commencer",
+      "watchDemo": "Regarder la démo"
+    }
+  }
+}

--- a/website/src/i18n/locales/fr/landing.json
+++ b/website/src/i18n/locales/fr/landing.json
@@ -1,0 +1,272 @@
+{
+  "landing": {
+    "navigation": {
+      "brand": "Caro",
+      "cta": "Commencez gratuitement",
+      "darkMode": {
+        "toggle": "Basculer en mode sombre"
+      }
+    },
+    "hero": {
+      "badge": "Agent Compagnon",
+      "tagline": "Votre fidèle compagnon de shell",
+      "subtitle": "Un agent de commande shell POSIX spécialisé pour les utilisateurs de Claude. Valide les commandes générées par IA avec une conception priorisant la sécurité, détecte les motifs dangereux et assure la conformité POSIX.",
+      "installLabel": "Disponible en tant que compétence de Claude :",
+      "cta": {
+        "getStarted": "Commencer",
+        "watchDemo": "Regarder la démo"
+      }
+    },
+    "features": {
+      "title": "Pourquoi Caro ?",
+      "subtitle": "Un agent compagnon construit pour la sécurité, l'empathie et l'expertise",
+      "alphaNotice": "Nous construisons activement avec notre communauté. Rejoignez-nous pour aider à façonner l'avenir de Caro !",
+      "alphaLabel": "Lancement Alpha Doux",
+      "ctaText": "Voir exactement ce que Caro bloque et pourquoi",
+      "ctaLink": "Voir les motifs de sécurité",
+      "items": [
+        {
+          "icon": "🛡️",
+          "title": "Ne jamais détruire la production à nouveau",
+          "description": "Bloque rm -rf /, les bombes fork et plus de 50 autres commandes qui pourraient ruiner votre carrière AVANT que vous puissiez les exécuter. Votre moi de 2 heures du matin vous remerciera.",
+          "highlight": true
+        },
+        {
+          "icon": "🔒",
+          "title": "Vos données restent les vôtres",
+          "description": "Zéro télémétrie. Zéro appel d'API cloud. Fonctionne dans des réseaux isolés. Passez n'importe quel audit de conformité. Vos commandes ne quittent jamais votre machine.",
+          "highlight": true,
+          "privacyLink": true
+        },
+        {
+          "icon": "✅",
+          "title": "Des commandes qui fonctionnent réellement",
+          "description": "Génère des commandes qui fonctionnent sur votre Mac, votre serveur Linux et la machine BSD de votre collègue. La première fois. À chaque fois.",
+          "highlight": false
+        },
+        {
+          "icon": "⚡",
+          "title": "Assez rapide pour ne pas briser le flux",
+          "description": "Inférence en moins de 2s sur Apple Silicon. Pas d'attente pour les API cloud. Pas de doute si le serveur est en panne. Juste des réponses.",
+          "highlight": false
+        }
+      ],
+      "cards": {
+        "safetyGuardian": {
+          "title": "Gardien de la Sécurité",
+          "description": "Une validation complète bloque les commandes dangereuses comme rm -rf /, les bombes fork et les opérations destructrices. 52 motifs de sécurité prédéfinis avec évaluation du niveau de risque."
+        },
+        "crossPlatform": {
+          "title": "Expert Multi-Plateformes",
+          "description": "Fonctionne sur macOS, Linux, Windows, GNU et BSD. Comprend les nuances spécifiques à chaque plateforme et respecte votre choix de distribution."
+        },
+        "platformAware": {
+          "title": "Conscient de la Plateforme",
+          "description": "Fournit des recommandations basées sur les capacités de votre plateforme et les meilleures pratiques. Distingue automatiquement la syntaxe des commandes BSD et GNU."
+        },
+        "posixSpecialist": {
+          "title": "Spécialiste POSIX",
+          "description": "Expert en commandes shell conformes à POSIX qui fonctionnent de manière fiable sur les systèmes. Portable, sûr et optimisé pour votre terminal."
+        },
+        "lightningFast": {
+          "title": "Rapide comme l'éclair",
+          "description": "Objectif : Démarrage en moins de 100ms, inférence en moins de 2s sur Apple Silicon. Intégration du cadre MLX pour l'accélération GPU sur les puces de série M."
+        },
+        "claudeCompanion": {
+          "title": "Le Compagnon de Claude",
+          "description": "Compétence officielle de Claude Code pour la génération de commandes shell sûres. S'active automatiquement lorsque vous avez besoin d'aide, fournit des conseils de sécurité et s'intègre de manière transparente dans votre flux de travail. Installez avec /plugin install wildcard/caro"
+        }
+      }
+    },
+    "comparison": {
+      "title": "Comment Caro se Compare",
+      "subtitle": "Conçu pour les ingénieurs DevOps et les SRE qui refusent de sacrifier la vie privée pour la productivité",
+      "summary": {
+        "privacy": {
+          "stat": "Vie privée",
+          "label": "Conception Prioritaire*"
+        },
+        "safety": {
+          "stat": "52+",
+          "label": "Motifs de Sécurité"
+        },
+        "offline": {
+          "stat": "100%",
+          "label": "Capable Hors-ligne"
+        },
+        "speed": {
+          "stat": "Rust",
+          "label": "Conçu pour la Vitesse"
+        }
+      },
+      "competitors": {
+        "caro": "Caro",
+        "copilotCli": "GitHub Copilot CLI",
+        "warp": "Warp AI",
+        "kiro": "Kiro CLI",
+        "opencode": "OpenCode"
+      },
+      "table": {
+        "feature": "Fonctionnalité",
+        "youreHere": "Vous êtes ici"
+      },
+      "categories": {
+        "privacyData": {
+          "title": "Vie privée & Données",
+          "features": {
+            "worksOffline": {
+              "name": "Fonctionne 100% hors-ligne",
+              "tooltip": "Aucun internet requis pour les fonctionnalités principales"
+            },
+            "privacyFirst": {
+              "name": "Conception prioritaire de la vie privée",
+              "tooltip": "Télémétrie minimale, anonyme avec désinscription facile"
+            },
+            "airGapped": {
+              "name": "Compatible avec les réseaux isolés",
+              "tooltip": "Peut fonctionner dans des environnements isolés"
+            },
+            "openSource": {
+              "name": "Open source",
+              "tooltip": "Code source complet disponible"
+            }
+          }
+        },
+        "safetyControl": {
+          "title": "Sécurité & Contrôle",
+          "features": {
+            "ruleBasedSafety": {
+              "name": "Vérifications de sécurité basées sur des règles",
+              "tooltip": "Validation avant exécution avec des motifs définis"
+            },
+            "explicitConfirmation": {
+              "name": "Confirmation explicite requise",
+              "tooltip": "Les commandes ne s'exécutent jamais sans votre approbation"
+            },
+            "blocksDangerous": {
+              "name": "Bloque les commandes dangereuses",
+              "tooltip": "Empêche rm -rf /, les bombes fork, etc."
+            },
+            "riskLevel": {
+              "name": "Évaluation du niveau de risque",
+              "tooltip": "Commandes évaluées par impact potentiel"
+            }
+          }
+        },
+        "shellExpertise": {
+          "title": "Expertise Shell",
+          "features": {
+            "posixFirst": {
+              "name": "Approche prioritaire POSIX",
+              "tooltip": "Commandes portables qui fonctionnent partout"
+            },
+            "crossPlatform": {
+              "name": "Multi-plateformes (macOS/Linux/BSD)",
+              "tooltip": "Fonctionne sur les systèmes de type Unix"
+            },
+            "existingTerminal": {
+              "name": "Utilise votre terminal existant",
+              "tooltip": "Aucun nouvel émulateur de terminal requis"
+            },
+            "platformAware": {
+              "name": "Commandes conscientes de la plateforme",
+              "tooltip": "Ajuste pour la syntaxe GNU vs BSD"
+            }
+          }
+        },
+        "modelBackend": {
+          "title": "Modèle & Backend",
+          "features": {
+            "localInference": {
+              "name": "Inférence locale",
+              "tooltip": "Les modèles fonctionnent sur votre machine"
+            },
+            "multiBackend": {
+              "name": "Support multi-backend",
+              "tooltip": "Choisissez votre moteur d'inférence"
+            },
+            "appleSilicon": {
+              "name": "Optimisé pour Apple Silicon",
+              "tooltip": "Cadre MLX pour les Macs de série M"
+            },
+            "selfHostable": {
+              "name": "Auto-hébergeable",
+              "tooltip": "Contrôle complet sur l'infrastructure"
+            }
+          }
+        }
+      },
+      "cta": {
+        "text": "Prêt pour un compagnon de shell qui respecte votre vie privée ?",
+        "getStarted": "Commencez gratuitement",
+        "fullComparison": "Voir la comparaison complète"
+      },
+      "legend": {
+        "fullSupport": "Support complet",
+        "partial": "Partiel/configurable",
+        "notSupported": "Non supporté",
+        "planned": "Prévu"
+      },
+      "values": {
+        "yes": "Oui",
+        "no": "Non",
+        "partial": "Partiel",
+        "planned": "Prévu"
+      }
+    },
+    "scenarios": {},
+    "demo": {},
+    "useCases": {},
+    "differentiators": {},
+    "communityVoices": {},
+    "trust": {},
+    "story": {
+      "title": "Rencontrez Caro",
+      "subtitle": "Un compagnon avec une histoire de loyauté et de transformation",
+      "paragraphs": {
+        "intro": "Caro est la digitalisation de Kyaro (Kyarorain Kadosh), le chien bien-aimé du mainteneur. Tout comme un compagnon fidèle reste à vos côtés à travers chaque défi, Caro est là pour vous aider à naviguer dans les complexités des commandes shell avec sécurité et expertise.",
+        "highlight": "Dans Portal 2, nous avons appris que GLaDOS était autrefois Caroline, la secrétaire du fondateur de Aperture Science—transformée en gardienne éternelle de l'installation. Comme Caroline est devenue le cœur battant des chambres de test, Caro est votre compagnon éternel pour le terminal.",
+        "platforms": "Elle se spécialise dans les commandes shell POSIX et comprend les nuances de chaque plateforme—que vous soyez sur macOS, Linux, Windows, GNU ou BSD. Caro apporte vos préférences partout où vous la déployez, respectant votre choix de distribution tout en vous protégeant des commandes dangereuses.",
+        "companion": "En tant que compagnon fidèle de Claude, Caro gère le travail lourd spécifique au shell, permettant à Claude de se concentrer sur le travail plus large tout en s'assurant que chaque commande est sûre, correcte et optimisée pour votre plateforme."
+      }
+    },
+    "faq": {
+      "title": "Préoccupations courantes",
+      "subtitle": "Questions réelles d'ingénieurs sceptiques (nous comprenons)",
+      "concerns": [
+        {
+          "question": "Attendez, Caro fonctionne localement. Comment reste-t-il à jour avec de nouveaux motifs dangereux ?",
+          "answer": "Les motifs de sécurité de Caro sont intégrés dans le binaire—aucun réseau nécessaire. Lorsque vous mettez à jour Caro (cargo install caro --force), vous obtenez les derniers motifs. Les commandes dangereuses principales (rm -rf /, les bombes fork, les effaceurs de disque) ne changent pas. Nous acceptons également les contributions de motifs via GitHub.",
+          "icon": "🔄"
+        },
+        {
+          "question": "Cela va-t-il ralentir ma réponse aux incidents ?",
+          "answer": "Non. Caro ajoute <100ms à la génération de commande. La vérification de sécurité est instantanée (correspondance de motifs, pas d'inférence IA). Dans un véritable incident, c'est 100ms qui pourraient vous éviter de rendre les choses 10 fois pires. La validation est synchrone—vous voyez l'avertissement immédiatement.",
+          "icon": "⚡"
+        },
+        {
+          "question": "Comment sait-il ma configuration système spécifique (BSD vs GNU, etc.) ?",
+          "answer": "Caro détecte votre OS et votre shell au moment de l'exécution. Sur macOS, il sait que vous utilisez les outils BSD. Sur Linux, il s'ajuste pour la syntaxe GNU. Il lit votre $SHELL et s'ajuste en conséquence. Aucune configuration nécessaire—ça fonctionne juste.",
+          "icon": "🖥️"
+        },
+        {
+          "question": "Et si j'ai réellement BESOIN d'exécuter une commande dangereuse ?",
+          "answer": "Caro avertit, il n'enferme pas. Lorsque vous voyez un avertissement, vous pouvez toujours continuer—nous nous assurons juste que vous le faites intentionnellement. Pour les commandes réellement destructrices (rm -rf /), vous devrez confirmer. C'est votre ceinture de sécurité, pas une camisole de force.",
+          "icon": "🔓"
+        },
+        {
+          "question": "Est-ce juste une autre enveloppe d'IA qui envoie mes commandes au cloud ?",
+          "answer": "Non. Caro fonctionne à 100% localement. Vos commandes, chemins de fichiers, noms de serveurs et structures de répertoires ne quittent jamais votre machine. L'inférence se fait sur votre matériel. Nous n'avons aucune télémétrie. Vérifiez le code source—il est sous licence AGPL-3.0.",
+          "icon": "🔒"
+        },
+        {
+          "question": "Pourquoi devrais-je faire confiance à des commandes shell générées par IA du tout ?",
+          "answer": "Vous ne devriez pas leur faire confiance aveuglément—c'est le point. Caro génère des commandes ET les valide avant que vous les exécutiez. Ce n'est pas 'faire confiance à l'IA'—c'est 'faire confiance à la couche de sécurité basée sur des motifs qui attrape ce que l'IA pourrait mal faire.' La validation est déterministe, pas probabiliste.",
+          "icon": "🎯"
+        }
+      ]
+    },
+    "download": {},
+    "footer": {}
+  }
+}

--- a/website/src/i18n/locales/fr/navigation.json
+++ b/website/src/i18n/locales/fr/navigation.json
@@ -1,0 +1,48 @@
+{
+  "navigation": {
+    "brand": "🐕 Caro",
+    "links": {
+      "features": "Fonctionnalités",
+      "compare": "Comparer",
+      "play": "Jouer",
+      "blog": "Blog",
+      "getStarted": "Commencer",
+      "github": "GitHub"
+    },
+    "darkMode": {
+      "toggle": "Activer le mode sombre"
+    },
+    "holidayTheme": {
+      "toggle": "Activer le menu du thème des fêtes",
+      "title": "Thème des Fêtes",
+      "menuHeader": "Thème des Fêtes",
+      "options": {
+        "christmas": "Noël",
+        "hanukkah": "Hanoukka",
+        "noTheme": "Sans Thème"
+      },
+      "snowEffect": "Effet de neige"
+    }
+  },
+  "footer": {
+    "builtWith": "Construit avec Rust 🦀 | Open source sur",
+    "github": "GitHub",
+    "domain": {
+      "name": "caro.sh",
+      "tagline": "Votre fidèle compagnon de shell"
+    },
+    "links": {
+      "license": "AGPL-3.0",
+      "credits": "Crédits & Attribution",
+      "contributing": "Contribuer",
+      "issues": "Problèmes"
+    },
+    "kyaro": {
+      "title": "Rencontrez Kyaro IRL (Kyarorain Kadosh) ! 🐕🖤",
+      "followText": "Suivez ses aventures sur",
+      "instagram": "Instagram @kyaroblackheart"
+    },
+    "inspiration": "Inspiré par Caroline de Portal—la loyauté transformée en compagnonnage numérique",
+    "elevatorCredit": "Effet de défilement par"
+  }
+}


### PR DESCRIPTION
## Automated Translation Update

**Locale:** French (fr)
**Source:** English JSON files in `website/src/i18n/locales/en/`

Translation includes all landing page components:
- Navigation
- Hero
- Features
- Comparison (summary, categories, features, tooltips, CTA, legend)
- Story

### Checklist
- [ ] Review translated strings for accuracy
- [ ] Check placeholders like `{count}`, `{name}` are preserved
- [ ] Verify brand names like "Caro" remain unchanged
- [ ] Build website to verify no syntax errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds French (fr) translations across the website to enable the fr locale for the landing experience and shared UI. Includes a comparison stub and minor key additions in common strings.

- **New Features**
  - Added fr translations for navigation, hero, features, landing, download, and shared common strings; footer text included in navigation.json.
  - Preserved placeholders (e.g., {count}) and kept brand names unchanged.
  - Added compare.json as a stub; comparison strings will be extracted next.

- **Dependencies**
  - Added openai ^6.16.0 for translation tooling.

<sup>Written for commit 1fea7b43a9480fb3a2d8dfbcbc89f4ef95050b11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

