### PR TITLE
fix(backends): Handle malformed JSON with unescaped quotes in LLM responses

### DIFF
--- a/src/backends/remote/exo.rs
+++ b/src/backends/remote/exo.rs
@@ -11,12 +11,19 @@
 // - Support for large models like llama-3.1-405b across device clusters
 
 use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use reqwest::{header, Client, Url};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError};
+
+/// Regex pattern to extract command from malformed JSON with unescaped quotes
+/// Handles cases like: {"cmd": "find . -type f -name "*.txt""}
+static CMD_EXTRACT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"\{\s*"cmd"\s*:\s*"(.+)"\s*\}"#).expect("Invalid regex pattern"));
 use crate::models::{CommandRequest, GeneratedCommand, RiskLevel};
 
 /// Default port for exo cluster API
@@ -254,6 +261,17 @@ Request: {}
                     if !cmd.is_empty() && !cmd.contains('{') && !cmd.contains('}') {
                         return Ok(cmd.to_string());
                     }
+                }
+            }
+        }
+
+        // Regex fallback: Handle malformed JSON with unescaped quotes
+        // e.g., {"cmd": "find . -type f -name "*.txt""}
+        if let Some(caps) = CMD_EXTRACT_REGEX.captures(response) {
+            if let Some(cmd_match) = caps.get(1) {
+                let cmd = cmd_match.as_str().trim();
+                if !cmd.is_empty() {
+                    return Ok(cmd.to_string());
                 }
             }
         }

--- a/src/backends/remote/vllm.rs
+++ b/src/backends/remote/vllm.rs
@@ -1,12 +1,19 @@
 // vLLM server backend implementation
 
 use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use reqwest::{header, Client, Url};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError};
+
+/// Regex pattern to extract command from malformed JSON with unescaped quotes
+/// Handles cases like: {"cmd": "find . -type f -name "*.txt""}
+static CMD_EXTRACT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"\{\s*"cmd"\s*:\s*"(.+)"\s*\}"#).expect("Invalid regex pattern"));
 use crate::models::{CommandRequest, GeneratedCommand, RiskLevel};
 
 /// vLLM API request format (OpenAI-compatible)
@@ -158,6 +165,17 @@ Request: {}
                     if !cmd.is_empty() && !cmd.contains('{') && !cmd.contains('}') {
                         return Ok(cmd.to_string());
                     }
+                }
+            }
+        }
+
+        // Regex fallback: Handle malformed JSON with unescaped quotes
+        // e.g., {"cmd": "find . -type f -name "*.txt""}
+        if let Some(caps) = CMD_EXTRACT_REGEX.captures(response) {
+            if let Some(cmd_match) = caps.get(1) {
+                let cmd = cmd_match.as_str().trim();
+                if !cmd.is_empty() {
+                    return Ok(cmd.to_string());
                 }
             }
         }


### PR DESCRIPTION
Fixes JSON parsing failures when LLMs output malformed JSON with unescaped nested quotes.

**Problem:**
LLMs sometimes output JSON with unescaped nested quotes like:
```json
{"cmd": "find . -type f -name "*.llm""}
```

This causes JSON parsing to fail completely.

**Solution:**
Added a regex-based fallback that extracts the command even when JSON is malformed, using a greedy pattern to capture everything between the first quote after `"cmd":` and the last `"}` at the end.

**Applied to all backends:**
- ✓ embedded
- ✓ ollama
- ✓ vllm
- ✓ exo

**Type:** Bug Fix
**Lines changed:** +81

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON parsing failures when LLMs return unescaped nested quotes by adding a regex fallback to extract the cmd value. Improves reliability across all backends when responses include patterns like "*.llm".

- **Bug Fixes**
  - Add regex fallback to extract cmd from malformed JSON when strict parsing fails.
  - Apply to embedded, ollama, vllm, and exo; includes a regression test for nested quotes.

<sup>Written for commit 6d4bc794e1a148fb7f5cc302af142b7480a5ede7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

