### PR TITLE
feat: Add CLI subcommands for knowledge index management

### DIFF
--- a/src/knowledge/index.rs
+++ b/src/knowledge/index.rs
@@ -234,7 +234,8 @@ impl KnowledgeIndex {
                 return Ok(json!({
                     "version": "1.0",
                     "entries": []
-                }).to_string());
+                })
+                .to_string());
             }
         };
 
@@ -322,7 +323,8 @@ impl KnowledgeIndex {
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
                     let feedback = entry.get("feedback").and_then(|v| v.as_str());
-                    self.record_correction(request, original, command, feedback).await?;
+                    self.record_correction(request, original, command, feedback)
+                        .await?;
                     imported_count += 1;
                 }
                 _ => {

--- a/src/knowledge/index.rs
+++ b/src/knowledge/index.rs
@@ -8,6 +8,7 @@ use crate::knowledge::{
 };
 use arrow_array::{RecordBatch, RecordBatchIterator};
 use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
 use lancedb::{
     connect,
     query::{ExecutableQuery, QueryBase},
@@ -219,6 +220,119 @@ impl KnowledgeIndex {
             *table = None;
         }
         Ok(())
+    }
+
+    /// Export all entries to JSON
+    pub async fn export_to_json(&self) -> Result<String> {
+        use serde_json::json;
+
+        let table = self.table.read().await;
+        let table = match table.as_ref() {
+            Some(t) => t,
+            None => {
+                // Empty index
+                return Ok(json!({
+                    "version": "1.0",
+                    "entries": []
+                }).to_string());
+            }
+        };
+
+        // Query all entries
+        let results = table
+            .query()
+            .limit(10000) // Reasonable limit for export
+            .execute()
+            .await
+            .map_err(|e| KnowledgeError::Database(e.to_string()))?;
+
+        let batches = results
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| KnowledgeError::Database(e.to_string()))?;
+
+        let mut all_entries = Vec::new();
+        for batch in batches {
+            let entries = self.parse_batch(&batch)?;
+            all_entries.extend(entries);
+        }
+
+        // Convert to JSON
+        let export_data = json!({
+            "version": "1.0",
+            "exported_at": Utc::now().to_rfc3339(),
+            "total_entries": all_entries.len(),
+            "entries": all_entries.iter().map(|e| json!({
+                "request": e.request,
+                "command": e.command,
+                "context": e.context,
+                "timestamp": e.timestamp.to_rfc3339(),
+                "entry_type": match e.entry_type {
+                    EntryType::Success => "success",
+                    EntryType::Correction => "correction",
+                },
+                "original_command": e.original_command,
+                "feedback": e.feedback,
+            })).collect::<Vec<_>>()
+        });
+
+        Ok(export_data.to_string())
+    }
+
+    /// Import entries from JSON
+    pub async fn import_from_json(&self, json_data: &str) -> Result<usize> {
+        use serde_json::Value;
+
+        let data: Value = serde_json::from_str(json_data)
+            .map_err(|e| KnowledgeError::Schema(format!("Invalid JSON: {}", e)))?;
+
+        let entries = data
+            .get("entries")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| KnowledgeError::Schema("Missing 'entries' array".to_string()))?;
+
+        let mut imported_count = 0;
+
+        for entry in entries {
+            let request = entry
+                .get("request")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| KnowledgeError::Schema("Missing 'request' field".to_string()))?;
+
+            let command = entry
+                .get("command")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| KnowledgeError::Schema("Missing 'command' field".to_string()))?;
+
+            let context = entry.get("context").and_then(|v| v.as_str());
+
+            let entry_type = entry
+                .get("entry_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("success");
+
+            match entry_type {
+                "success" => {
+                    self.record_success(request, command, context).await?;
+                    imported_count += 1;
+                }
+                "correction" => {
+                    let original = entry
+                        .get("original_command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let feedback = entry.get("feedback").and_then(|v| v.as_str());
+                    self.record_correction(request, original, command, feedback).await?;
+                    imported_count += 1;
+                }
+                _ => {
+                    // Skip unknown types
+                    continue;
+                }
+            }
+        }
+
+        Ok(imported_count)
     }
 
     /// Add a batch of entries to the index

--- a/src/main.rs
+++ b/src/main.rs
@@ -845,16 +845,8 @@ async fn handle_knowledge_command(command: KnowledgeCommands) -> Result<(), Stri
 
             println!("{}", "Knowledge Index Statistics".bold());
             println!();
-            println!(
-                "  {}: {}",
-                "Total entries".cyan(),
-                stats.total_entries
-            );
-            println!(
-                "  {}: {}",
-                "Success count".cyan(),
-                stats.success_count
-            );
+            println!("  {}: {}", "Total entries".cyan(), stats.total_entries);
+            println!("  {}: {}", "Success count".cyan(), stats.success_count);
             println!(
                 "  {}: {}",
                 "Correction count".cyan(),
@@ -883,13 +875,21 @@ async fn handle_knowledge_command(command: KnowledgeCommands) -> Result<(), Stri
                 println!();
 
                 for (i, entry) in results.iter().enumerate() {
-                    println!("{}. {} (similarity: {:.2})", i + 1, entry.command.green(), entry.similarity);
+                    println!(
+                        "{}. {} (similarity: {:.2})",
+                        i + 1,
+                        entry.command.green(),
+                        entry.similarity
+                    );
                     println!("   Request: {}", entry.request.dimmed());
                     if let Some(ctx) = &entry.context {
                         println!("   Context: {}", ctx.dimmed());
                     }
                     println!("   Type: {:?}", entry.entry_type);
-                    println!("   Timestamp: {}", entry.timestamp.format("%Y-%m-%d %H:%M:%S"));
+                    println!(
+                        "   Timestamp: {}",
+                        entry.timestamp.format("%Y-%m-%d %H:%M:%S")
+                    );
                     println!();
                 }
             }
@@ -897,7 +897,10 @@ async fn handle_knowledge_command(command: KnowledgeCommands) -> Result<(), Stri
 
         KnowledgeCommands::Clear { yes } => {
             if !yes {
-                print!("{} ", "Are you sure you want to clear all knowledge? [y/N]".yellow());
+                print!(
+                    "{} ",
+                    "Are you sure you want to clear all knowledge? [y/N]".yellow()
+                );
                 std::io::Write::flush(&mut std::io::stdout()).unwrap();
 
                 let mut input = String::new();
@@ -925,8 +928,7 @@ async fn handle_knowledge_command(command: KnowledgeCommands) -> Result<(), Stri
                 .await
                 .map_err(|e| format!("Failed to export: {}", e))?;
 
-            std::fs::write(&path, json_data)
-                .map_err(|e| format!("Failed to write file: {}", e))?;
+            std::fs::write(&path, json_data).map_err(|e| format!("Failed to write file: {}", e))?;
 
             println!("{} Exported knowledge to {}", "✓".green(), path.display());
         }
@@ -940,7 +942,12 @@ async fn handle_knowledge_command(command: KnowledgeCommands) -> Result<(), Stri
                 .await
                 .map_err(|e| format!("Failed to import: {}", e))?;
 
-            println!("{} Imported {} entries from {}", "✓".green(), count, path.display());
+            println!(
+                "{} Imported {} entries from {}",
+                "✓".green(),
+                count,
+                path.display()
+            );
         }
     }
 
@@ -1160,15 +1167,13 @@ async fn main() {
             process::exit(0);
         }
         #[cfg(feature = "knowledge")]
-        Some(Commands::Knowledge { command }) => {
-            match handle_knowledge_command(command).await {
-                Ok(()) => process::exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    process::exit(1);
-                }
+        Some(Commands::Knowledge { command }) => match handle_knowledge_command(command).await {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
             }
-        }
+        },
         // NOTE: Telemetry subcommand disabled in v1.1.0-beta.1
         // Some(Commands::Telemetry { command }) => {
         //     let storage_path = dirs::data_dir()


### PR DESCRIPTION
## Summary

Implements Issue #492 by adding CLI subcommands for managing the knowledge index.

## Changes

### New CLI Subcommands

All commands require the `knowledge` feature flag:

- `caro knowledge stats` - Display index statistics (total entries, success count, correction count)
- `caro knowledge search <query> [--limit N]` - Search for similar commands using semantic search
- `caro knowledge clear [--yes]` - Clear all knowledge with confirmation prompt
- `caro knowledge export <path>` - Export knowledge to JSON file
- `caro knowledge import <path>` - Import knowledge from JSON file

### Implementation Details

**Backend Methods** (`src/knowledge/index.rs`):
- Added `export_to_json()` - Exports all entries to versioned JSON format
- Added `import_from_json()` - Imports entries from JSON with validation
- Added `futures::TryStreamExt` import for async stream handling

**CLI Layer** (`src/main.rs`):
- Added `KnowledgeCommands` enum with all subcommand variants
- Added `Commands::Knowledge` variant to main command enum
- Implemented `handle_knowledge_command()` async function
- Uses colored output for better UX (stats in cyan, success in green, errors in yellow)

### Export/Import Format

```json
{
  "version": "1.0",
  "exported_at": "2026-01-17T12:34:56Z",
  "total_entries": 42,
  "entries": [
    {
      "request": "list all files",
      "command": "ls -la",
      "context": "rust project",
      "timestamp": "2026-01-17T12:00:00Z",
      "entry_type": "success",
      "original_command": null,
      "feedback": null
    }
  ]
}
```

## Testing

All subcommands tested manually:
- ✅ `knowledge stats` - Shows empty index correctly
- ✅ `knowledge search` - Returns "No results found" for empty index
- ✅ `knowledge export` - Creates JSON file with correct format
- ✅ `knowledge import` - Reads JSON and reports imported count
- ✅ Build passes with `--features knowledge`

## Related

- Closes #492
- Depends on PR #490 (knowledge index implementation) - already merged

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `caro knowledge` CLI to manage the knowledge index: view stats, search, clear, export, and import. Requires the `knowledge` feature flag and fulfills #492.

- **New Features**
  - `caro knowledge stats` — Show total, success, and correction counts.
  - `caro knowledge search <query> [--limit N]` — Semantic search for similar commands.
  - `caro knowledge clear [--yes]` — Clear all knowledge with a confirmation prompt.
  - `caro knowledge export <path>` — Export to versioned JSON.
  - `caro knowledge import <path>` — Import from JSON with validation.

<sup>Written for commit 445078acdbecdd0d66921ec4fdd57d344f082869. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

