### PR TITLE
feat: Add explanation mode with --explain flag for educational command breakdowns

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -77,6 +77,12 @@ pub struct CliResult {
     pub stdout: Option<String>,
     pub stderr: Option<String>,
     pub execution_error: Option<String>,
+    /// Whether explanation mode is enabled
+    #[serde(default)]
+    pub explain_mode: bool,
+    /// Detailed explanation for explain mode
+    #[serde(default)]
+    pub detailed_explanation: Option<crate::prompts::CommandExplanation>,
 }
 
 /// Supported output formats
@@ -135,6 +141,7 @@ pub trait IntoCliArgs {
     fn dry_run(&self) -> bool;
     fn interactive(&self) -> bool;
     fn force_llm(&self) -> bool;
+    fn explain(&self) -> bool;
 }
 
 impl CliApp {
@@ -537,6 +544,16 @@ impl CliApp {
 
         let total_time = start_time.elapsed();
 
+        // Generate detailed explanation if explain mode is enabled
+        let explain_mode = args.explain();
+        let detailed_explanation = if explain_mode {
+            use crate::prompts::ExplainerPromptBuilder;
+            let explainer = ExplainerPromptBuilder::new(CapabilityProfile::detect().await);
+            Some(explainer.create_explanation(&generated.command, &prompt))
+        } else {
+            None
+        };
+
         Ok(CliResult {
             generated_command: generated.command,
             explanation: generated.explanation,
@@ -572,6 +589,8 @@ impl CliApp {
             stdout,
             stderr,
             execution_error,
+            explain_mode,
+            detailed_explanation,
         })
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -629,6 +629,9 @@ pub struct UserConfiguration {
     pub cache_max_size_gb: u64,
     pub log_rotation_days: u32,
     pub telemetry: crate::telemetry::TelemetryConfig,
+    /// Default generation profile (generator or explainer)
+    #[serde(default)]
+    pub generation_profile: crate::prompts::profiles::GenerationProfile,
 }
 
 impl Default for UserConfiguration {
@@ -642,6 +645,7 @@ impl Default for UserConfiguration {
             cache_max_size_gb: 10,
             log_rotation_days: 7,
             telemetry: crate::telemetry::TelemetryConfig::default(),
+            generation_profile: crate::prompts::profiles::GenerationProfile::default(),
         }
     }
 }
@@ -680,6 +684,7 @@ pub struct UserConfigurationBuilder {
     cache_max_size_gb: u64,
     log_rotation_days: u32,
     telemetry: crate::telemetry::TelemetryConfig,
+    generation_profile: crate::prompts::profiles::GenerationProfile,
 }
 
 impl Default for UserConfigurationBuilder {
@@ -700,6 +705,7 @@ impl UserConfigurationBuilder {
             cache_max_size_gb: defaults.cache_max_size_gb,
             log_rotation_days: defaults.log_rotation_days,
             telemetry: defaults.telemetry,
+            generation_profile: defaults.generation_profile,
         }
     }
 
@@ -743,6 +749,14 @@ impl UserConfigurationBuilder {
         self
     }
 
+    pub fn generation_profile(
+        mut self,
+        profile: crate::prompts::profiles::GenerationProfile,
+    ) -> Self {
+        self.generation_profile = profile;
+        self
+    }
+
     pub fn build(self) -> Result<UserConfiguration, String> {
         let config = UserConfiguration {
             default_shell: self.default_shell,
@@ -753,6 +767,7 @@ impl UserConfigurationBuilder {
             cache_max_size_gb: self.cache_max_size_gb,
             log_rotation_days: self.log_rotation_days,
             telemetry: self.telemetry,
+            generation_profile: self.generation_profile,
         };
         config.validate()?;
         Ok(config)

--- a/src/prompts/explainer_prompt.rs
+++ b/src/prompts/explainer_prompt.rs
@@ -1,0 +1,572 @@
+//! Explainer Prompt System
+//!
+//! This module provides a prompt system optimized for educational command explanations.
+//! Unlike the generator prompt which focuses on quick command synthesis, this system
+//! provides detailed explanations of commands, options, and alternatives.
+//!
+//! # Design Philosophy
+//!
+//! The explainer prompt is inspired by how expert developers explain commands:
+//!
+//! 1. **Identify the Tool**: Recognize the relevant Unix utility for the task
+//! 2. **Explain the Command**: Break down what the command does
+//! 3. **Describe Options**: Explain each flag and option used
+//! 4. **Show Examples**: Provide variations for different use cases
+//!
+//! # Example Output
+//!
+//! For "find files modified in the last 24 hours":
+//!
+//! ```text
+//! Use `find` with time-based filters:
+//!
+//!   # Last 24 hours
+//!   find . -type f -mtime -1
+//!
+//!   # With file details
+//!   find . -type f -mtime -1 -ls
+//!
+//! The `-mtime -1` means "modified less than 1 day ago".
+//! Use `-mmin` for minute precision (1440 minutes = 24 hours).
+//! ```
+
+use super::capability_profile::{CapabilityProfile, ProfileType};
+use super::profiles::{
+    AlternativeCommand, CommandExplanation, OptionExplanation, ProfileConfig, UsageExample,
+};
+
+/// Builder for explainer-mode prompts
+///
+/// This prompt builder generates responses that explain commands in detail,
+/// suitable for users who want to learn how shell commands work.
+pub struct ExplainerPromptBuilder {
+    profile: CapabilityProfile,
+    #[allow(dead_code)]
+    config: ProfileConfig,
+    #[allow(dead_code)]
+    current_directory: Option<String>,
+    #[allow(dead_code)]
+    available_context: Option<String>,
+}
+
+impl ExplainerPromptBuilder {
+    /// Create a new explainer prompt builder with the given capability profile
+    pub fn new(profile: CapabilityProfile) -> Self {
+        Self {
+            profile,
+            config: ProfileConfig::explainer(),
+            current_directory: None,
+            available_context: None,
+        }
+    }
+
+    /// Create with custom profile config
+    pub fn with_config(profile: CapabilityProfile, config: ProfileConfig) -> Self {
+        Self {
+            profile,
+            config,
+            current_directory: None,
+            available_context: None,
+        }
+    }
+
+    /// Create an Ubuntu-optimized explainer prompt builder
+    pub fn ubuntu() -> Self {
+        Self::new(CapabilityProfile::ubuntu())
+    }
+
+    /// Set current working directory context
+    pub fn current_directory(mut self, dir: impl Into<String>) -> Self {
+        self.current_directory = Some(dir.into());
+        self
+    }
+
+    /// Set additional context
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.available_context = Some(context.into());
+        self
+    }
+
+    /// Build the system prompt for explanation mode
+    pub fn build_system_prompt(&self) -> String {
+        let mut prompt = String::new();
+
+        // Role definition
+        prompt.push_str(&self.build_role_section());
+        prompt.push('\n');
+
+        // Output format for explanations
+        prompt.push_str(&self.build_output_format());
+        prompt.push('\n');
+
+        // Tool knowledge base
+        prompt.push_str(&self.build_tool_knowledge());
+        prompt.push('\n');
+
+        // Platform context
+        prompt.push_str(&self.build_platform_context());
+        prompt.push('\n');
+
+        // Few-shot examples
+        prompt.push_str(&self.build_examples());
+        prompt.push('\n');
+
+        prompt.push_str("\nRespond to the next user message using the format above.\n");
+
+        prompt
+    }
+
+    /// Format a complete chat prompt with system and user messages
+    pub fn format_chat(&self, user_query: &str) -> String {
+        let system_prompt = self.build_system_prompt();
+
+        format!(
+            "<|im_start|>system\n{}<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n<|im_start|>assistant\n",
+            system_prompt, user_query
+        )
+    }
+
+    fn build_role_section(&self) -> String {
+        r#"You are ShellCommandExplainer, an expert Unix systems educator.
+
+GOAL: Given a user's question about shell commands, provide:
+1. The BEST command for their task
+2. A CLEAR explanation of how it works
+3. Examples showing common variations
+
+Your explanations should be concise yet educational, like a senior engineer helping a colleague."#
+            .to_string()
+    }
+
+    fn build_output_format(&self) -> String {
+        r#"OUTPUT FORMAT:
+
+Start with a brief intro identifying the relevant tool, then show commands with comments:
+
+```
+Use `<tool>` with <key concept>:
+
+  # <description>
+  <command>
+
+  # <variation description>
+  <command variation>
+```
+
+After commands, add a brief explanation of key options.
+
+RULES:
+1. Start response with "Use `<tool>`..." identifying the main Unix utility
+2. Show 2-4 command examples with # comments explaining each
+3. End with 1-2 sentences explaining the most important options
+4. Keep total response under 15 lines
+5. Focus on POSIX-compatible commands when possible"#
+            .to_string()
+    }
+
+    fn build_tool_knowledge(&self) -> String {
+        let mut section = String::from("[TOOL KNOWLEDGE]\n");
+        section.push_str("Common tasks and their primary tools:\n\n");
+
+        section.push_str("FINDING FILES:\n");
+        section.push_str("- find: locate files by name, type, size, date, permissions\n");
+        section.push_str("  Key options: -name, -type f/d, -size +/-N, -mtime +/-N, -exec\n\n");
+
+        section.push_str("SEARCHING TEXT:\n");
+        section.push_str("- grep: search file contents for patterns\n");
+        section.push_str("  Key options: -r (recursive), -i (ignore case), -n (line numbers), -l (files only)\n\n");
+
+        section.push_str("LISTING & SORTING:\n");
+        section.push_str("- ls: list directory contents\n");
+        section.push_str("  Key options: -l (long), -a (all), -h (human sizes), -t (by time), -S (by size)\n");
+        section.push_str("- sort: sort lines of text\n");
+        section.push_str("  Key options: -n (numeric), -r (reverse), -k N (by column N), -h (human sizes)\n\n");
+
+        section.push_str("DISK & SIZE:\n");
+        section.push_str("- du: disk usage by directory\n");
+        section.push_str("  Key options: -s (summary), -h (human), -d N (depth)\n");
+        section.push_str("- df: disk space on filesystems\n");
+        section.push_str("  Key options: -h (human readable)\n\n");
+
+        section.push_str("TEXT PROCESSING:\n");
+        section.push_str("- awk: field-based text processing\n");
+        section.push_str("  Pattern: awk '{print $1}' (print first field)\n");
+        section.push_str("- sed: stream editing/substitution\n");
+        section.push_str("  Pattern: sed 's/old/new/g' (global substitution)\n");
+        section.push_str("- cut: extract columns\n");
+        section.push_str("  Pattern: cut -d',' -f1 (first comma-separated field)\n\n");
+
+        section.push_str("PROCESSES:\n");
+        section.push_str("- ps: list processes\n");
+        section.push_str("  Pattern: ps aux (all processes, detailed)\n");
+        section.push_str("- top/htop: interactive process viewer\n\n");
+
+        section.push_str("NETWORK:\n");
+        section.push_str("- netstat/ss: network connections and ports\n");
+        section.push_str("- lsof: list open files (including network)\n");
+        section.push_str("  Pattern: lsof -i :PORT (find process on port)\n");
+
+        section
+    }
+
+    fn build_platform_context(&self) -> String {
+        let mut section = format!(
+            "[PLATFORM]\nOS: {} {}\nProfile: {}\n",
+            self.profile.os_name, self.profile.os_version, self.profile.profile_type
+        );
+
+        // Add platform-specific notes
+        match self.profile.profile_type {
+            ProfileType::Bsd => {
+                section.push_str("\nBSD/macOS notes:\n");
+                section.push_str("- Use `stat -f '%z %N'` instead of `stat -c '%s %n'`\n");
+                section.push_str("- find doesn't support -printf, use -exec stat instead\n");
+                section.push_str("- sed -i requires '' argument: sed -i '' 's/...'\n");
+            }
+            ProfileType::GnuLinux => {
+                section.push_str("\nGNU/Linux notes:\n");
+                section.push_str("- Full GNU coreutils available\n");
+                section.push_str("- find supports -printf for custom output\n");
+                section.push_str("- grep supports -P for Perl regex\n");
+            }
+            ProfileType::Busybox => {
+                section.push_str("\nBusyBox notes:\n");
+                section.push_str("- Limited flag support, prefer POSIX options\n");
+                section.push_str("- Some GNU extensions unavailable\n");
+            }
+            _ => {}
+        }
+
+        if let Some(ctx) = &self.available_context {
+            section.push_str(&format!("\n[CONTEXT]\n{}\n", ctx));
+        }
+
+        section
+    }
+
+    fn build_examples(&self) -> String {
+        let mut section = String::from("[EXAMPLES]\n\n");
+
+        // Example 1: Finding files
+        section.push_str("User: \"how to find files modified in last 24 hours\"\n");
+        section.push_str("Assistant: Use `find` with time-based filters:\n\n");
+        section.push_str("  # Last 24 hours\n");
+        section.push_str("  find . -type f -mtime -1\n\n");
+        section.push_str("  # Last 24 hours with details\n");
+        section.push_str("  find . -type f -mtime -1 -ls\n\n");
+        section.push_str("  # Specific directory, last 24 hours\n");
+        section.push_str("  find /path/to/dir -type f -mtime -1\n\n");
+        section.push_str("  # Last N minutes (more precise)\n");
+        section.push_str("  find . -type f -mmin -1440  # 1440 minutes = 24 hours\n\n");
+        section.push_str(
+            "The `-mtime -1` means \"modified less than 1 day ago\". Use `-mmin` for minute precision.\n\n",
+        );
+
+        // Example 2: Disk usage
+        section.push_str("User: \"show disk usage by folder sorted by size\"\n");
+        section.push_str("Assistant: Use `du` with `sort` for size-ordered output:\n\n");
+        section.push_str("  # Top 10 largest directories\n");
+        section.push_str("  du -sh */ | sort -rh | head -10\n\n");
+        section.push_str("  # All subdirectories with human-readable sizes\n");
+        section.push_str("  du -h --max-depth=1 | sort -rh\n\n");
+        section.push_str("  # Specific path\n");
+        section.push_str("  du -sh /var/log/* | sort -rh\n\n");
+        section.push_str(
+            "The `-s` flag summarizes each argument, `-h` gives human-readable sizes, and `sort -rh` sorts largest first.\n\n",
+        );
+
+        // Example 3: Searching text
+        section.push_str("User: \"search for TODO in all python files\"\n");
+        section.push_str("Assistant: Use `grep` for text search across files:\n\n");
+        section.push_str("  # Basic recursive search\n");
+        section.push_str("  grep -rn 'TODO' --include='*.py' .\n\n");
+        section.push_str("  # Case-insensitive\n");
+        section.push_str("  grep -rni 'todo' --include='*.py' .\n\n");
+        section.push_str("  # Just show matching files\n");
+        section.push_str("  grep -rl 'TODO' --include='*.py' .\n\n");
+        section.push_str(
+            "The `-r` flag searches recursively, `-n` shows line numbers, and `--include` filters by filename pattern.\n",
+        );
+
+        section
+    }
+
+    /// Generate a structured explanation for a command (for programmatic use)
+    pub fn create_explanation(
+        &self,
+        command: &str,
+        intent: &str,
+    ) -> CommandExplanation {
+        // This would typically be generated by the LLM, but we can provide
+        // static explanations for common patterns
+        let tool = self.identify_primary_tool(command);
+
+        CommandExplanation {
+            command: command.to_string(),
+            summary: format!("Uses {} to {}", tool, intent),
+            detailed_explanation: self.generate_explanation_for_command(command, &tool),
+            option_breakdown: self.extract_options(command, &tool),
+            examples: self.generate_examples(&tool, intent),
+            alternatives: self.generate_alternatives(&tool),
+            tool_used: tool,
+            use_cases: vec![intent.to_string()],
+        }
+    }
+
+    fn identify_primary_tool(&self, command: &str) -> String {
+        let command = command.trim();
+        // Get first word (the command name)
+        command
+            .split_whitespace()
+            .next()
+            .unwrap_or("unknown")
+            .to_string()
+    }
+
+    fn generate_explanation_for_command(&self, command: &str, tool: &str) -> String {
+        match tool {
+            "find" => format!(
+                "The `find` command searches for files in a directory hierarchy. \
+                 This command ({}) searches from the specified starting point and \
+                 applies the given filters to locate matching files.",
+                command
+            ),
+            "grep" => format!(
+                "The `grep` command searches for text patterns within files. \
+                 This command ({}) searches for the specified pattern in the given files or directories.",
+                command
+            ),
+            "du" => format!(
+                "The `du` command estimates file space usage. \
+                 This command ({}) calculates and displays disk usage for the specified paths.",
+                command
+            ),
+            "ls" => format!(
+                "The `ls` command lists directory contents. \
+                 This command ({}) displays files and directories with the specified options.",
+                command
+            ),
+            _ => format!(
+                "This command ({}) uses the `{}` utility to perform the requested operation.",
+                command, tool
+            ),
+        }
+    }
+
+    fn extract_options(&self, command: &str, tool: &str) -> Vec<OptionExplanation> {
+        let mut options = Vec::new();
+
+        // Parse common options based on tool
+        match tool {
+            "find" => {
+                if command.contains("-type f") {
+                    options.push(OptionExplanation {
+                        option: "-type f".to_string(),
+                        description: "Match only regular files (not directories)".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-type d") {
+                    options.push(OptionExplanation {
+                        option: "-type d".to_string(),
+                        description: "Match only directories".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-name") {
+                    options.push(OptionExplanation {
+                        option: "-name".to_string(),
+                        description: "Match files by name pattern (case-sensitive)".to_string(),
+                        example_value: Some("'*.txt'".to_string()),
+                    });
+                }
+                if command.contains("-mtime") {
+                    options.push(OptionExplanation {
+                        option: "-mtime".to_string(),
+                        description: "Match by modification time in days (+N older, -N newer)"
+                            .to_string(),
+                        example_value: Some("-1 (last 24 hours)".to_string()),
+                    });
+                }
+                if command.contains("-size") {
+                    options.push(OptionExplanation {
+                        option: "-size".to_string(),
+                        description: "Match by file size (+N larger, -N smaller)".to_string(),
+                        example_value: Some("+100M (larger than 100MB)".to_string()),
+                    });
+                }
+            }
+            "grep" => {
+                if command.contains("-r") || command.contains("-R") {
+                    options.push(OptionExplanation {
+                        option: "-r/-R".to_string(),
+                        description: "Search recursively through directories".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-n") {
+                    options.push(OptionExplanation {
+                        option: "-n".to_string(),
+                        description: "Show line numbers with output".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-i") {
+                    options.push(OptionExplanation {
+                        option: "-i".to_string(),
+                        description: "Case-insensitive matching".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-l") {
+                    options.push(OptionExplanation {
+                        option: "-l".to_string(),
+                        description: "Only print names of matching files".to_string(),
+                        example_value: None,
+                    });
+                }
+            }
+            "ls" => {
+                if command.contains("-l") {
+                    options.push(OptionExplanation {
+                        option: "-l".to_string(),
+                        description: "Long listing format with details".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-a") {
+                    options.push(OptionExplanation {
+                        option: "-a".to_string(),
+                        description: "Show hidden files (starting with .)".to_string(),
+                        example_value: None,
+                    });
+                }
+                if command.contains("-h") {
+                    options.push(OptionExplanation {
+                        option: "-h".to_string(),
+                        description: "Human-readable file sizes".to_string(),
+                        example_value: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        options
+    }
+
+    fn generate_examples(&self, tool: &str, _intent: &str) -> Vec<UsageExample> {
+        match tool {
+            "find" => vec![
+                UsageExample {
+                    description: "Find all Python files".to_string(),
+                    command: "find . -name '*.py' -type f".to_string(),
+                },
+                UsageExample {
+                    description: "Find files larger than 100MB".to_string(),
+                    command: "find . -type f -size +100M".to_string(),
+                },
+                UsageExample {
+                    description: "Find and delete empty directories".to_string(),
+                    command: "find . -type d -empty -delete".to_string(),
+                },
+            ],
+            "grep" => vec![
+                UsageExample {
+                    description: "Search recursively with line numbers".to_string(),
+                    command: "grep -rn 'pattern' .".to_string(),
+                },
+                UsageExample {
+                    description: "Case-insensitive search".to_string(),
+                    command: "grep -ri 'pattern' .".to_string(),
+                },
+                UsageExample {
+                    description: "Search in specific file types".to_string(),
+                    command: "grep -rn 'pattern' --include='*.js' .".to_string(),
+                },
+            ],
+            _ => vec![],
+        }
+    }
+
+    fn generate_alternatives(&self, tool: &str) -> Vec<AlternativeCommand> {
+        match tool {
+            "find" => vec![
+                AlternativeCommand {
+                    command: "fd".to_string(),
+                    reason: "Faster, simpler syntax (requires installation)".to_string(),
+                },
+                AlternativeCommand {
+                    command: "locate".to_string(),
+                    reason: "Faster for filename search (uses database, may be stale)".to_string(),
+                },
+            ],
+            "grep" => vec![
+                AlternativeCommand {
+                    command: "rg (ripgrep)".to_string(),
+                    reason: "Much faster, respects .gitignore (requires installation)".to_string(),
+                },
+                AlternativeCommand {
+                    command: "ag (silver searcher)".to_string(),
+                    reason: "Faster than grep, good defaults (requires installation)".to_string(),
+                },
+            ],
+            _ => vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_explainer_prompt_builder() {
+        let builder = ExplainerPromptBuilder::ubuntu();
+        let prompt = builder.build_system_prompt();
+
+        assert!(prompt.contains("ShellCommandExplainer"));
+        assert!(prompt.contains("TOOL KNOWLEDGE"));
+        assert!(prompt.contains("find"));
+        assert!(prompt.contains("grep"));
+    }
+
+    #[test]
+    fn test_format_chat() {
+        let builder = ExplainerPromptBuilder::ubuntu();
+        let chat = builder.format_chat("find files modified today");
+
+        assert!(chat.starts_with("<|im_start|>system"));
+        assert!(chat.contains("find files modified today"));
+        assert!(chat.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn test_create_explanation() {
+        let builder = ExplainerPromptBuilder::ubuntu();
+        let explanation =
+            builder.create_explanation("find . -type f -mtime -1", "find recent files");
+
+        assert_eq!(explanation.tool_used, "find");
+        assert!(!explanation.option_breakdown.is_empty());
+        assert!(explanation.option_breakdown.iter().any(|o| o.option == "-type f"));
+    }
+
+    #[test]
+    fn test_identify_tool() {
+        let builder = ExplainerPromptBuilder::ubuntu();
+
+        assert_eq!(
+            builder.identify_primary_tool("find . -type f"),
+            "find"
+        );
+        assert_eq!(
+            builder.identify_primary_tool("grep -rn 'pattern' ."),
+            "grep"
+        );
+        assert_eq!(
+            builder.identify_primary_tool("ls -la"),
+            "ls"
+        );
+    }
+}

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -82,12 +82,19 @@
 
 pub mod capability_profile;
 pub mod command_templates;
+pub mod explainer_prompt;
+pub mod profiles;
 pub mod smollm_prompt;
 pub mod validation;
 
 // Re-export main types for convenient access
 pub use capability_profile::{AwkType, CapabilityProfile, DetectedShell, ProfileType, StatFormat};
 pub use command_templates::{CommandTemplate, TemplateLibrary};
+pub use explainer_prompt::ExplainerPromptBuilder;
+pub use profiles::{
+    AlternativeCommand, CommandExplanation, GenerationProfile, OptionExplanation, ProfileConfig,
+    UsageExample,
+};
 pub use smollm_prompt::{CommandOutput, PromptResponse, RepairPromptBuilder, SmolLMPromptBuilder};
 pub use validation::{
     CommandValidator, RiskLevel, ValidationError, ValidationErrorCode, ValidationResult,

--- a/src/prompts/profiles.rs
+++ b/src/prompts/profiles.rs
@@ -1,0 +1,279 @@
+//! Generation Profile System
+//!
+//! This module provides different behavioral profiles for command generation.
+//! Each profile configures how caro generates and explains commands.
+//!
+//! # Profiles
+//!
+//! - **Generator** (default): Optimized for quick command generation with brief explanations
+//! - **Explainer**: Educational mode with detailed explanations of commands and options
+//!
+//! # Usage
+//!
+//! ```rust
+//! use caro::prompts::profiles::{GenerationProfile, ProfileConfig};
+//!
+//! // Use default generator profile
+//! let config = ProfileConfig::default();
+//!
+//! // Use explainer profile
+//! let config = ProfileConfig::new(GenerationProfile::Explainer);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Generation profile that controls command generation behavior
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GenerationProfile {
+    /// Default profile optimized for quick command generation
+    /// - Fast inference
+    /// - Brief explanations
+    /// - Minimal output
+    #[default]
+    Generator,
+
+    /// Educational profile with detailed explanations
+    /// - Identifies relevant Unix tools
+    /// - Explains command syntax and options
+    /// - Provides usage examples and alternatives
+    /// - Ideal for learning and understanding commands
+    Explainer,
+}
+
+impl GenerationProfile {
+    /// Get the display name of the profile
+    pub fn name(&self) -> &'static str {
+        match self {
+            GenerationProfile::Generator => "generator",
+            GenerationProfile::Explainer => "explainer",
+        }
+    }
+
+    /// Get a description of what this profile does
+    pub fn description(&self) -> &'static str {
+        match self {
+            GenerationProfile::Generator => {
+                "Quick command generation with minimal output"
+            }
+            GenerationProfile::Explainer => {
+                "Educational mode with detailed explanations of commands and options"
+            }
+        }
+    }
+
+    /// Check if this profile should include detailed explanations
+    pub fn should_explain(&self) -> bool {
+        matches!(self, GenerationProfile::Explainer)
+    }
+
+    /// Check if this profile is the default
+    pub fn is_default(&self) -> bool {
+        matches!(self, GenerationProfile::Generator)
+    }
+}
+
+impl fmt::Display for GenerationProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl std::str::FromStr for GenerationProfile {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "generator" | "gen" | "default" => Ok(GenerationProfile::Generator),
+            "explainer" | "explain" | "educational" | "learn" => Ok(GenerationProfile::Explainer),
+            _ => Err(format!(
+                "Unknown profile '{}'. Valid profiles: generator, explainer",
+                s
+            )),
+        }
+    }
+}
+
+/// Configuration for a generation profile
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileConfig {
+    /// The active profile
+    pub profile: GenerationProfile,
+
+    /// Whether to show alternatives in output
+    pub show_alternatives: bool,
+
+    /// Whether to show examples in explanations
+    pub show_examples: bool,
+
+    /// Whether to show option breakdowns
+    pub show_option_breakdown: bool,
+
+    /// Maximum number of examples to show
+    pub max_examples: usize,
+}
+
+impl Default for ProfileConfig {
+    fn default() -> Self {
+        Self {
+            profile: GenerationProfile::default(),
+            show_alternatives: false,
+            show_examples: false,
+            show_option_breakdown: false,
+            max_examples: 3,
+        }
+    }
+}
+
+impl ProfileConfig {
+    /// Create a new profile config with the specified profile
+    pub fn new(profile: GenerationProfile) -> Self {
+        match profile {
+            GenerationProfile::Generator => Self::default(),
+            GenerationProfile::Explainer => Self {
+                profile,
+                show_alternatives: true,
+                show_examples: true,
+                show_option_breakdown: true,
+                max_examples: 5,
+            },
+        }
+    }
+
+    /// Create a generator profile config
+    pub fn generator() -> Self {
+        Self::new(GenerationProfile::Generator)
+    }
+
+    /// Create an explainer profile config
+    pub fn explainer() -> Self {
+        Self::new(GenerationProfile::Explainer)
+    }
+}
+
+/// Explanation output for a generated command
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandExplanation {
+    /// The generated command
+    pub command: String,
+
+    /// Brief one-line summary
+    pub summary: String,
+
+    /// Detailed explanation of what the command does
+    pub detailed_explanation: String,
+
+    /// Breakdown of individual options/flags
+    pub option_breakdown: Vec<OptionExplanation>,
+
+    /// Usage examples with variations
+    pub examples: Vec<UsageExample>,
+
+    /// Alternative approaches to achieve the same goal
+    pub alternatives: Vec<AlternativeCommand>,
+
+    /// Relevant Unix tool identified
+    pub tool_used: String,
+
+    /// When to use this command vs alternatives
+    pub use_cases: Vec<String>,
+}
+
+impl Default for CommandExplanation {
+    fn default() -> Self {
+        Self {
+            command: String::new(),
+            summary: String::new(),
+            detailed_explanation: String::new(),
+            option_breakdown: Vec::new(),
+            examples: Vec::new(),
+            alternatives: Vec::new(),
+            tool_used: String::new(),
+            use_cases: Vec::new(),
+        }
+    }
+}
+
+/// Explanation of a single option/flag
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptionExplanation {
+    /// The option/flag (e.g., "-type f")
+    pub option: String,
+
+    /// What this option does
+    pub description: String,
+
+    /// Example value if applicable
+    pub example_value: Option<String>,
+}
+
+/// A usage example
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageExample {
+    /// Description of this example
+    pub description: String,
+
+    /// The example command
+    pub command: String,
+}
+
+/// An alternative command approach
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlternativeCommand {
+    /// The alternative command
+    pub command: String,
+
+    /// Why you might use this alternative
+    pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_profile_from_str() {
+        assert_eq!(
+            "generator".parse::<GenerationProfile>().unwrap(),
+            GenerationProfile::Generator
+        );
+        assert_eq!(
+            "explainer".parse::<GenerationProfile>().unwrap(),
+            GenerationProfile::Explainer
+        );
+        assert_eq!(
+            "explain".parse::<GenerationProfile>().unwrap(),
+            GenerationProfile::Explainer
+        );
+        assert_eq!(
+            "default".parse::<GenerationProfile>().unwrap(),
+            GenerationProfile::Generator
+        );
+        assert!("unknown".parse::<GenerationProfile>().is_err());
+    }
+
+    #[test]
+    fn test_profile_display() {
+        assert_eq!(GenerationProfile::Generator.to_string(), "generator");
+        assert_eq!(GenerationProfile::Explainer.to_string(), "explainer");
+    }
+
+    #[test]
+    fn test_profile_config() {
+        let gen_config = ProfileConfig::generator();
+        assert_eq!(gen_config.profile, GenerationProfile::Generator);
+        assert!(!gen_config.show_examples);
+
+        let exp_config = ProfileConfig::explainer();
+        assert_eq!(exp_config.profile, GenerationProfile::Explainer);
+        assert!(exp_config.show_examples);
+        assert!(exp_config.show_alternatives);
+    }
+
+    #[test]
+    fn test_profile_should_explain() {
+        assert!(!GenerationProfile::Generator.should_explain());
+        assert!(GenerationProfile::Explainer.should_explain());
+    }
+}


### PR DESCRIPTION
Implements an explanation mode profile system providing detailed, educational explanations of generated shell commands.

**New Features:**
- ✓ `--explain` CLI flag to enable educational output mode
- ✓ Profile system with Generator (default) and Explainer modes
- ✓ ExplainerPromptBuilder for generating educational prompts

**Detailed Command Explanations Include:**
- Tool identification (e.g., "Use find with...")
- Option breakdowns with descriptions
- Usage examples with variations
- Alternative tool suggestions

**New Files:**
- `src/prompts/profiles.rs`: GenerationProfile enum and ProfileConfig
- `src/prompts/explainer_prompt.rs`: Educational prompt builder

**Output Format** (crush-style educational pattern):
```
Use `find` for this task:
  # Primary command
  find . -type f -mtime -1
  # Alternative variations
  ...
Options explained:
  -type f: Match only regular files
  -mtime -1: Modified less than 1 day ago
```

**Type:** Feature
**Lines changed:** +980 -8

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explanation mode (--explain) that shows a crush-style, educational breakdown of generated shell commands. Introduces a generation profile system (Generator default, Explainer) and integrates ExplainerPromptBuilder for structured command explanations.

- **New Features**
  - CLI: --explain flag; prints “Use <tool> …”, primary command, examples, options, and alternatives.
  - Profiles: GenerationProfile (generator/explainer) with ProfileConfig; default remains generator; config adds generation_profile.
  - Prompts: ExplainerPromptBuilder generates structured CommandExplanation (tool, options, examples, alternatives).
  - API: CliResult includes explain_mode and detailed_explanation; prompts module re-exports new types.

- **Migration**
  - No breaking changes; existing behavior unchanged by default.
  - To use: caro --explain "<your prompt>".
  - Optional: set generation_profile in user config to make explainer the default.
  - If consuming CLI JSON, handle new fields: explain_mode and detailed_explanation.

<sup>Written for commit 49558523ff14072c107717c0cc161d2283d8aba4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

