### PR TITLE
fix(version): Match standard CLI version output format

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -27,12 +27,10 @@ impl VersionInfo {
 
     /// Generate short version string (scriptable, single line)
     ///
-    /// Format: `caro 1.0.2 (abc1234 2025-01-15)`
+    /// Format: `caro 1.0.2 (x86_64-unknown-linux-gnu)`
+    /// Follows standard CLI conventions (bash, rustc, etc.)
     pub fn short(&self) -> String {
-        format!(
-            "caro {} ({} {})",
-            self.version, self.git_hash, self.git_date
-        )
+        format!("caro {} ({})", self.version, self.target)
     }
 
     /// Generate long version string (verbose, Caro's voice)
@@ -142,6 +140,9 @@ mod tests {
         let short = short();
         assert!(short.starts_with("caro "));
         assert!(short.contains(env!("CARGO_PKG_VERSION")));
+        // Verify platform/target triple is included
+        let info = VersionInfo::get();
+        assert!(short.contains(info.target), "Version should include target triple");
     }
 
     #[test]


### PR DESCRIPTION
Updates version output to follow standard CLI conventions like bash and rustc, showing version and platform in a clean format.

**Before:** `caro 1.1.3 (a16609d 2026-01-17)`
**After:** `caro 1.1.3 (x86_64-unknown-linux-gnu)`

The commit hash and date remain available in verbose output (`--version --verbose`).

**Changes:**
- Modified `src/version.rs` to show platform triple instead of git hash
- Follows conventions from bash, rustc, and other standard CLI tools

**Type:** Bug Fix
**Lines changed:** +6 -5

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the --version output to show the target triple instead of the git hash/date, matching conventions used by tools like bash and rustc. Verbose mode (--version --verbose) still includes the commit hash and build date.

<sup>Written for commit 5d31d4ad76f7b2f0fe29807619161b33cd66db13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

