### PR TITLE
fix(static_matcher): Skip pattern matching on Windows and fix debug display

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -136,6 +136,7 @@ impl AgentLoop {
                 GeneratorError::Internal { .. } => "internal_error",
                 GeneratorError::Unsafe { .. } => "unsafe_command",
                 GeneratorError::ValidationFailed { .. } => "validation_failed",
+                GeneratorError::NoMatch { .. } => "no_match",
             };
 
             crate::telemetry::emit_event(crate::telemetry::events::EventType::CommandGeneration {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -76,6 +76,9 @@ pub enum GeneratorError {
 
     #[error("Validation failed: {reason}")]
     ValidationFailed { reason: String },
+
+    #[error("No matching pattern found: {reason}")]
+    NoMatch { reason: String },
 }
 
 // Types are already public, no re-export needed

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -600,11 +600,17 @@ impl CliApp {
 
         // Collect debug info if verbose
         let debug_info = if args.verbose() {
-            let backend_info = self.backend.backend_info();
+            // Only show model name for actual LLM backends, not for static-matcher
+            let model_display = if generated.backend_used == "static-matcher" {
+                "N/A (pattern matching)".to_string()
+            } else {
+                let backend_info = self.backend.backend_info();
+                backend_info.model_name
+            };
             Some(format!(
                 "Backend: {}, Model: {}, Confidence: {:.2}, Safety: {:?}",
                 generated.backend_used,
-                backend_info.model_name,
+                model_display,
                 generated.confidence_score,
                 safety_level
             ))


### PR DESCRIPTION
Fixes two issues with the static matcher on Windows:

**Issue 1: Misleading debug info**
- Debug info now shows "N/A (pattern matching)" for model name when static-matcher is used
- Previously showed embedded LLM model name which was confusing

**Issue 2: Unix commands on Windows**
- Static matcher now returns NoMatch error for Windows shells (CMD, PowerShell)
- All patterns generate Unix/POSIX commands that don't work on Windows
- Allows embedded backend to handle Windows-specific command generation instead

**New Patterns Added:**
- "list images" → `docker images`
- "list containers" → `docker ps -a`

**Files modified:**
- `src/agent/mod.rs`
- `src/backends/mod.rs`
- `src/backends/static_matcher.rs`
- `src/cli/mod.rs`

**Type:** Bug Fix
**Lines changed:** +96 -2

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip static pattern matching on Windows to avoid generating unusable Unix commands, and fix the CLI debug display for static matcher. Adds patterns to list Docker images and containers.

- **Bug Fixes**
  - Static matcher returns NoMatch for CMD/PowerShell, letting the embedded backend generate Windows commands.
  - Debug info shows "N/A (pattern matching)" for the model when static matcher is used.

- **New Features**
  - Added Docker patterns: "list images" → docker images, "list containers" → docker ps -a.

<sup>Written for commit c1baebd6bf932104e71e524942c6668333e9fdb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

