### PR TITLE
Add CodeBlock component with copy-to-clipboard functionality

### DIFF
--- a/website/src/hooks/index.ts
+++ b/website/src/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useClipboard } from './useClipboard';
+export type {
+  UseClipboardOptions,
+  UseClipboardReturn,
+} from './useClipboard';

--- a/website/src/hooks/useClipboard.ts
+++ b/website/src/hooks/useClipboard.ts
@@ -1,0 +1,83 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+export interface UseClipboardOptions {
+  /** Duration in ms to show "copied" state (default: 2000) */
+  resetDelay?: number;
+  /** Callback on successful copy */
+  onCopy?: (text: string) => void;
+  /** Callback on copy error */
+  onError?: (error: Error) => void;
+}
+
+export interface UseClipboardReturn {
+  /** Whether content was recently copied */
+  copied: boolean;
+  /** Copy text to clipboard */
+  copy: (text: string) => Promise<boolean>;
+  /** Reset copied state manually */
+  reset: () => void;
+}
+
+/**
+ * Hook for clipboard operations with copy feedback state.
+ *
+ * @example
+ * ```tsx
+ * const { copied, copy } = useClipboard();
+ *
+ * <button onClick={() => copy('Hello')}>
+ *   {copied ? 'Copied!' : 'Copy'}
+ * </button>
+ * ```
+ */
+export function useClipboard(
+  options: UseClipboardOptions = {}
+): UseClipboardReturn {
+  const { resetDelay = 2000, onCopy, onError } = options;
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reset = useCallback(() => {
+    setCopied(false);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        onCopy?.(text);
+
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          timeoutRef.current = null;
+        }, resetDelay);
+
+        return true;
+      } catch (err) {
+        const error =
+          err instanceof Error ? err : new Error('Failed to copy to clipboard');
+        onError?.(error);
+        return false;
+      }
+    },
+    [resetDelay, onCopy, onError]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return { copied, copy, reset };
+}

--- a/website/src/ui/CodeBlock/CodeBlock.module.css
+++ b/website/src/ui/CodeBlock/CodeBlock.module.css
@@ -1,0 +1,215 @@
+/**
+ * CodeBlock Component Styles
+ * Low-profile design optimized for usability
+ */
+
+/* ============================================
+   SHARED STYLES
+   ============================================ */
+
+.code {
+  font-family: var(--font-family-code);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+
+.copyBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.copyBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-primary);
+}
+
+.copyBtn:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.copyBtn:active {
+  transform: scale(0.95);
+}
+
+/* ============================================
+   INLINE CODE (single line)
+   ============================================ */
+
+.inline {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 2px var(--space-sm);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-secondary);
+  vertical-align: baseline;
+}
+
+.inline:hover .copyBtn,
+.inline:focus-within .copyBtn {
+  opacity: 1;
+}
+
+.inline .copyBtn {
+  width: 22px;
+  height: 22px;
+  margin-right: -4px;
+}
+
+.inline .copyBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ============================================
+   BLOCK CODE (multiline)
+   ============================================ */
+
+.block {
+  position: relative;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  overflow: hidden;
+}
+
+.block:hover .copyBtn,
+.block:focus-within .copyBtn {
+  opacity: 1;
+}
+
+.block .copyBtn {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  z-index: 1;
+}
+
+.pre {
+  margin: 0;
+  padding: var(--space-md);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ============================================
+   LINE NUMBERS
+   ============================================ */
+
+.line {
+  display: block;
+}
+
+.lineNum {
+  display: inline-block;
+  width: 2ch;
+  margin-right: var(--space-md);
+  color: var(--color-text-secondary);
+  text-align: right;
+  user-select: none;
+  opacity: 0.5;
+}
+
+.lineContent {
+  /* Allows line content to be selected independently */
+}
+
+/* ============================================
+   VARIANT: DEFAULT
+   ============================================ */
+
+.default {
+  background: var(--color-bg-secondary);
+}
+
+.default .code {
+  color: var(--color-text);
+}
+
+/* ============================================
+   VARIANT: MUTED
+   ============================================ */
+
+.muted {
+  background: var(--color-bg-tertiary);
+}
+
+.muted .code {
+  color: var(--color-text-tertiary);
+}
+
+/* ============================================
+   DARK MODE
+   ============================================ */
+
+:global(.dark) .inline,
+:global(.dark) .block {
+  background: var(--color-bg-secondary);
+}
+
+:global(.dark) .code {
+  color: var(--color-text);
+}
+
+:global(.dark) .copyBtn {
+  color: var(--color-text-secondary);
+}
+
+:global(.dark) .copyBtn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-primary-light);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+
+@media (max-width: 600px) {
+  .block .copyBtn {
+    opacity: 0.7;
+  }
+
+  .inline .copyBtn {
+    opacity: 0.7;
+  }
+
+  .pre {
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--font-size-xs);
+  }
+}
+
+/* ============================================
+   REDUCED MOTION
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .copyBtn {
+    transition: none;
+  }
+}
+
+/* ============================================
+   PRINT
+   ============================================ */
+
+@media print {
+  .copyBtn {
+    display: none;
+  }
+}

--- a/website/src/ui/CodeBlock/CodeBlock.stories.tsx
+++ b/website/src/ui/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,313 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CodeBlock } from './CodeBlock';
+
+const meta: Meta<typeof CodeBlock> = {
+  title: 'Components/CodeBlock',
+  component: CodeBlock,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+Minimal code block with copy-to-clipboard functionality.
+
+**Features**:
+- Automatic inline/block detection based on content
+- Low-profile copy button (appears on hover)
+- Optional line numbers for multiline blocks
+- Works with both single-line and multiline code
+- Accessible keyboard navigation
+
+**Design Philosophy**:
+- Subtle UX that doesn't distract from content
+- Copy button only visible when needed
+- Optimized for both usability and maintainability
+        `,
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'Code content to display',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'muted'],
+      description: 'Visual variant',
+    },
+    lang: {
+      control: 'text',
+      description: 'Language for accessibility (not displayed)',
+    },
+    lineNumbers: {
+      control: 'boolean',
+      description: 'Show line numbers',
+    },
+    noCopy: {
+      control: 'boolean',
+      description: 'Disable copy functionality',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeBlock>;
+
+// ============================================
+// INLINE CODE (single line)
+// ============================================
+
+export const Inline: Story = {
+  args: {
+    children: 'npm install caro',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Single-line code automatically renders inline with a subtle copy button.',
+      },
+    },
+  },
+};
+
+export const InlineCommand: Story = {
+  args: {
+    children: 'cargo install caro',
+    lang: 'bash',
+  },
+};
+
+export const InlineLong: Story = {
+  args: {
+    children: 'bash <(curl -sSfL https://setup.caro.sh)',
+    lang: 'bash',
+  },
+};
+
+// ============================================
+// BLOCK CODE (multiline)
+// ============================================
+
+export const Block: Story = {
+  args: {
+    children: `const greeting = 'Hello, World!';
+console.log(greeting);`,
+    lang: 'typescript',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Multiline code automatically renders as a block with copy button in top-right.',
+      },
+    },
+  },
+};
+
+export const BlockWithLineNumbers: Story = {
+  args: {
+    children: `function fibonacci(n: number): number {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+console.log(fibonacci(10));`,
+    lang: 'typescript',
+    lineNumbers: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Enable `lineNumbers` for longer code blocks to improve readability.',
+      },
+    },
+  },
+};
+
+export const BlockLong: Story = {
+  args: {
+    children: `use std::io::{self, Write};
+
+fn main() -> io::Result<()> {
+    let mut input = String::new();
+
+    print!("Describe what you want to do: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+
+    let command = generate_command(&input.trim());
+    println!("Generated: {}", command);
+
+    Ok(())
+}`,
+    lang: 'rust',
+    lineNumbers: true,
+  },
+};
+
+// ============================================
+// VARIANTS
+// ============================================
+
+export const VariantDefault: Story = {
+  args: {
+    children: 'const x = 42;',
+    variant: 'default',
+  },
+};
+
+export const VariantMuted: Story = {
+  args: {
+    children: 'const x = 42;',
+    variant: 'muted',
+  },
+};
+
+// ============================================
+// WITHOUT COPY
+// ============================================
+
+export const NoCopy: Story = {
+  args: {
+    children: 'read-only code',
+    noCopy: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Set `noCopy` to hide the copy button for read-only displays.',
+      },
+    },
+  },
+};
+
+// ============================================
+// USE CASES
+// ============================================
+
+export const InstallCommand: Story = {
+  args: {
+    children: 'cargo install caro',
+    lang: 'bash',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Typical usage for install commands.',
+      },
+    },
+  },
+};
+
+export const ConfigExample: Story = {
+  args: {
+    children: `{
+  "model": "mlx",
+  "safety": true,
+  "confirm": "always"
+}`,
+    lang: 'json',
+    lineNumbers: true,
+  },
+};
+
+export const ShellScript: Story = {
+  args: {
+    children: `#!/bin/bash
+set -e
+
+echo "Installing Caro..."
+cargo install caro
+
+echo "Done!"`,
+    lang: 'bash',
+    lineNumbers: true,
+  },
+};
+
+// ============================================
+// ALL VARIANTS
+// ============================================
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div>
+        <p style={{ margin: '0 0 8px', fontSize: '12px', color: '#666' }}>Default</p>
+        <CodeBlock variant="default">npm install caro</CodeBlock>
+      </div>
+      <div>
+        <p style={{ margin: '0 0 8px', fontSize: '12px', color: '#666' }}>Muted</p>
+        <CodeBlock variant="muted">npm install caro</CodeBlock>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// INLINE VS BLOCK COMPARISON
+// ============================================
+
+export const InlineVsBlock: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '500px' }}>
+      <div>
+        <p style={{ margin: '0 0 8px', fontSize: '12px', color: '#666' }}>
+          Inline (auto-detected from single line)
+        </p>
+        <CodeBlock>npm install caro</CodeBlock>
+      </div>
+      <div>
+        <p style={{ margin: '0 0 8px', fontSize: '12px', color: '#666' }}>
+          Block (auto-detected from multiline)
+        </p>
+        <CodeBlock>{`npm install caro
+caro --version`}</CodeBlock>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// DARK MODE
+// ============================================
+
+export const DarkMode: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <CodeBlock>npm install caro</CodeBlock>
+      <CodeBlock lineNumbers>{`const x = 1;
+const y = 2;
+console.log(x + y);`}</CodeBlock>
+    </div>
+  ),
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+  decorators: [
+    (Story) => {
+      document.documentElement.classList.add('dark');
+      return <Story />;
+    },
+  ],
+};
+
+// ============================================
+// MOBILE
+// ============================================
+
+export const Mobile: Story = {
+  args: {
+    children: `// On mobile, copy button is always visible
+const isMobile = window.innerWidth < 600;`,
+    lineNumbers: true,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};

--- a/website/src/ui/CodeBlock/CodeBlock.tsx
+++ b/website/src/ui/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useClipboard } from '../../hooks/useClipboard';
+import styles from './CodeBlock.module.css';
+
+export type CodeBlockVariant = 'default' | 'muted';
+
+export interface CodeBlockProps {
+  /** Code content to display */
+  children: string;
+  /** Visual variant */
+  variant?: CodeBlockVariant;
+  /** Language label for accessibility (not displayed) */
+  lang?: string;
+  /** Show line numbers for multiline code */
+  lineNumbers?: boolean;
+  /** Disable copy functionality */
+  noCopy?: boolean;
+  /** Additional class name */
+  className?: string;
+}
+
+/**
+ * Minimal code block with copy-to-clipboard.
+ * Automatically renders as inline or block based on content.
+ *
+ * @example
+ * ```tsx
+ * // Inline code (single line)
+ * <CodeBlock>npm install caro</CodeBlock>
+ *
+ * // Block code (multiline)
+ * <CodeBlock lang="typescript" lineNumbers>
+ * {`const x = 1;
+ * const y = 2;`}
+ * </CodeBlock>
+ * ```
+ */
+export function CodeBlock({
+  children,
+  variant = 'default',
+  lang,
+  lineNumbers = false,
+  noCopy = false,
+  className = '',
+}: CodeBlockProps) {
+  const { copied, copy } = useClipboard();
+  const isMultiline = children.includes('\n');
+  const lines = lineNumbers ? children.split('\n') : null;
+
+  const handleCopy = () => copy(children);
+
+  const copyButton = !noCopy && (
+    <button
+      type="button"
+      className={styles.copyBtn}
+      onClick={handleCopy}
+      aria-label={copied ? 'Copied to clipboard' : 'Copy code'}
+    >
+      {copied ? (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+
+  // Inline code (single line)
+  if (!isMultiline) {
+    return (
+      <span
+        className={`${styles.inline} ${styles[variant]} ${className}`.trim()}
+        data-lang={lang}
+      >
+        <code className={styles.code}>{children}</code>
+        {copyButton}
+      </span>
+    );
+  }
+
+  // Block code (multiline)
+  return (
+    <div
+      className={`${styles.block} ${styles[variant]} ${className}`.trim()}
+      data-lang={lang}
+    >
+      {copyButton}
+      <pre className={styles.pre}>
+        {lines ? (
+          <code className={styles.code}>
+            {lines.map((line, i) => (
+              <span key={i} className={styles.line}>
+                <span className={styles.lineNum}>{i + 1}</span>
+                <span className={styles.lineContent}>{line}</span>
+                {i < lines.length - 1 && '\n'}
+              </span>
+            ))}
+          </code>
+        ) : (
+          <code className={styles.code}>{children}</code>
+        )}
+      </pre>
+    </div>
+  );
+}
+
+export default CodeBlock;

--- a/website/src/ui/CodeBlock/index.ts
+++ b/website/src/ui/CodeBlock/index.ts
@@ -1,0 +1,2 @@
+export { CodeBlock } from './CodeBlock';
+export type { CodeBlockProps, CodeBlockVariant } from './CodeBlock';

--- a/website/src/ui/index.ts
+++ b/website/src/ui/index.ts
@@ -42,6 +42,11 @@ export {
   type CopyCodeBlockSize,
 } from './CopyCodeBlock';
 export {
+  CodeBlock,
+  type CodeBlockProps,
+  type CodeBlockVariant,
+} from './CodeBlock';
+export {
   IconButton,
   type IconButtonProps,
   type IconButtonSize,


### PR DESCRIPTION
Adds reusable CodeBlock component with copy-to-clipboard functionality for better documentation UX.

**New Components:**
- **CodeBlock**: Auto-detects inline vs block rendering
- **useClipboard hook**: Reusable clipboard logic with timeout reset

**Features:**
- ✓ Low-profile copy button appears on hover/focus
- ✓ Line numbers support
- ✓ Dark mode support
- ✓ Reduced motion preferences respected
- ✓ Comprehensive Storybook stories

**Files Added:**
- `website/src/ui/CodeBlock/CodeBlock.tsx`
- `website/src/ui/CodeBlock/CodeBlock.module.css`
- `website/src/ui/CodeBlock/CodeBlock.stories.tsx`
- `website/src/hooks/useClipboard.ts`

**Type:** Feature (UI Component)
**Lines changed:** +754

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable CodeBlock component with copy-to-clipboard to improve docs UX and make code snippets easy to copy.

- **New Features**
  - Inline vs block rendering auto-detected from content.
  - Low-profile copy button (hover/focus) powered by a new useClipboard hook.
  - Optional line numbers for multiline blocks.
  - Accessible labels, dark mode support, and reduced-motion respect.
  - Exported via ui and hooks indexes with Storybook examples for variants and use cases.

<sup>Written for commit 2ca3c90df3b835041328a8d9d5eb06b894d28617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

