### PR TITLE
Fix elevator music delay on scroll to top

### DIFF
--- a/website/src/components/BackToTop.astro
+++ b/website/src/components/BackToTop.astro
@@ -213,6 +213,12 @@
 </style>
 
 <script>
+  // Preload elevator music immediately for instant playback (no delay on first click)
+  const elevatorAudio = new Audio('/elevator-music.mp3');
+  elevatorAudio.preload = 'auto';
+  // Trigger actual loading by setting src and calling load()
+  elevatorAudio.load();
+
   // Import elevator.js
   const script = document.createElement('script');
   script.src = '/elevator.js';
@@ -223,6 +229,7 @@
 
     // Check localStorage for mute preference (default: unmuted)
     let isMuted = localStorage.getItem('elevatorMuted') === 'true';
+    let isRiding = false;
 
     // Update mute button visual state
     const updateMuteButtonState = () => {
@@ -235,33 +242,26 @@
 
     updateMuteButtonState();
 
-    // Initialize elevator.js once without audio - we'll handle audio manually
-    let elevatorDuration = 3000; // 3 seconds
-    let currentAudio: HTMLAudioElement | null = null;
-
+    // Initialize elevator.js with callbacks for proper audio synchronization
+    // Using callbacks instead of setTimeout ensures audio is perfectly synced with scroll animation
     // @ts-ignore - Elevator is loaded from external script
     const elevator = new Elevator({
       element: button,
-      duration: elevatorDuration,
-    });
-
-    // Handle audio manually on button click
-    button?.addEventListener('click', () => {
-      if (!isMuted) {
-        // Create and play audio
-        currentAudio = new Audio('/elevator-music.mp3');
-        currentAudio.play().catch(() => {
-          // Ignore errors if user hasn't interacted yet
-        });
-
-        // Stop audio after elevator ride
-        setTimeout(() => {
-          if (currentAudio) {
-            currentAudio.pause();
-            currentAudio.currentTime = 0;
-            currentAudio = null;
-          }
-        }, elevatorDuration);
+      startCallback: () => {
+        isRiding = true;
+        if (!isMuted) {
+          // Reset and play preloaded audio - no loading delay!
+          elevatorAudio.currentTime = 0;
+          elevatorAudio.play().catch(() => {
+            // Ignore errors if user hasn't interacted yet
+          });
+        }
+      },
+      endCallback: () => {
+        isRiding = false;
+        // Stop audio exactly when elevator finishes - perfectly synced!
+        elevatorAudio.pause();
+        elevatorAudio.currentTime = 0;
       }
     });
 
@@ -273,11 +273,10 @@
       isMuted = !isMuted;
       localStorage.setItem('elevatorMuted', isMuted.toString());
 
-      // Stop currently playing audio immediately
-      if (currentAudio) {
-        currentAudio.pause();
-        currentAudio.currentTime = 0;
-        currentAudio = null;
+      // Stop currently playing audio immediately if riding
+      if (isRiding) {
+        elevatorAudio.pause();
+        elevatorAudio.currentTime = 0;
       }
 
       // Update visual state


### PR DESCRIPTION
## Summary
- Fix delay in elevator music playback when scrolling to top
- Improve audio synchronization with scroll animation

## Changes
- Refactored `website/src/components/BackToTop.astro`
- Added audio preloading to eliminate initial delay
- Synchronized audio playback with scroll animation callbacks

## Technical Details
- Audio element now preloads on component mount
- Playback starts immediately when scroll animation begins
- Better handling of audio state and timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delay in elevator music when scrolling to top and syncs playback precisely with the scroll animation.

- **Bug Fixes**
  - Preload elevator music on component mount for instant playback.
  - Use ElevatorJS start/end callbacks to start and stop audio in lockstep with the scroll.
  - Remove hardcoded 3s timer and stop audio immediately when muted mid-ride.

<sup>Written for commit b87bbc0a82e9f92b9a3fd478b95a3d1c9db1ff21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

