### PR TITLE
feat(setup): Add Oh My Zsh and Oh My Bash plugin support

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,72 @@
+# Caro Shell Plugins
+
+Shell plugin integrations for popular shell frameworks.
+
+## Automatic Installation
+
+When you install caro using the setup script:
+
+```bash
+bash <(curl -sSfL https://setup.caro.sh)
+```
+
+The installer automatically detects Oh My Zsh or Oh My Bash and installs the appropriate plugin.
+
+## Manual Installation
+
+### Oh My Zsh
+
+1. Clone or copy the plugin to your custom plugins directory:
+
+```bash
+mkdir -p ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/caro
+curl -fsSL https://raw.githubusercontent.com/wildcard/caro/main/plugins/oh-my-zsh/caro.plugin.zsh \
+  -o ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/caro/caro.plugin.zsh
+```
+
+2. Add `caro` to your plugins in `~/.zshrc`:
+
+```zsh
+plugins=(git caro)  # Add caro to your existing plugins
+```
+
+3. Restart your terminal or run `source ~/.zshrc`
+
+### Oh My Bash
+
+1. Clone or copy the plugin to your custom plugins directory:
+
+```bash
+mkdir -p ${OSH_CUSTOM:-~/.oh-my-bash/custom}/plugins/caro
+curl -fsSL https://raw.githubusercontent.com/wildcard/caro/main/plugins/oh-my-bash/caro.plugin.sh \
+  -o ${OSH_CUSTOM:-~/.oh-my-bash/custom}/plugins/caro/caro.plugin.sh
+```
+
+2. Add `caro` to your plugins in `~/.bashrc`:
+
+```bash
+plugins=(git caro)  # Add caro to your existing plugins
+```
+
+3. Restart your terminal or run `source ~/.bashrc`
+
+## What the Plugins Provide
+
+- **PATH Configuration**: Automatically adds `~/.local/bin` and `~/.cargo/bin` to your PATH
+- **Shell Completions**: Tab completion for caro commands
+- **Aliases**:
+  - `c` - shorthand for `caro`
+  - `cx` - `caro -x` (execute directly)
+  - `ce` - `caro -e` (explain command)
+  - `cs` - `caro -s` (safe/strict mode)
+- **Functions**:
+  - `crun "query"` - Generate command and prompt before executing
+  - `cexplain` - Explain your last command in natural language
+
+## Customization
+
+You can override the caro installation directory by setting:
+
+```bash
+export CARO_INSTALL_DIR=/custom/path
+```

--- a/plugins/oh-my-bash/caro.plugin.sh
+++ b/plugins/oh-my-bash/caro.plugin.sh
@@ -1,0 +1,49 @@
+# caro - Oh My Bash Plugin
+# Natural Language → Shell Commands
+# https://github.com/wildcard/caro
+
+# Add caro to PATH if not already present
+CARO_BIN="${CARO_INSTALL_DIR:-$HOME/.local/bin}"
+if [[ ":$PATH:" != *":$CARO_BIN:"* ]]; then
+    export PATH="$CARO_BIN:$PATH"
+fi
+
+# Also check cargo bin
+if [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]] && [[ -d "$HOME/.cargo/bin" ]]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# Verify caro is available
+if ! command -v caro &>/dev/null; then
+    echo "[caro] Warning: caro not found in PATH. Install with:"
+    echo "  bash <(curl -sSfL https://setup.caro.sh)"
+    return
+fi
+
+# Load completions
+if command -v caro &>/dev/null; then
+    eval "$(caro --completion bash 2>/dev/null)" || true
+fi
+
+# Aliases
+alias c='caro'
+alias cx='caro -x'      # Execute directly
+alias ce='caro -e'      # Explain command
+alias cs='caro -s'      # Safe mode (strict)
+
+# Quick execute with confirmation
+crun() {
+    local cmd
+    cmd=$(caro "$@") || return $?
+    echo "Execute: $cmd"
+    read -p "Run? [y/N] " reply
+    if [[ "$reply" =~ ^[Yy]$ ]]; then
+        eval "$cmd"
+    fi
+}
+
+# History integration - convert last command to natural language explanation
+cexplain() {
+    local last_cmd="${1:-$(fc -ln -1 2>/dev/null || history 1 | sed 's/^[ ]*[0-9]*[ ]*//')}"
+    caro -e "$last_cmd"
+}

--- a/plugins/oh-my-zsh/caro.plugin.zsh
+++ b/plugins/oh-my-zsh/caro.plugin.zsh
@@ -1,0 +1,48 @@
+# caro - Oh My Zsh Plugin
+# Natural Language → Shell Commands
+# https://github.com/wildcard/caro
+
+# Add caro to PATH if not already present
+typeset -U path  # Ensure unique entries
+path=(
+    "${CARO_INSTALL_DIR:-$HOME/.local/bin}"
+    "$HOME/.cargo/bin"
+    $path
+)
+export PATH
+
+# Verify caro is available
+if (( ! $+commands[caro] )); then
+    echo "[caro] Warning: caro not found in PATH. Install with:"
+    echo "  bash <(curl -sSfL https://setup.caro.sh)"
+    return
+fi
+
+# Load completions
+if (( $+commands[caro] )); then
+    eval "$(caro --completion zsh 2>/dev/null)" || true
+fi
+
+# Aliases
+alias c='caro'
+alias cx='caro -x'      # Execute directly
+alias ce='caro -e'      # Explain command
+alias cs='caro -s'      # Safe mode (strict)
+
+# Quick execute with confirmation
+crun() {
+    local cmd
+    cmd=$(caro "$@") || return $?
+    echo "Execute: $cmd"
+    echo -n "Run? [y/N] "
+    read -r reply
+    if [[ "$reply" =~ ^[Yy]$ ]]; then
+        eval "$cmd"
+    fi
+}
+
+# History integration - convert last command to natural language explanation
+cexplain() {
+    local last_cmd="${1:-$(fc -ln -1)}"
+    caro -e "$last_cmd"
+}


### PR DESCRIPTION
Adds shell framework plugins providing cleaner integration for users with Oh My Zsh or Oh My Bash.

**New Plugin Features:**
- ✓ Automatic PATH configuration for ~/.local/bin and ~/.cargo/bin
- ✓ Shell completions via `caro --completion`
- ✓ Useful aliases: `c`, `cx` (execute), `ce` (explain), `cs` (safe mode)
- ✓ Helper functions: `crun` (run with confirmation), `cexplain` (explain last cmd)

**Installer Changes:**
- ✓ Auto-detect Oh My Zsh (~/.oh-my-zsh) and Oh My Bash (~/.oh-my-bash)
- ✓ Download and install appropriate plugin to custom plugins directory
- ✓ Guide user to enable plugin in their shell config
- ✓ Fall back to direct PATH configuration if no plugin manager found

**New Files:**
- `plugins/README.md` - Plugin documentation
- `plugins/oh-my-bash/caro.plugin.sh` - Oh My Bash plugin
- `plugins/oh-my-zsh/caro.plugin.zsh` - Oh My Zsh plugin

**Updated:** `setup.sh` - Plugin auto-detection and installation

**Benefit:** More native experience for users with shell frameworks while maintaining compatibility with vanilla bash/zsh/fish.

**Type:** Feature
**Lines changed:** +270 -2

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Oh My Zsh and Oh My Bash plugins with completions, aliases, and PATH setup. The installer now auto-detects and installs these plugins or configures PATH directly for a smoother first run.

- **New Features**
  - Oh My Zsh/Oh My Bash plugins: PATH for ~/.local/bin and ~/.cargo/bin, completions, aliases (c, cx, ce, cs), functions (crun, cexplain).
  - Installer: detects OMZ/OMB and installs the plugin; falls back to adding PATH via add_to_path; shows shell-specific reload hints; warns about legacy cmdai alias.

- **Migration**
  - If using OMZ/OMB, add `caro` to your plugins in ~/.zshrc or ~/.bashrc.
  - Open a new terminal or source your shell config.

<sup>Written for commit 293f4e458f063159011da97c3b7356104610a12e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

