### PR TITLE
fix: Show correct version when built from crates.io source

### DIFF
--- a/src/prompts/profiles.rs
+++ b/src/prompts/profiles.rs
@@ -20,11 +20,12 @@
 //! let config = ProfileConfig::new(GenerationProfile::Explainer);
 //! ```
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Generation profile that controls command generation behavior
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum GenerationProfile {
     /// Default profile optimized for quick command generation


### PR DESCRIPTION
Fixes version output to show correct version when built from crates.io source instead of "unknown".

**Problem:**
When users install via `cargo install caro`, the build script couldn't access git info, resulting in "unknown" version output.

**Solution:**
- Check for `CARGO_PKG_VERSION` first (available in crates.io builds)
- Fall back to git describe if in a git repository
- Show "unknown" only if both methods fail

**Files Modified:**
- `build.rs`

**Type:** Bug Fix
**Lines changed:** +46 -2

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version output for crates.io installs so users see the correct crate version and commit instead of "unknown". Also adds JsonSchema derive to GenerationProfile for schema compatibility.

- **Bug Fixes**
  - Use CARGO_PKG_VERSION for version in crates.io builds.
  - Parse .cargo_vcs_info.json to get commit SHA without extra deps.
  - Keep git-based values when a repo is present; otherwise show "source" for date.
  - Derive schemars::JsonSchema for GenerationProfile to ensure schema compatibility.

<sup>Written for commit 973cad8980a7965ca456119b2fe6188e43287921. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

