### PR TITLE
feat(clarification): Add intelligent clarification UX design and shell profile patterns

### DIFF
--- a/docs/adr/ADR-005-intelligent-clarification-ux.md
+++ b/docs/adr/ADR-005-intelligent-clarification-ux.md
@@ -1,0 +1,609 @@
+# ADR-005: Intelligent Clarification UX
+
+| **Status**     | Proposed                            |
+|----------------|-------------------------------------|
+| **Date**       | January 2026                        |
+| **Authors**    | Caro Maintainers                    |
+| **Supersedes** | N/A                                 |
+| **Relates To** | ADR-004 (Pre-Processing Pipeline), Spec 006 (Intelligent Prompt Generation) |
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Context and Problem Statement](#context-and-problem-statement)
+3. [Decision Drivers](#decision-drivers)
+4. [Proposed Solution](#proposed-solution)
+5. [Architecture](#architecture)
+6. [Implementation Details](#implementation-details)
+7. [User Experience Design](#user-experience-design)
+8. [Consequences](#consequences)
+9. [Alternatives Considered](#alternatives-considered)
+
+---
+
+## Executive Summary
+
+This ADR defines the architecture for an **intelligent clarification system** that transforms the current unhelpful "Please clarify your request" response into a collaborative, reasoning-based query improvement experience. Instead of dead-ending users with vague error messages, caro will use structured reasoning to understand ambiguity, generate targeted questions, and help users refine their queries to get accurate commands.
+
+**Core Principle**: When caro doesn't understand, it should say **why** and offer **specific help** to improve the query.
+
+---
+
+## Context and Problem Statement
+
+### The Problem
+
+When a user submits a query that caro cannot confidently translate to a shell command, the current behavior is:
+
+```
+PS C:\Users\User> caro how to reload powershell profile?
+Command:
+  echo 'Please clarify your request'
+
+Execute this command?:
+  Yes - execute
+> No - skip
+  Edit - modify in shell
+```
+
+This is a poor user experience because:
+
+1. **Unhelpful**: "Please clarify" doesn't tell the user *what* to clarify or *why* the request was unclear
+2. **Dead-end**: No guidance on how to rephrase the query
+3. **Wastes time**: User must guess what went wrong and retry blindly
+4. **Platform blindness**: Doesn't recognize this is a PowerShell-specific query (vs POSIX)
+5. **No learning**: System doesn't improve from these interactions
+
+### Real Example Analysis
+
+The query "how to reload powershell profile?" fails because:
+- **Platform mismatch**: Caro is POSIX-focused, PowerShell is a different paradigm
+- **Intent unclear to model**: "reload profile" could mean several things
+- **No static pattern**: PowerShell commands aren't in the pattern library
+- **LLM fallback**: Model defaults to clarification when uncertain
+
+The **correct answer** for PowerShell is: `. $PROFILE`
+
+But caro can't reach this answer because:
+1. No PowerShell-specific knowledge in current prompts
+2. No clarification mechanism to ask "Did you mean PowerShell?" vs "bash/zsh profile?"
+3. No reasoning chain to identify the ambiguity type
+
+---
+
+## Decision Drivers
+
+### Primary Drivers
+
+1. **User Success**: Every interaction should move toward a successful command
+2. **Transparency**: Users should understand why caro is uncertain
+3. **Actionability**: Clarification requests must be specific and answerable
+4. **Learning**: System should improve from clarification interactions
+5. **Efficiency**: Minimize round-trips to successful command
+
+### Secondary Drivers
+
+- Cross-platform awareness (POSIX vs PowerShell vs CMD)
+- Graceful degradation when clarification isn't possible
+- Consistent UX across all backends
+- Integration with existing safety validation
+
+---
+
+## Proposed Solution
+
+### Core Concept: Reasoning-Based Clarification
+
+Instead of a binary "understood/not understood" model, implement a **reasoning chain** that:
+
+1. **Analyzes** why the query is ambiguous
+2. **Categorizes** the ambiguity type
+3. **Generates** targeted clarification questions
+4. **Enhances** the query with answers
+5. **Retries** generation with improved context
+
+### Ambiguity Categories
+
+| Category | Description | Example Query | Clarification Strategy |
+|----------|-------------|---------------|----------------------|
+| **Platform Ambiguous** | Could apply to multiple shells/OS | "reload profile" | Ask which shell (PowerShell/bash/zsh) |
+| **Scope Ambiguous** | Unclear target files/directories | "delete old files" | Ask location, age threshold, confirmation |
+| **Action Ambiguous** | Multiple possible operations | "clean up disk" | Ask specific cleanup type |
+| **Missing Context** | Needs additional parameters | "connect to server" | Ask server address, protocol |
+| **Domain Unknown** | Outside caro's knowledge | "deploy to kubernetes" | Explain limitations, suggest alternatives |
+| **Safety Concern** | Potentially destructive | "remove everything" | Confirm intent, explain risks |
+
+### Reasoning Output Format
+
+```json
+{
+  "understood": false,
+  "confidence": 0.3,
+  "reasoning": {
+    "what_i_understood": "User wants to reload some kind of profile configuration",
+    "what_is_unclear": [
+      "Which shell environment (PowerShell, bash, zsh, fish)?",
+      "Current profile or all profiles?",
+      "Reload in current session or restart shell?"
+    ],
+    "ambiguity_type": "platform_ambiguous",
+    "knowledge_gap": "PowerShell-specific commands not in training data"
+  },
+  "clarification_questions": [
+    {
+      "id": "shell_type",
+      "question": "Which shell are you using?",
+      "options": ["PowerShell", "bash", "zsh", "fish"],
+      "detected_hint": "Query mentions 'powershell' - likely PowerShell"
+    }
+  ],
+  "partial_answer": {
+    "if_powershell": ". $PROFILE",
+    "if_bash": "source ~/.bashrc",
+    "if_zsh": "source ~/.zshrc"
+  }
+}
+```
+
+---
+
+## Architecture
+
+### System Flow
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                          INTELLIGENT CLARIFICATION FLOW                        │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                                │
+│  User Query: "how to reload powershell profile?"                              │
+│       │                                                                        │
+│       ▼                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                    STAGE 1: INITIAL ANALYSIS                            │  │
+│  │                                                                          │  │
+│  │  ┌──────────────────┐  ┌──────────────────┐  ┌───────────────────────┐  │  │
+│  │  │ Static Matcher   │  │ Platform Detector│  │ Keyword Extractor     │  │  │
+│  │  │ Result: NO_MATCH │  │ Hint: PowerShell │  │ ["reload", "profile"] │  │  │
+│  │  └──────────────────┘  └──────────────────┘  └───────────────────────┘  │  │
+│  │                                                                          │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│       │                                                                        │
+│       ▼                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                    STAGE 2: LLM REASONING                               │  │
+│  │                                                                          │  │
+│  │  System Prompt: "Analyze this query. If unclear, explain WHY and        │  │
+│  │                  generate specific clarification questions."             │  │
+│  │                                                                          │  │
+│  │  Reasoning Output:                                                       │  │
+│  │  • Platform hint detected: "powershell" in query                        │  │
+│  │  • Intent: reload shell configuration                                    │  │
+│  │  • Confidence: 0.85 (high due to explicit platform mention)             │  │
+│  │  • Suggested command: `. $PROFILE` (PowerShell)                         │  │
+│  │                                                                          │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│       │                                                                        │
+│       ▼                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                    STAGE 3: CONFIDENCE GATE                             │  │
+│  │                                                                          │  │
+│  │  If confidence >= 0.7:                                                   │  │
+│  │    → Generate command with platform note                                 │  │
+│  │                                                                          │  │
+│  │  If confidence < 0.7:                                                    │  │
+│  │    → Enter clarification flow                                            │  │
+│  │                                                                          │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│       │                                                                        │
+│       ▼ (In this case: HIGH confidence due to explicit "powershell")          │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                    OUTPUT: COMMAND WITH CONTEXT                          │  │
+│  │                                                                          │  │
+│  │  Command: . $PROFILE                                                     │  │
+│  │  Shell: PowerShell                                                       │  │
+│  │  Explanation: Reloads PowerShell profile in current session              │  │
+│  │  Note: Detected "powershell" in query, using PowerShell syntax           │  │
+│  │                                                                          │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Clarification Flow (Low Confidence Path)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                          CLARIFICATION FLOW (Confidence < 0.7)                │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                                │
+│  User Query: "clean up my disk"                                               │
+│       │                                                                        │
+│       ▼                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │  Reasoning: Ambiguous - multiple interpretations possible                │  │
+│  │  • Could mean: delete temp files, find large files, empty trash, etc.   │  │
+│  │  • Confidence: 0.35                                                      │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│       │                                                                        │
+│       ▼                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                    CLARIFICATION UI                                      │  │
+│  │                                                                          │  │
+│  │  I need a bit more context to help you clean up disk space.             │  │
+│  │                                                                          │  │
+│  │  1. What type of cleanup?                                               │  │
+│  │     [a] Find large files (to review and delete manually)                │  │
+│  │     [b] Delete temp/cache files                                         │  │
+│  │     [c] Find and remove duplicate files                                 │  │
+│  │     [d] Show disk usage breakdown                                       │  │
+│  │                                                                          │  │
+│  │  2. Which location?                                                      │  │
+│  │     [a] Current directory                                               │  │
+│  │     [b] Home directory (~)                                              │  │
+│  │     [c] System-wide (may require sudo)                                  │  │
+│  │                                                                          │  │
+│  │  Your choice (e.g., "1a 2b"): _                                         │  │
+│  │                                                                          │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│       │                                                                        │
+│       ▼ (User enters: "1a 2b")                                                │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │  Enhanced Query: "Find large files in home directory for review"        │  │
+│  │                                                                          │  │
+│  │  Generated Command: find ~ -type f -size +100M -exec ls -lh {} \;       │  │
+│  │  Confidence: 0.95                                                        │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Design
+
+#### 1. Ambiguity Analyzer
+
+```rust
+pub struct AmbiguityAnalyzer {
+    platform_detector: PlatformDetector,
+    keyword_extractor: KeywordExtractor,
+    domain_classifier: DomainClassifier,
+}
+
+impl AmbiguityAnalyzer {
+    /// Analyze a query and determine ambiguity type and questions
+    pub async fn analyze(&self, query: &str) -> AmbiguityAnalysis {
+        let platform_hints = self.platform_detector.detect_hints(query);
+        let keywords = self.keyword_extractor.extract(query);
+        let domain = self.domain_classifier.classify(query);
+
+        AmbiguityAnalysis {
+            platform_hints,
+            keywords,
+            domain,
+            ambiguity_type: self.determine_ambiguity_type(&platform_hints, &keywords, &domain),
+            suggested_questions: self.generate_questions(&platform_hints, &keywords, &domain),
+        }
+    }
+}
+
+pub struct AmbiguityAnalysis {
+    pub platform_hints: Vec<PlatformHint>,
+    pub keywords: Vec<String>,
+    pub domain: CommandDomain,
+    pub ambiguity_type: AmbiguityType,
+    pub suggested_questions: Vec<ClarificationQuestion>,
+}
+
+pub enum AmbiguityType {
+    PlatformAmbiguous,      // Which shell/OS?
+    ScopeAmbiguous,         // Which files/directories?
+    ActionAmbiguous,        // What operation exactly?
+    MissingContext,         // Need more parameters
+    DomainUnknown,          // Outside caro's expertise
+    SafetyConcern,          // Potentially destructive
+    HighConfidence,         // No clarification needed
+}
+```
+
+#### 2. Clarification Question Generator
+
+```rust
+pub struct ClarificationQuestion {
+    pub id: String,
+    pub question: String,
+    pub options: Vec<QuestionOption>,
+    pub allow_freeform: bool,
+    pub detected_hint: Option<String>,
+}
+
+pub struct QuestionOption {
+    pub key: char,           // 'a', 'b', 'c', etc.
+    pub label: String,       // "PowerShell"
+    pub description: String, // "Windows command shell"
+    pub maps_to: String,     // ". $PROFILE"
+}
+
+impl ClarificationQuestionGenerator {
+    pub fn generate_for_platform_ambiguity(&self, hints: &[PlatformHint]) -> Vec<ClarificationQuestion> {
+        vec![ClarificationQuestion {
+            id: "shell_type".to_string(),
+            question: "Which shell are you using?".to_string(),
+            options: vec![
+                QuestionOption {
+                    key: 'a',
+                    label: "PowerShell".to_string(),
+                    description: "Windows PowerShell or PowerShell Core".to_string(),
+                    maps_to: ". $PROFILE".to_string(),
+                },
+                QuestionOption {
+                    key: 'b',
+                    label: "bash".to_string(),
+                    description: "Bourne Again Shell (Linux/macOS)".to_string(),
+                    maps_to: "source ~/.bashrc".to_string(),
+                },
+                QuestionOption {
+                    key: 'c',
+                    label: "zsh".to_string(),
+                    description: "Z Shell (macOS default)".to_string(),
+                    maps_to: "source ~/.zshrc".to_string(),
+                },
+            ],
+            allow_freeform: false,
+            detected_hint: hints.first().map(|h| format!("Detected '{}' in your query", h.keyword)),
+        }]
+    }
+}
+```
+
+#### 3. Query Enhancer
+
+```rust
+pub struct QueryEnhancer {
+    template_engine: TemplateEngine,
+}
+
+impl QueryEnhancer {
+    /// Enhance the original query with clarification answers
+    pub fn enhance(&self, original: &str, answers: &[Answer]) -> EnhancedQuery {
+        let context = answers.iter()
+            .map(|a| format!("{}: {}", a.question_id, a.selected_option.label))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        EnhancedQuery {
+            original: original.to_string(),
+            enhanced: format!("{} [Context: {}]", original, context),
+            platform_override: answers.iter()
+                .find(|a| a.question_id == "shell_type")
+                .map(|a| a.selected_option.maps_to.clone()),
+        }
+    }
+}
+```
+
+---
+
+## User Experience Design
+
+### Terminal UI for Clarification
+
+```
+$ caro clean up disk space
+
+┌─ Clarification Needed ─────────────────────────────────────────────────┐
+│                                                                         │
+│  I can help you clean up disk space, but I need to know more:          │
+│                                                                         │
+│  ❓ What type of cleanup?                                               │
+│     [1] Find large files (for manual review)                           │
+│     [2] Delete temporary/cache files                                    │
+│     [3] Find duplicate files                                            │
+│     [4] Show disk usage breakdown                                       │
+│                                                                         │
+│  ❓ Which location?                                                     │
+│     [a] Current directory (.)                                          │
+│     [b] Home directory (~)                                              │
+│     [c] System-wide (requires sudo)                                     │
+│                                                                         │
+│  💡 Tip: Enter choices like "1b" or press Enter for default [1a]       │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Your choice: 1b
+
+✓ Generated command for: "Find large files in home directory"
+
+Command: find ~ -type f -size +100M -exec ls -lh {} \;
+```
+
+### PowerShell-Specific Example
+
+```
+$ caro how to reload powershell profile
+
+┌─ Quick Answer ─────────────────────────────────────────────────────────┐
+│                                                                         │
+│  💡 Detected "powershell" in your query                                │
+│                                                                         │
+│  Command: . $PROFILE                                                    │
+│                                                                         │
+│  This reloads your PowerShell profile in the current session.          │
+│                                                                         │
+│  📋 Alternative for other shells:                                       │
+│     • bash:  source ~/.bashrc                                          │
+│     • zsh:   source ~/.zshrc                                           │
+│     • fish:  source ~/.config/fish/config.fish                         │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Execute this command? [Y/n/e]:
+```
+
+### Error Recovery Flow
+
+```
+$ caro deploy to kubernetes
+
+┌─ Outside My Expertise ─────────────────────────────────────────────────┐
+│                                                                         │
+│  ⚠️  This request involves Kubernetes deployment, which requires        │
+│     complex orchestration beyond single shell commands.                 │
+│                                                                         │
+│  I can help with related tasks:                                         │
+│     [1] Check if kubectl is installed and configured                   │
+│     [2] List current Kubernetes contexts                                │
+│     [3] Show pods in current namespace                                  │
+│     [4] Get deployment status                                           │
+│                                                                         │
+│  For full deployment workflows, consider:                               │
+│     • kubectl apply -f <manifest.yaml>                                 │
+│     • Helm charts                                                       │
+│     • CI/CD pipelines                                                   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Would you like help with one of these alternatives? [1/2/3/4/n]:
+```
+
+---
+
+## Implementation Details
+
+### LLM Prompt for Reasoning
+
+```
+You are a shell command assistant. When given a user query, analyze it and respond with structured reasoning.
+
+OUTPUT FORMAT (JSON):
+{
+  "understood": true|false,
+  "confidence": 0.0-1.0,
+  "reasoning": {
+    "what_i_understood": "Brief summary of interpreted intent",
+    "what_is_unclear": ["List of ambiguous aspects"],
+    "ambiguity_type": "platform|scope|action|context|domain|safety|none",
+    "knowledge_gap": "Specific area where more context would help"
+  },
+  "command": "the_command_if_understood",
+  "clarification_questions": [
+    {
+      "id": "unique_id",
+      "question": "Human-readable question",
+      "options": [{"key": "a", "label": "Option A", "maps_to": "command_a"}]
+    }
+  ],
+  "platform_detected": "powershell|bash|zsh|fish|posix|unknown"
+}
+
+RULES:
+1. If query explicitly mentions a platform (e.g., "powershell"), set high confidence
+2. Generate clarification questions ONLY for truly ambiguous cases
+3. For known single-answer queries, just provide the command
+4. Always explain your reasoning in the "reasoning" field
+
+User Query: {{user_input}}
+Platform Context: {{platform_context}}
+```
+
+### Integration with Static Matcher
+
+The clarification system integrates as a fallback:
+
+```
+User Query
+    │
+    ▼
+┌──────────────────┐
+│ Static Matcher   │ ─── Match? ──► Return command
+└──────────────────┘
+    │ No match
+    ▼
+┌──────────────────┐
+│ LLM Generation   │ ─── High confidence? ──► Return command
+└──────────────────┘
+    │ Low confidence
+    ▼
+┌──────────────────┐
+│ Clarification    │ ─── Questions answered ──► Enhanced query ──► LLM retry
+└──────────────────┘
+    │ User declines
+    ▼
+"I couldn't understand your request. Try rephrasing or use 'caro --help'."
+```
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Better UX**: Users get specific guidance instead of dead-ends
+2. **Higher success rate**: Clarification increases command accuracy
+3. **Platform awareness**: System explicitly handles cross-platform queries
+4. **Transparency**: Reasoning shows users why caro is uncertain
+5. **Learning opportunity**: Clarification data improves future training
+
+### Negative
+
+1. **Increased latency**: Clarification adds interactive round-trips
+2. **Complexity**: More code paths to maintain and test
+3. **LLM dependency**: Reasoning quality depends on model capability
+4. **Edge cases**: Some queries may loop in clarification
+
+### Mitigation Strategies
+
+| Risk | Mitigation |
+|------|------------|
+| Latency | Cache common clarification patterns; stream questions while processing |
+| Complexity | Well-defined state machine; comprehensive tests |
+| LLM quality | Fallback to heuristic-based questions; A/B test prompts |
+| Infinite loops | Max 2 clarification rounds; escalate to "I can't help" |
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Just Improve Static Patterns
+
+**Description**: Add more patterns to static matcher instead of clarification
+**Pros**: Faster, deterministic, no LLM dependency
+**Cons**: Can't cover all variations; doesn't help truly ambiguous queries
+**Decision**: Partial - add PowerShell patterns, but clarification still needed
+
+### Alternative 2: Always Ask for Platform First
+
+**Description**: Start every session by asking user's shell
+**Pros**: Simple, avoids per-query detection
+**Cons**: Annoying UX for POSIX users (majority); state management needed
+**Decision**: Rejected - detect from query or default to POSIX
+
+### Alternative 3: Provide Multiple Commands
+
+**Description**: When ambiguous, show all possible commands
+**Pros**: No interaction needed
+**Cons**: Overwhelming; user may pick wrong one; no learning
+**Decision**: Partial - show alternatives in low-ambiguity cases
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| "Please clarify" responses | ~15% | <5% |
+| Command generation success rate | 60% | 85% |
+| User retry rate after failure | 40% | 15% |
+| Average interactions to success | 2.5 | 1.3 |
+| Cross-platform query success | 20% | 75% |
+
+---
+
+## References
+
+- [Spec 006: Intelligent Prompt Generation](../../specs/006-intelligent-prompt-generation/spec.md)
+- [ADR-004: Pre-Processing Pipeline](./ADR-004-pre-processing-pipeline.md)
+- [PowerShell Profile Documentation](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles)
+
+---
+
+*This ADR was authored in January 2026 and defines the intelligent clarification UX for caro.*

--- a/docs/design/clarification-interface-design.md
+++ b/docs/design/clarification-interface-design.md
@@ -1,0 +1,691 @@
+# Clarification Interface Design
+
+**Technical Design Document**
+
+## Overview
+
+This document describes the reasoning-based prompt improvement interface for caro. When caro cannot confidently generate a command, it should use structured reasoning to understand WHY the query is ambiguous and help the user refine their request.
+
+## Current Behavior (Problem)
+
+```
+$ caro how to reload powershell profile?
+Command:
+  echo 'Please clarify your request'
+
+Execute this command?:
+  Yes - execute
+> No - skip
+  Edit - modify in shell
+```
+
+**Issues:**
+1. No explanation of what's unclear
+2. No guidance on how to improve the query
+3. Unhelpful fallback command
+4. Dead-end user experience
+
+## Proposed Behavior (Solution)
+
+### Scenario 1: Platform-Detected Query
+
+When the query explicitly mentions a platform:
+
+```
+$ caro how to reload powershell profile?
+
+┌─ Command Generated ────────────────────────────────────────────────────┐
+│                                                                         │
+│  Detected: PowerShell environment                                      │
+│                                                                         │
+│  Command: . $PROFILE                                                    │
+│                                                                         │
+│  Reloads your PowerShell profile configuration in the current session. │
+│                                                                         │
+│  Alternatives for other shells:                                         │
+│    bash  → source ~/.bashrc                                            │
+│    zsh   → source ~/.zshrc                                             │
+│    fish  → source ~/.config/fish/config.fish                           │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Execute? [Y]es / [n]o / [e]dit:
+```
+
+### Scenario 2: Ambiguous Query with Clarification
+
+When the query is ambiguous and needs clarification:
+
+```
+$ caro clean up my disk
+
+┌─ Clarification Needed ─────────────────────────────────────────────────┐
+│                                                                         │
+│  I can help you clean up disk space, but I need more context:          │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐ │
+│  │ 1. What type of cleanup?                                          │ │
+│  │    [a] Find large files (for review)                              │ │
+│  │    [b] Delete temp/cache files                                    │ │
+│  │    [c] Find duplicate files                                       │ │
+│  │    [d] Show disk usage breakdown                                  │ │
+│  └───────────────────────────────────────────────────────────────────┘ │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐ │
+│  │ 2. Where should I look?                                           │ │
+│  │    [a] Current directory (.)                                      │ │
+│  │    [b] Home directory (~)                                         │ │
+│  │    [c] Entire system (may require sudo)                           │ │
+│  └───────────────────────────────────────────────────────────────────┘ │
+│                                                                         │
+│  Enter choices (e.g., "1a 2b") or [s]kip:                              │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+> 1a 2b
+
+Command: find ~ -type f -size +100M -exec ls -lh {} \;
+Finds large files (>100MB) in your home directory.
+
+Execute? [Y]es / [n]o / [e]dit:
+```
+
+### Scenario 3: Outside Expertise
+
+When the request is outside caro's domain:
+
+```
+$ caro write a python script to parse JSON
+
+┌─ Outside My Expertise ─────────────────────────────────────────────────┐
+│                                                                         │
+│  This request involves writing code, which is beyond my scope.         │
+│                                                                         │
+│  I can help with related shell tasks:                                   │
+│    [1] Parse JSON with jq                                              │
+│    [2] Pretty-print a JSON file                                        │
+│    [3] Extract a field from JSON                                       │
+│                                                                         │
+│  For Python scripting, try:                                             │
+│    • GitHub Copilot                                                     │
+│    • ChatGPT                                                            │
+│    • Your IDE's AI assistant                                            │
+│                                                                         │
+│  Would you like help with one of the alternatives? [1/2/3/n]:          │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Scenario 4: Reasoning Mode (Verbose)
+
+When the user wants to understand caro's thinking:
+
+```
+$ caro --verbose "deploy my app"
+
+┌─ Reasoning ────────────────────────────────────────────────────────────┐
+│                                                                         │
+│  Analysis:                                                              │
+│    Understood: User wants to deploy an application                     │
+│    Confidence: 0.25 (low)                                              │
+│                                                                         │
+│  Ambiguity factors:                                                     │
+│    • Deployment target unknown (local, cloud, container?)              │
+│    • Application type unspecified (web, CLI, service?)                 │
+│    • Deployment method unclear (docker, k8s, rsync?)                   │
+│                                                                         │
+│  Ambiguity type: missing_context                                        │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─ Clarification Needed ─────────────────────────────────────────────────┐
+│                                                                         │
+│  [Questions would appear here...]                                       │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Structures
+
+### AmbiguityAnalysis
+
+```rust
+pub struct AmbiguityAnalysis {
+    /// Overall confidence score (0.0 - 1.0)
+    pub confidence: f64,
+
+    /// Type of ambiguity detected
+    pub ambiguity_type: AmbiguityType,
+
+    /// What we understood from the query
+    pub understood: String,
+
+    /// What remains unclear
+    pub unclear_aspects: Vec<String>,
+
+    /// Platform hints detected in query
+    pub platform_hints: Vec<PlatformHint>,
+
+    /// Generated clarification questions
+    pub questions: Vec<ClarificationQuestion>,
+
+    /// Partial answers if we can infer some
+    pub partial_answers: HashMap<String, String>,
+}
+
+pub enum AmbiguityType {
+    /// Query could apply to multiple shells/platforms
+    PlatformAmbiguous,
+    /// Unclear target files/directories/scope
+    ScopeAmbiguous,
+    /// Multiple possible operations
+    ActionAmbiguous,
+    /// Need additional parameters
+    MissingContext,
+    /// Outside caro's expertise
+    DomainUnknown,
+    /// Potentially destructive operation
+    SafetyConcern,
+    /// High confidence, no clarification needed
+    Clear,
+}
+```
+
+### ClarificationQuestion
+
+```rust
+pub struct ClarificationQuestion {
+    /// Unique identifier for this question
+    pub id: String,
+
+    /// Human-readable question text
+    pub question: String,
+
+    /// Available options
+    pub options: Vec<QuestionOption>,
+
+    /// Allow freeform text input
+    pub allow_freeform: bool,
+
+    /// Detected hint from the query (if any)
+    pub detected_hint: Option<String>,
+}
+
+pub struct QuestionOption {
+    /// Single character key (a, b, c, d)
+    pub key: char,
+
+    /// Display label
+    pub label: String,
+
+    /// Description of what this option does
+    pub description: Option<String>,
+
+    /// What this option maps to in the enhanced query
+    pub maps_to: String,
+}
+```
+
+### ClarificationResponse
+
+```rust
+pub struct ClarificationResponse {
+    /// Questions that were answered
+    pub answers: Vec<Answer>,
+
+    /// Enhanced query after applying answers
+    pub enhanced_query: String,
+
+    /// Platform override if detected
+    pub platform_override: Option<ShellType>,
+}
+
+pub struct Answer {
+    /// Question ID
+    pub question_id: String,
+
+    /// Selected option (or freeform text)
+    pub selection: AnswerSelection,
+}
+
+pub enum AnswerSelection {
+    /// User selected an option
+    Option(char),
+    /// User provided freeform text
+    Freeform(String),
+    /// User skipped this question
+    Skipped,
+}
+```
+
+## UI Components
+
+### Terminal Renderer
+
+```rust
+pub struct ClarificationRenderer {
+    /// Terminal width for box drawing
+    width: usize,
+
+    /// Color support level
+    colors: ColorSupport,
+}
+
+impl ClarificationRenderer {
+    /// Render a clarification question box
+    pub fn render_questions(&self, analysis: &AmbiguityAnalysis) -> String {
+        let mut output = String::new();
+
+        // Draw header
+        output.push_str(&self.draw_header("Clarification Needed"));
+
+        // Draw explanation
+        output.push_str(&self.wrap_text(&analysis.explanation()));
+        output.push('\n');
+
+        // Draw each question
+        for (i, question) in analysis.questions.iter().enumerate() {
+            output.push_str(&self.draw_question(i + 1, question));
+        }
+
+        // Draw input prompt
+        output.push_str(&self.draw_input_prompt());
+
+        output
+    }
+
+    /// Render a detected platform note
+    pub fn render_platform_detected(&self, platform: &str, command: &str) -> String {
+        // ... render platform-detected box
+    }
+
+    /// Render an outside-expertise message
+    pub fn render_outside_expertise(&self, alternatives: &[Alternative]) -> String {
+        // ... render alternatives box
+    }
+}
+```
+
+### Input Handler
+
+```rust
+pub struct ClarificationInputHandler {
+    /// Questions being answered
+    questions: Vec<ClarificationQuestion>,
+}
+
+impl ClarificationInputHandler {
+    /// Parse user input like "1a 2b" or "1a,2b" or "a b"
+    pub fn parse_input(&self, input: &str) -> Result<Vec<Answer>, InputError> {
+        // Handle formats:
+        // "1a 2b" - numbered question + option
+        // "a b" - just options (in order)
+        // "1a, 2b" - with comma separation
+        // "s" or "skip" - skip clarification
+
+        let input = input.trim().to_lowercase();
+
+        if input == "s" || input == "skip" {
+            return Ok(vec![]);  // Skip clarification
+        }
+
+        // Parse input tokens
+        let tokens: Vec<&str> = input.split(|c: char| c.is_whitespace() || c == ',')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let mut answers = Vec::new();
+
+        for token in tokens {
+            let answer = self.parse_token(token)?;
+            answers.push(answer);
+        }
+
+        Ok(answers)
+    }
+
+    fn parse_token(&self, token: &str) -> Result<Answer, InputError> {
+        // Parse "1a" format (question number + option)
+        if let Some(caps) = Regex::new(r"^(\d)([a-d])$").unwrap().captures(token) {
+            let q_num: usize = caps[1].parse().unwrap();
+            let option = caps[2].chars().next().unwrap();
+
+            if q_num < 1 || q_num > self.questions.len() {
+                return Err(InputError::InvalidQuestionNumber(q_num));
+            }
+
+            let question = &self.questions[q_num - 1];
+            if !question.options.iter().any(|o| o.key == option) {
+                return Err(InputError::InvalidOption(option));
+            }
+
+            return Ok(Answer {
+                question_id: question.id.clone(),
+                selection: AnswerSelection::Option(option),
+            });
+        }
+
+        // Parse single letter (option only, assume order)
+        if token.len() == 1 {
+            let option = token.chars().next().unwrap();
+            // ... handle single option
+        }
+
+        Err(InputError::InvalidFormat(token.to_string()))
+    }
+}
+```
+
+## Integration Points
+
+### Agent Loop Integration
+
+The clarification system integrates into the existing agent loop:
+
+```rust
+// In src/agent/mod.rs
+
+pub async fn generate_command(&self, request: CommandRequest) -> Result<GeneratedCommand, GeneratorError> {
+    // 1. Try static matcher first
+    if let Ok(cmd) = self.static_matcher.generate_command(&request).await {
+        return Ok(cmd);
+    }
+
+    // 2. Try LLM generation
+    let result = self.backend.generate_command(&request).await?;
+
+    // 3. Check confidence and potentially clarify
+    if result.confidence_score < self.config.clarification_threshold {
+        // Analyze ambiguity
+        let analysis = self.ambiguity_analyzer.analyze(&request.input).await?;
+
+        // If clarification questions available, enter clarification flow
+        if !analysis.questions.is_empty() {
+            return self.handle_clarification(request, analysis).await;
+        }
+    }
+
+    Ok(result)
+}
+
+async fn handle_clarification(
+    &self,
+    original_request: CommandRequest,
+    analysis: AmbiguityAnalysis,
+) -> Result<GeneratedCommand, GeneratorError> {
+    // Render clarification UI
+    let renderer = ClarificationRenderer::new();
+    let ui = renderer.render_questions(&analysis);
+
+    // Get user input
+    println!("{}", ui);
+    let input = self.read_user_input()?;
+
+    // Parse answers
+    let handler = ClarificationInputHandler::new(&analysis.questions);
+    let answers = handler.parse_input(&input)?;
+
+    // If user skipped, return best guess
+    if answers.is_empty() {
+        return self.generate_best_guess(&original_request).await;
+    }
+
+    // Enhance query with answers
+    let enhancer = QueryEnhancer::new();
+    let enhanced = enhancer.enhance(&original_request.input, &answers);
+
+    // Retry generation with enhanced query
+    let enhanced_request = CommandRequest::new(&enhanced.enhanced_query, original_request.shell);
+    self.backend.generate_command(&enhanced_request).await
+}
+```
+
+### LLM Prompt Integration
+
+The LLM prompt includes instructions for reasoning output:
+
+```
+You are a shell command assistant. Analyze the user's query and respond with structured JSON.
+
+OUTPUT FORMAT:
+{
+  "understood": true|false,
+  "confidence": 0.0-1.0,
+  "reasoning": {
+    "what_understood": "Brief summary of interpreted intent",
+    "unclear_aspects": ["List of ambiguous aspects"],
+    "ambiguity_type": "platform|scope|action|context|domain|safety|clear"
+  },
+  "command": "the_command_if_understood",
+  "clarification_questions": [
+    {
+      "id": "unique_id",
+      "question": "Human-readable question",
+      "options": [
+        {"key": "a", "label": "Option A", "maps_to": "command_variant_a"},
+        {"key": "b", "label": "Option B", "maps_to": "command_variant_b"}
+      ]
+    }
+  ],
+  "platform_detected": "powershell|bash|zsh|fish|posix|unknown"
+}
+
+RULES:
+1. If query explicitly mentions a platform (e.g., "powershell"), set high confidence
+2. Generate clarification questions ONLY for truly ambiguous cases
+3. For known single-answer queries, just provide the command
+4. Always explain reasoning in the "reasoning" field
+
+User Query: {{user_input}}
+```
+
+## Question Templates
+
+Pre-defined templates for common ambiguity types:
+
+### Platform Questions
+
+```yaml
+# templates/questions/platform.yaml
+id: shell_type
+question: "Which shell are you using?"
+options:
+  - key: a
+    label: PowerShell
+    description: Windows PowerShell or PowerShell Core
+  - key: b
+    label: bash
+    description: Bourne Again Shell (Linux/macOS)
+  - key: c
+    label: zsh
+    description: Z Shell (macOS default)
+  - key: d
+    label: fish
+    description: Friendly Interactive Shell
+allow_freeform: false
+```
+
+### Scope Questions
+
+```yaml
+# templates/questions/scope.yaml
+id: target_location
+question: "Where should I look?"
+options:
+  - key: a
+    label: Current directory
+    description: The directory you're in (.)
+  - key: b
+    label: Home directory
+    description: Your home folder (~)
+  - key: c
+    label: Specific path
+    description: Enter a custom path
+allow_freeform: true
+```
+
+### Action Questions
+
+```yaml
+# templates/questions/action_cleanup.yaml
+id: cleanup_type
+question: "What kind of cleanup?"
+options:
+  - key: a
+    label: Find large files
+    description: List files over 100MB for review
+  - key: b
+    label: Delete temp files
+    description: Remove temporary and cache files
+  - key: c
+    label: Find duplicates
+    description: Identify duplicate files
+  - key: d
+    label: Usage breakdown
+    description: Show disk usage by folder
+allow_freeform: false
+```
+
+## Configuration
+
+Users can configure clarification behavior:
+
+```toml
+# ~/.config/caro/config.toml
+
+[clarification]
+# Enable/disable clarification prompts
+enabled = true
+
+# Confidence threshold for triggering clarification (0.0-1.0)
+threshold = 0.7
+
+# Maximum clarification rounds before giving up
+max_rounds = 2
+
+# Show reasoning output by default
+verbose = false
+
+[preferences]
+# Default shell for ambiguous queries
+default_shell = "bash"  # or "powershell", "zsh", "fish"
+```
+
+## Error Handling
+
+```rust
+pub enum ClarificationError {
+    /// User skipped clarification
+    Skipped,
+
+    /// User provided invalid input
+    InvalidInput(InputError),
+
+    /// Maximum clarification rounds exceeded
+    MaxRoundsExceeded,
+
+    /// Query still ambiguous after clarification
+    StillAmbiguous,
+
+    /// Outside caro's domain
+    OutsideDomain(String),
+}
+
+impl ClarificationError {
+    /// Generate a helpful error message
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::Skipped => "Clarification skipped. Using best guess.".to_string(),
+            Self::InvalidInput(e) => format!("Invalid input: {}. Try again.", e),
+            Self::MaxRoundsExceeded => "Couldn't understand after 2 rounds. Try rephrasing.".to_string(),
+            Self::StillAmbiguous => "Query still unclear. Please be more specific.".to_string(),
+            Self::OutsideDomain(domain) => format!("{} is outside my expertise.", domain),
+        }
+    }
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_input_numbered() {
+        let questions = vec![
+            ClarificationQuestion { id: "q1".to_string(), /* ... */ },
+            ClarificationQuestion { id: "q2".to_string(), /* ... */ },
+        ];
+
+        let handler = ClarificationInputHandler::new(&questions);
+
+        let answers = handler.parse_input("1a 2b").unwrap();
+        assert_eq!(answers.len(), 2);
+        assert_eq!(answers[0].question_id, "q1");
+        assert_eq!(answers[1].question_id, "q2");
+    }
+
+    #[test]
+    fn test_parse_input_skip() {
+        let handler = ClarificationInputHandler::new(&[]);
+
+        let answers = handler.parse_input("skip").unwrap();
+        assert!(answers.is_empty());
+    }
+
+    #[test]
+    fn test_platform_detection() {
+        let analyzer = AmbiguityAnalyzer::new();
+
+        let analysis = analyzer.analyze("reload powershell profile").await.unwrap();
+
+        assert!(analysis.platform_hints.contains(&PlatformHint::PowerShell));
+        assert!(analysis.confidence > 0.8);
+    }
+}
+```
+
+### Integration Tests
+
+```rust
+#[tokio::test]
+async fn test_clarification_flow_end_to_end() {
+    let agent = Agent::new_with_mock_backend();
+
+    // Simulate ambiguous query
+    let request = CommandRequest::new("clean up disk", ShellType::Bash);
+
+    // Should trigger clarification
+    let result = agent.analyze_for_clarification(&request).await;
+    assert!(result.is_clarification_needed());
+
+    // Provide answers
+    let answers = vec![
+        Answer { question_id: "cleanup_type".to_string(), selection: AnswerSelection::Option('a') },
+        Answer { question_id: "target_location".to_string(), selection: AnswerSelection::Option('b') },
+    ];
+
+    // Enhanced query should generate command
+    let enhanced = agent.enhance_query(&request, &answers).await;
+    let result = agent.generate_command(&enhanced).await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap().command.contains("find ~"));
+}
+```
+
+## Migration Path
+
+1. **Phase 1**: Add static patterns for PowerShell and shell profiles (done in this PR)
+2. **Phase 2**: Implement basic clarification UI without LLM reasoning
+3. **Phase 3**: Add LLM-based reasoning output and dynamic questions
+4. **Phase 4**: Add configuration and verbose mode
+5. **Phase 5**: Implement query enhancement and retry logic
+
+---
+
+*This design document was created in January 2026 for caro v1.3.0.*

--- a/docs/prd/PRD-001-intelligent-clarification.md
+++ b/docs/prd/PRD-001-intelligent-clarification.md
@@ -1,0 +1,519 @@
+# PRD-001: Intelligent Clarification System
+
+**Product Requirements Document**
+
+| Field | Value |
+|-------|-------|
+| **PRD ID** | PRD-001 |
+| **Status** | Draft |
+| **Created** | January 2026 |
+| **Authors** | Caro Product Team |
+| **Priority** | P1 - High |
+| **Target Release** | v1.3.0 |
+
+---
+
+## Executive Summary
+
+### Problem Statement
+
+Caro currently provides an unhelpful response when it cannot confidently translate a user query to a shell command:
+
+```
+Command: echo 'Please clarify your request'
+```
+
+This creates a frustrating user experience with no actionable guidance. Users must guess what went wrong and blindly retry, leading to abandonment and poor product perception.
+
+**Real Example:**
+```
+PS C:\Users\User> caro how to reload powershell profile?
+Command:
+  echo 'Please clarify your request'
+```
+
+The user wanted `. $PROFILE` (PowerShell's profile reload command) but got no help achieving their goal.
+
+### Proposed Solution
+
+Implement an **Intelligent Clarification System** that:
+1. Analyzes WHY a query is ambiguous using LLM reasoning
+2. Generates targeted, answerable clarification questions
+3. Enhances the original query with user responses
+4. Retries command generation with improved context
+5. Provides alternatives when the request is outside caro's expertise
+
+### Success Metrics
+
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| "Please clarify" rate | 15% | <5% | Responses containing clarification fallback |
+| First-try success rate | 60% | 80% | Commands that work on first generation |
+| Cross-platform success | 20% | 75% | PowerShell/CMD queries resolved correctly |
+| User retry rate | 40% | 15% | Users who rephrase after failure |
+| Net Promoter Score | 35 | 60 | User satisfaction survey |
+
+---
+
+## User Stories
+
+### US-001: Platform-Aware Clarification
+
+**As a** Windows PowerShell user
+**I want** caro to recognize when I'm asking about PowerShell
+**So that** I get the correct PowerShell command instead of a POSIX equivalent
+
+**Acceptance Criteria:**
+- [x] Query containing "powershell" triggers PowerShell mode
+- [x] System generates `. $PROFILE` for profile reload
+- [x] Alternative commands shown for other shells
+- [x] Platform detection explained in response
+
+**Example:**
+```
+$ caro how to reload powershell profile
+
+Detected: PowerShell query
+
+Command: . $PROFILE
+
+Alternatives:
+  bash:  source ~/.bashrc
+  zsh:   source ~/.zshrc
+```
+
+---
+
+### US-002: Interactive Clarification for Ambiguous Queries
+
+**As a** user with an ambiguous request
+**I want** caro to ask specific questions
+**So that** I can provide context and get the right command
+
+**Acceptance Criteria:**
+- [ ] System detects ambiguity score > 0.7
+- [ ] Generates 1-3 focused clarification questions
+- [ ] Questions have clear, selectable options
+- [ ] User can answer with single keystrokes (1a, 2b)
+- [ ] Enhanced query generates accurate command
+
+**Example:**
+```
+$ caro clean up disk space
+
+I need a bit more context:
+
+1. What type of cleanup?
+   [a] Find large files (manual review)
+   [b] Delete temp/cache files
+   [c] Find duplicates
+   [d] Show disk breakdown
+
+2. Which location?
+   [a] Current directory
+   [b] Home directory
+   [c] System-wide
+
+Your choice (e.g., "1a 2b"): 1b
+
+Command: find ~ -type f -size +100M -exec ls -lh {} \;
+```
+
+---
+
+### US-003: Transparent Reasoning
+
+**As a** power user
+**I want** to understand why caro is uncertain
+**So that** I can rephrase my query more effectively
+
+**Acceptance Criteria:**
+- [ ] Reasoning available via `--verbose` or `--debug` flag
+- [ ] Shows what caro understood vs. what's unclear
+- [ ] Displays confidence score
+- [ ] Lists ambiguity factors
+
+**Example:**
+```
+$ caro --verbose "deploy my app"
+
+Reasoning:
+  Understood: User wants to deploy an application
+  Unclear:
+    - Deployment target (local, cloud, container?)
+    - Application type (web, CLI, service?)
+    - Deployment method (docker, k8s, rsync?)
+  Confidence: 0.25
+  Ambiguity Type: missing_context
+```
+
+---
+
+### US-004: Graceful Limitations
+
+**As a** user asking about unsupported domains
+**I want** caro to explain its limitations
+**So that** I know to seek help elsewhere
+
+**Acceptance Criteria:**
+- [ ] System detects queries outside its expertise
+- [ ] Explains what it can and cannot help with
+- [ ] Suggests related queries it can handle
+- [ ] Points to external resources when appropriate
+
+**Example:**
+```
+$ caro write a python script to analyze logs
+
+This request involves writing code, which is outside my expertise.
+
+I can help with:
+  [1] Find log files matching a pattern
+  [2] Search for errors in log files
+  [3] Count occurrences of a pattern
+  [4] Tail log files in real-time
+
+For Python scripting, try:
+  - GitHub Copilot
+  - ChatGPT
+  - Your favorite IDE
+```
+
+---
+
+### US-005: Clarification Memory
+
+**As a** returning user
+**I want** caro to remember my platform preferences
+**So that** I don't have to specify my shell every time
+
+**Acceptance Criteria:**
+- [ ] Platform preference stored in config file
+- [ ] Preference can be set via `caro config set shell powershell`
+- [ ] Preference overridable per-query with `--shell` flag
+- [ ] Clear indication when using stored preference
+
+**Example:**
+```
+$ caro config set shell powershell
+Shell preference set to: PowerShell
+
+$ caro reload profile
+Using stored preference: PowerShell
+
+Command: . $PROFILE
+```
+
+---
+
+## Functional Requirements
+
+### FR-001: Ambiguity Detection
+
+| Requirement | Description | Priority |
+|-------------|-------------|----------|
+| FR-001.1 | Calculate ambiguity score (0.0-1.0) for every query | P1 |
+| FR-001.2 | Classify ambiguity type (platform, scope, action, context, domain, safety) | P1 |
+| FR-001.3 | Detect platform hints in query text (powershell, bash, zsh, etc.) | P1 |
+| FR-001.4 | Extract key intent keywords for analysis | P2 |
+| FR-001.5 | Identify safety-critical requests early | P1 |
+
+### FR-002: Clarification Question Generation
+
+| Requirement | Description | Priority |
+|-------------|-------------|----------|
+| FR-002.1 | Generate 1-3 questions maximum per interaction | P1 |
+| FR-002.2 | Each question has 2-4 selectable options | P1 |
+| FR-002.3 | Options map directly to command variants | P1 |
+| FR-002.4 | Allow freeform input for complex cases | P2 |
+| FR-002.5 | Show detected hints with questions | P2 |
+
+### FR-003: Query Enhancement
+
+| Requirement | Description | Priority |
+|-------------|-------------|----------|
+| FR-003.1 | Combine original query with clarification answers | P1 |
+| FR-003.2 | Override platform when explicitly answered | P1 |
+| FR-003.3 | Retry generation with enhanced context | P1 |
+| FR-003.4 | Limit to 2 clarification rounds maximum | P1 |
+| FR-003.5 | Fall back to helpful error after max rounds | P1 |
+
+### FR-004: User Interface
+
+| Requirement | Description | Priority |
+|-------------|-------------|----------|
+| FR-004.1 | Display questions in clear, boxed format | P1 |
+| FR-004.2 | Support single-keystroke answers (1a, 2b) | P1 |
+| FR-004.3 | Show "Detected: X" hint when platform identified | P1 |
+| FR-004.4 | Display alternatives for cross-platform commands | P2 |
+| FR-004.5 | Support `--no-clarify` flag to skip questions | P2 |
+
+### FR-005: Configuration
+
+| Requirement | Description | Priority |
+|-------------|-------------|----------|
+| FR-005.1 | Store shell preference in ~/.config/caro/config.toml | P2 |
+| FR-005.2 | `caro config set shell <shell>` command | P2 |
+| FR-005.3 | `caro config get shell` command | P2 |
+| FR-005.4 | Per-query override with `--shell <shell>` flag | P2 |
+| FR-005.5 | `caro config set clarify.enabled <bool>` | P3 |
+
+---
+
+## Non-Functional Requirements
+
+### NFR-001: Performance
+
+| Requirement | Description | Target |
+|-------------|-------------|--------|
+| NFR-001.1 | Ambiguity analysis latency | <200ms |
+| NFR-001.2 | Question generation latency | <500ms |
+| NFR-001.3 | Total clarification round-trip | <2s |
+| NFR-001.4 | Enhanced query generation | <2s |
+
+### NFR-002: Reliability
+
+| Requirement | Description | Target |
+|-------------|-------------|--------|
+| NFR-002.1 | Clarification flow completion rate | >95% |
+| NFR-002.2 | Graceful degradation on LLM failure | 100% |
+| NFR-002.3 | No infinite clarification loops | 100% |
+
+### NFR-003: Usability
+
+| Requirement | Description | Target |
+|-------------|-------------|--------|
+| NFR-003.1 | Questions require <10 words to answer | >90% |
+| NFR-003.2 | Single interaction clarification | >70% |
+| NFR-003.3 | Clear error messages on failure | 100% |
+
+---
+
+## Technical Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        CLARIFICATION SYSTEM                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  ┌──────────────────┐    ┌──────────────────┐    ┌───────────────┐  │
+│  │ Ambiguity        │───▶│ Question         │───▶│ Query         │  │
+│  │ Analyzer         │    │ Generator        │    │ Enhancer      │  │
+│  │                  │    │                  │    │               │  │
+│  │ • Score calc     │    │ • Template-based │    │ • Combine Q+A │  │
+│  │ • Type classify  │    │ • LLM-generated  │    │ • Platform    │  │
+│  │ • Platform detect│    │ • Validate opts  │    │   override    │  │
+│  └──────────────────┘    └──────────────────┘    └───────────────┘  │
+│           │                       │                      │           │
+│           └───────────────────────┴──────────────────────┘           │
+│                                   │                                   │
+│                                   ▼                                   │
+│                    ┌──────────────────────────┐                      │
+│                    │ Clarification UI         │                      │
+│                    │                          │                      │
+│                    │ • Terminal renderer      │                      │
+│                    │ • Input handler          │                      │
+│                    │ • State machine          │                      │
+│                    └──────────────────────────┘                      │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+User Query ──▶ Static Matcher ──(no match)──▶ LLM Generation
+                                                   │
+                                                   ▼
+                                            Confidence Check
+                                                   │
+                          ┌────────────────────────┴────────────────────┐
+                          │                                             │
+                    High (>0.7)                                   Low (<0.7)
+                          │                                             │
+                          ▼                                             ▼
+                   Return Command                          Ambiguity Analyzer
+                                                                   │
+                                                                   ▼
+                                                          Question Generator
+                                                                   │
+                                                                   ▼
+                                                          Clarification UI
+                                                                   │
+                                                                   ▼
+                                                          User Answers
+                                                                   │
+                                                                   ▼
+                                                          Query Enhancer
+                                                                   │
+                                                                   ▼
+                                                          LLM Generation (retry)
+                                                                   │
+                                                                   ▼
+                                                          Return Command
+```
+
+### Key Files to Create/Modify
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/clarification/mod.rs` | New | Module root |
+| `src/clarification/analyzer.rs` | New | Ambiguity analysis |
+| `src/clarification/questions.rs` | New | Question generation |
+| `src/clarification/enhancer.rs` | New | Query enhancement |
+| `src/clarification/ui.rs` | New | Terminal UI |
+| `src/agent/mod.rs` | Modify | Integrate clarification flow |
+| `src/prompts/smollm_prompt.rs` | Modify | Add reasoning output format |
+| `src/config.rs` | Modify | Add shell preference |
+| `src/backends/static_matcher.rs` | Modify | Add PowerShell patterns |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation (Week 1-2)
+
+**Deliverables:**
+1. Ambiguity analyzer with platform detection
+2. Basic question templates for common ambiguity types
+3. Simple terminal UI for clarification
+4. Integration into agent loop
+
+**Success Criteria:**
+- [ ] Platform detection works for "powershell", "bash", "zsh", "fish"
+- [ ] Clarification UI displays correctly in terminal
+- [ ] At least 5 ambiguity scenarios have question templates
+- [ ] End-to-end flow works for profile reload example
+
+### Phase 2: LLM Integration (Week 3-4)
+
+**Deliverables:**
+1. LLM-based reasoning output format
+2. Dynamic question generation from reasoning
+3. Query enhancement with LLM context
+4. Confidence-based routing
+
+**Success Criteria:**
+- [ ] Reasoning JSON output parsed correctly
+- [ ] LLM generates relevant clarification questions
+- [ ] Enhanced queries produce better commands
+- [ ] Confidence threshold tuned for optimal routing
+
+### Phase 3: Polish & Config (Week 5-6)
+
+**Deliverables:**
+1. Shell preference configuration
+2. `--verbose` reasoning output
+3. `--no-clarify` flag
+4. Graceful limitations handling
+5. Comprehensive testing
+
+**Success Criteria:**
+- [ ] All config commands work correctly
+- [ ] Verbose mode shows full reasoning
+- [ ] No-clarify mode skips to best guess
+- [ ] Outside-expertise queries handled gracefully
+- [ ] >90% test coverage on clarification module
+
+---
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| LLM reasoning quality varies | High | Medium | Fallback to template questions |
+| Clarification loops | Medium | High | Max 2 rounds, force exit after |
+| User abandonment during clarification | Medium | Medium | Single-keystroke answers, skip option |
+| Platform detection false positives | Low | Medium | Explicit override option |
+| Latency increase | High | Medium | Stream questions, cache patterns |
+
+---
+
+## Appendix A: PowerShell Profile Commands
+
+Common PowerShell profile operations for reference:
+
+| Operation | Command |
+|-----------|---------|
+| Reload current user profile | `. $PROFILE` |
+| Reload all profiles | `& $PROFILE.CurrentUserAllHosts` |
+| View profile path | `$PROFILE` |
+| Edit profile | `notepad $PROFILE` |
+| Check if profile exists | `Test-Path $PROFILE` |
+| Create profile | `New-Item -Path $PROFILE -Type File -Force` |
+
+---
+
+## Appendix B: Clarification Question Templates
+
+### Platform Ambiguity
+
+```yaml
+question_id: shell_type
+question: "Which shell are you using?"
+options:
+  - key: a
+    label: PowerShell
+    maps_to: powershell_variant
+  - key: b
+    label: bash
+    maps_to: bash_variant
+  - key: c
+    label: zsh
+    maps_to: zsh_variant
+  - key: d
+    label: Other
+    freeform: true
+```
+
+### Scope Ambiguity
+
+```yaml
+question_id: target_location
+question: "Where should I look?"
+options:
+  - key: a
+    label: Current directory
+    maps_to: "."
+  - key: b
+    label: Home directory
+    maps_to: "~"
+  - key: c
+    label: Specific path
+    freeform: true
+```
+
+### Action Ambiguity
+
+```yaml
+question_id: cleanup_type
+question: "What kind of cleanup?"
+options:
+  - key: a
+    label: Find large files
+    maps_to: find_large
+  - key: b
+    label: Delete temp files
+    maps_to: delete_temp
+  - key: c
+    label: Show usage breakdown
+    maps_to: show_usage
+```
+
+---
+
+## Appendix C: Competitive Analysis
+
+| Feature | caro (current) | caro (proposed) | GitHub Copilot CLI | tldr |
+|---------|----------------|-----------------|-------------------|------|
+| Clarification questions | No | Yes | No | No |
+| Platform detection | Partial | Yes | Yes | No |
+| Reasoning transparency | No | Yes | No | No |
+| Cross-platform commands | No | Yes | Yes | Yes |
+| Configuration memory | No | Yes | Yes | No |
+
+---
+
+*This PRD was authored in January 2026 for caro v1.3.0 planning.*


### PR DESCRIPTION
Addresses poor UX when caro cannot confidently generate a command. Adds comprehensive design documents and shell profile reload patterns.

**New Documents:**
1. **ADR-005**: Architecture decision for intelligent clarification UX
   - Reasoning-based ambiguity detection
   - Platform-aware clarification questions
   - Query enhancement workflow

2. **PRD-001**: Product requirements
   - User stories for platform detection and interactive clarification
   - Functional and non-functional requirements
   - Implementation phases

3. **Technical Design**: Clarification interface design
   - Data structures for ambiguity analysis
   - Terminal UI mockups
   - Integration points with agent loop

**New Features:**
4. **Static Patterns**: Cross-platform shell profile reload commands
   - PowerShell: `. $PROFILE`
   - bash: `source ~/.bashrc`
   - zsh: `source ~/.zshrc`
   - fish: `source ~/.config/fish/config.fish`
   - Generic shell profile with platform-aware defaults

**Test Plan:**
- ✓ All 20 static_matcher tests pass
- ✓ New PowerShell profile reload tests added
- ✓ Cross-platform tests for bash, zsh, fish profiles

**Fixes:** "how to reload powershell profile?" → Now correctly returns: `. $PROFILE`

**Type:** Feature + Documentation
**Lines changed:** +2,010

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross‑platform shell profile reload patterns and introduces the intelligent clarification UX design so users get the right command instead of “Please clarify.”
Fixes the PowerShell case by returning . $PROFILE.

- **New Features**
  - Static profile reload patterns: PowerShell (. $PROFILE), bash (source ~/.bashrc), zsh (source ~/.zshrc), fish (source ~/.config/fish/config.fish), plus generic defaults (GNU→bashrc, BSD→zshrc).
  - “How to reload powershell profile?” now resolves to . $PROFILE; tests added for PowerShell, bash, zsh, fish, and generic defaults.

<sup>Written for commit d3b1052d6fab6c4a2a8136b6a919488facfe9eb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

