### PR TITLE
feat: Implement system capability profile detection

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -40,9 +40,20 @@ pub struct CommandResponse {
 }
 
 impl AgentLoop {
+    /// Create a new AgentLoop with automatic profile detection.
+    /// Note: This uses a default Ubuntu profile. For proper system detection,
+    /// use `with_profile()` with a detected `CapabilityProfile`.
     pub fn new(backend: Arc<dyn CommandGenerator>, context: ExecutionContext) -> Self {
-        // Create static matcher with detected capabilities
-        let profile = CapabilityProfile::ubuntu(); // TODO: detect from system
+        Self::with_profile(backend, context, CapabilityProfile::ubuntu())
+    }
+
+    /// Create a new AgentLoop with a specific capability profile.
+    /// Use `CapabilityProfile::detect().await` to detect the current system's capabilities.
+    pub fn with_profile(
+        backend: Arc<dyn CommandGenerator>,
+        context: ExecutionContext,
+        profile: CapabilityProfile,
+    ) -> Self {
         let static_matcher = Some(StaticMatcher::new(profile.clone()));
         let validator = CommandValidator::new(profile);
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     backends::CommandGenerator,
     context::ExecutionContext,
     models::{CommandRequest, SafetyLevel, ShellType},
+    prompts::CapabilityProfile,
     safety::SafetyValidator,
 };
 
@@ -170,8 +171,11 @@ impl CliApp {
         // Detect execution context
         let context = ExecutionContext::detect();
 
-        // Create agent loop with backend and context
-        let agent_loop = AgentLoop::new(backend_arc.clone(), context.clone());
+        // Detect system capability profile for optimal command generation
+        let profile = CapabilityProfile::detect().await;
+
+        // Create agent loop with backend, context, and detected profile
+        let agent_loop = AgentLoop::with_profile(backend_arc.clone(), context.clone(), profile);
 
         Ok(Self {
             config,


### PR DESCRIPTION
Enables AgentLoop to detect the current system's capability profile instead of hardcoding Ubuntu, enabling optimal command generation for different platforms.

**Changes:**
- ✓ Add `AgentLoop::with_profile()` constructor for explicit profile injection
- ✓ Update CliApp to detect profile at initialization using `CapabilityProfile::detect()`
- ✓ Keep `AgentLoop::new()` for backward compatibility with Ubuntu default

**Benefit:** Optimal command generation for different platforms:
- GNU/Linux (Ubuntu, Debian, Fedora, etc.)
- BSD/macOS (Darwin)
- BusyBox/Alpine

**Files Modified:**
- `src/agent/mod.rs`
- `src/cli/mod.rs`

**Type:** Feature
**Lines changed:** +19 -4

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects the system’s capability profile at startup to generate correct, OS-specific commands instead of assuming Ubuntu. Improves cross-platform behavior on Linux, macOS/BSD, and BusyBox/Alpine.

- **New Features**
  - Added AgentLoop::with_profile(profile) to inject a detected capability profile.
  - CliApp now uses CapabilityProfile::detect().await during initialization.
  - Kept AgentLoop::new() with Ubuntu default for backward compatibility.

<sup>Written for commit ca206dd26cd71a399a5b8ca85f767e3fa4be027e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

