### PR TITLE
feat(knowledge): Add CLI subcommands for knowledge index management (#492)

### DIFF
--- a/src/knowledge/index.rs
+++ b/src/knowledge/index.rs
@@ -20,7 +20,7 @@ use tokio::sync::RwLock;
 const TABLE_NAME: &str = "commands";
 
 /// A knowledge entry retrieved from the index
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct KnowledgeEntry {
     /// The original natural language request
     pub request: String,

--- a/src/knowledge/schema.rs
+++ b/src/knowledge/schema.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub const EMBEDDING_DIM: usize = 384;
 
 /// Type of knowledge entry
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum EntryType {
     /// A successfully executed command
     Success,


### PR DESCRIPTION
## Summary

Adds CLI subcommands for managing the knowledge index, enabling users to inspect, search, and maintain their local command knowledge database.

**New commands:**
```bash
caro knowledge stats              # View index statistics
caro knowledge search "query"     # Search for similar past commands
caro knowledge clear              # Clear all entries (with confirmation)
caro knowledge export data.json   # Export knowledge to JSON
caro knowledge import data.json   # Import knowledge from JSON
```

## Implementation

- Added `KnowledgeCommands` enum with 5 subcommands (behind `knowledge` feature flag)
- Added `Knowledge` variant to main `Commands` enum
- Implemented `handle_knowledge_command()` async handler with:
  - Stats display with entry counts
  - Semantic search with similarity scores
  - Clear with confirmation prompt (using `dialoguer`)
  - Export to JSON file
  - Import from JSON file
- Added `Serialize`/`Deserialize` derives to `KnowledgeEntry` and `EntryType`

## Test plan

- [x] Build passes without knowledge feature (default)
- [x] Build passes with knowledge feature enabled
- [x] All 301 library tests pass
- [x] Clippy passes with knowledge feature

## Usage example

```bash
# Enable knowledge feature when building
cargo build --features knowledge

# Check stats
caro knowledge stats

# Search for similar commands
caro knowledge search "list files" --limit 10

# Export for backup
caro knowledge export ~/knowledge-backup.json

# Clear (will prompt for confirmation)
caro knowledge clear
```

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI subcommands to manage the knowledge index, fulfilling #492. Users can view stats, search past commands, clear entries, and export/import JSON (behind the knowledge feature flag).

- **New Features**
  - caro knowledge stats — View index stats
  - caro knowledge search "<query>" [--limit] — Semantic search with similarity scores
  - caro knowledge clear [--force] — Clear all entries with confirmation
  - caro knowledge export <path> — Export to JSON
  - caro knowledge import <path> — Import from JSON

<sup>Written for commit a380aac8627faf8c8629fef9ae0aa83b5b602886. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

