### PR TITLE
Add ADR and PRD for bubblewrap sandbox execution

### DIFF
--- a/docs/adr/ADR-004-bubblewrap-sandbox-execution.md
+++ b/docs/adr/ADR-004-bubblewrap-sandbox-execution.md
@@ -1,0 +1,291 @@
+# ADR-004: Bubblewrap Sandbox for Command Execution
+
+**Status**: Proposed
+
+**Date**: 2026-01-03
+
+**Authors**: @wildcard
+
+**Target**: Community
+
+## Context
+
+Caro generates shell commands from natural language using LLM inference. While we have a pattern-based safety validation system (52+ regex patterns in `src/safety/`), this approach has fundamental limitations:
+
+- **Pattern evasion**: Attackers can encode dangerous commands using hex escapes, variable expansion, or obfuscation
+- **Novel attacks**: New dangerous patterns not in our database bypass validation
+- **LLM hallucination**: The model may generate syntactically valid but semantically dangerous commands
+- **Environment differences**: Commands behave differently across systems (BSD vs GNU, different PATH)
+
+Our security policy (`SECURITY.md`) explicitly calls for "Defense in Depth" with execution sandboxing as a recommended layer. Currently, validated commands run directly in the user's shell with no isolation—if pattern matching fails, there's no safety net.
+
+### Problem Statement
+
+How do we provide a robust execution isolation layer that:
+1. Prevents dangerous commands from affecting the host system
+2. Allows legitimate commands to execute normally
+3. Adds minimal latency (<500ms overhead)
+4. Works without root privileges
+5. Integrates cleanly with our existing execution pipeline
+
+### Stakeholders
+
+- **End users**: Need protection from dangerous generated commands
+- **Security researchers**: Require auditable, defense-in-depth architecture
+- **Developers**: Need maintainable, testable sandbox implementation
+- **Enterprise users**: Require compliance with security policies
+
+## Decision
+
+We will integrate **bubblewrap (bwrap)** as the primary sandbox backend for Linux, with platform-specific alternatives for macOS and Windows.
+
+The sandbox layer will be:
+1. **Optional but recommended**: Enabled by default on supported platforms
+2. **Configurable**: Users can tune restrictions per safety level
+3. **Transparent**: Commands see a restricted but functional environment
+4. **Fail-safe**: If sandbox fails to initialize, block execution (don't fall through)
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Existing Caro Pipeline                       │
+│  Input → Agent Loop → Safety Validation → User Confirmation    │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    NEW: Sandbox Layer                           │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                  SandboxExecutor                         │   │
+│  │  ┌─────────────┬─────────────┬─────────────────────┐    │   │
+│  │  │ Bubblewrap  │ macOS       │ Windows             │    │   │
+│  │  │ (Linux)     │ sandbox-exec│ (Job Objects/WSL)   │    │   │
+│  │  └─────────────┴─────────────┴─────────────────────┘    │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Command Execution                            │
+│              Isolated environment with restricted access        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Sandbox Profiles
+
+Three pre-defined profiles mapping to existing `SafetyLevel`:
+
+| Profile | Network | Filesystem | Devices | Use Case |
+|---------|---------|------------|---------|----------|
+| `Strict` | Blocked | Read-only (whitelist) | None | High-risk commands |
+| `Moderate` | Blocked | Read-only + CWD write | Limited | Default for generated commands |
+| `Permissive` | Allowed | Full read, CWD write | Standard | User-trusted commands |
+
+## Rationale
+
+### Why Bubblewrap?
+
+1. **Unprivileged operation**: Uses user namespaces—no root/sudo required
+2. **Lightweight**: ~500KB binary, minimal overhead (<100ms typical)
+3. **Battle-tested**: Powers Flatpak, used by millions of Linux users
+4. **Fine-grained control**: Precise filesystem, network, PID isolation
+5. **No daemon**: Stateless, per-command invocation
+6. **Active maintenance**: Well-maintained by containers project
+
+### Why Not Alternatives?
+
+- **Docker/Podman**: Heavyweight, requires daemon, images, more complexity
+- **Firejail**: More features but larger attack surface, more complex
+- **systemd-nspawn**: Requires root privileges
+- **chroot**: Insufficient isolation, easily escapable
+- **SELinux/AppArmor**: Kernel-level, complex policy management
+
+### Alignment with Project Goals
+
+- **Defense in Depth**: Adds isolation layer after pattern matching
+- **User Safety**: Protects against LLM hallucination and evasion attacks
+- **Performance**: Bubblewrap overhead fits within <500ms budget
+- **Binary Size**: No significant impact (external dependency)
+- **Cross-platform**: Architecture supports platform-specific implementations
+
+## Consequences
+
+### Benefits
+
+1. **True isolation**: Commands cannot escape sandbox even if validation fails
+2. **Auditability**: Sandbox configuration is explicit and auditable
+3. **Confidence**: Users can run generated commands with higher trust
+4. **Compliance**: Meets enterprise security requirements for execution isolation
+5. **Graceful degradation**: Clear error when sandbox unavailable vs silent bypass
+
+### Trade-offs
+
+1. **Linux-first**: Bubblewrap only on Linux; need alternatives for macOS/Windows
+2. **Kernel requirements**: Needs user namespaces (kernel 3.8+, enabled on most distros)
+3. **Learning curve**: Users need to understand sandbox restrictions
+4. **Some commands fail**: Commands requiring full system access won't work in sandbox
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| User namespaces disabled on some systems | Sandbox unavailable | Detect at startup, provide clear guidance |
+| Commands fail unexpectedly in sandbox | User frustration | Clear error messages, easy disable option |
+| Sandbox escape vulnerabilities | Security compromise | Pin bubblewrap version, monitor CVEs |
+| Performance regression | Poor UX | Benchmark in CI, cache sandbox setup |
+| macOS/Windows parity | Inconsistent experience | Document platform differences clearly |
+
+## Alternatives Considered
+
+### Alternative 1: Docker-based Sandbox
+
+- **Description**: Run commands in ephemeral Docker containers
+- **Pros**: Full isolation, familiar to developers, extensive tooling
+- **Cons**: Requires Docker daemon, significant overhead (seconds), complex setup, heavyweight for single commands
+
+### Alternative 2: Firejail
+
+- **Description**: Use Firejail for sandboxing
+- **Pros**: Feature-rich, good network filtering, profile system
+- **Cons**: Larger attack surface, setuid binary (security concern), more complex than needed
+
+### Alternative 3: eBPF-based Monitoring
+
+- **Description**: Use eBPF to monitor and block dangerous syscalls
+- **Pros**: No container overhead, kernel-level visibility
+- **Cons**: Requires root/CAP_BPF, complex development, less isolation than namespaces
+
+### Alternative 4: Pure Pattern Matching (Status Quo)
+
+- **Description**: Continue with regex-based validation only
+- **Pros**: No additional dependencies, works everywhere
+- **Cons**: Fundamentally bypassable, no defense in depth, doesn't meet security goals
+
+## Implementation Notes
+
+### Module Structure
+
+```
+src/execution/
+├── mod.rs              # Re-exports, ExecutionResult
+├── executor.rs         # Existing CommandExecutor
+├── shell.rs            # Shell detection
+└── sandbox/            # NEW
+    ├── mod.rs          # SandboxExecutor, SandboxConfig
+    ├── backend.rs      # SandboxBackend trait
+    ├── bubblewrap.rs   # Linux implementation
+    ├── macos.rs        # macOS sandbox-exec implementation
+    ├── windows.rs      # Windows stub/future implementation
+    └── profiles.rs     # Predefined sandbox profiles
+```
+
+### Key Interfaces
+
+```rust
+#[async_trait]
+pub trait SandboxBackend: Send + Sync {
+    /// Check if this backend is available on the current system
+    fn is_available(&self) -> bool;
+
+    /// Execute command in sandbox with given restrictions
+    async fn execute(
+        &self,
+        command: &str,
+        shell: ShellType,
+        config: &SandboxConfig,
+    ) -> Result<ExecutionResult>;
+}
+
+pub struct SandboxConfig {
+    pub profile: SandboxProfile,
+    pub readonly_paths: Vec<PathBuf>,
+    pub writable_paths: Vec<PathBuf>,
+    pub blocked_paths: Vec<PathBuf>,
+    pub allow_network: bool,
+    pub timeout: Duration,
+    pub memory_limit_mb: Option<u32>,
+}
+
+pub enum SandboxProfile {
+    Strict,
+    Moderate,
+    Permissive,
+    Custom(SandboxConfig),
+}
+```
+
+### CLI Integration
+
+```bash
+# Enable sandbox (default on Linux)
+caro "find large files" --sandbox
+
+# Disable sandbox
+caro "list files" --no-sandbox
+
+# Specify profile
+caro "delete temp files" --sandbox-profile strict
+
+# Custom restrictions
+caro "build project" --sandbox-allow-write ./build --sandbox-allow-network
+```
+
+### Configuration (caro.toml)
+
+```toml
+[execution.sandbox]
+enabled = true                    # Enable by default
+default_profile = "moderate"      # Default restriction level
+fallback_on_unavailable = "block" # "block" | "warn" | "allow"
+
+[execution.sandbox.profiles.strict]
+allow_network = false
+readonly_paths = ["/usr", "/lib", "/bin", "/etc"]
+blocked_paths = ["/home", "/root", "/var"]
+
+[execution.sandbox.profiles.moderate]
+allow_network = false
+readonly_paths = ["/usr", "/lib", "/bin"]
+writable_paths = ["$CWD"]
+```
+
+### Testing Strategy
+
+1. **Unit tests**: Mock sandbox backend, test configuration parsing
+2. **Integration tests**: Real bubblewrap execution on Linux CI
+3. **Security tests**: Verify blocked paths are actually blocked
+4. **Performance tests**: Measure sandbox overhead, ensure <500ms
+5. **Cross-platform tests**: Verify graceful handling on unsupported platforms
+
+### Rollout Strategy
+
+1. **Phase 1**: Linux bubblewrap implementation, opt-in via flag
+2. **Phase 2**: macOS sandbox-exec implementation
+3. **Phase 3**: Enable by default on supported platforms
+4. **Phase 4**: Windows investigation (Job Objects or WSL2)
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Sandbox overhead | <500ms p99 | CI benchmark suite |
+| Security coverage | Block 100% of known evasion patterns | Security test suite |
+| User adoption | >50% of Linux users enable sandbox | Telemetry (opt-in) |
+| False positive rate | <5% commands fail due to sandbox | User feedback, logs |
+| Platform coverage | Linux + macOS GA, Windows preview | Release tracking |
+
+## References
+
+- [Bubblewrap GitHub](https://github.com/containers/bubblewrap)
+- [Linux user namespaces](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)
+- [Flatpak sandbox architecture](https://docs.flatpak.org/en/latest/sandbox-permissions.html)
+- [macOS sandbox-exec](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf)
+- [SECURITY.md](../SECURITY.md) - Defense in depth requirements
+- [ADR-001](./ADR-001-enterprise-community-architecture.md) - Architecture principles
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-03 | @wildcard | Initial draft |

--- a/specs/008-bubblewrap-sandbox-execution/README.md
+++ b/specs/008-bubblewrap-sandbox-execution/README.md
@@ -1,0 +1,66 @@
+# Spec 008: Bubblewrap Sandbox Execution
+
+## Overview
+
+This specification defines the implementation of a sandbox execution layer using bubblewrap (bwrap) for command isolation. The sandbox prevents dangerous commands from affecting the host system, providing defense-in-depth protection beyond pattern-based validation.
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [spec.md](./spec.md) | Full product requirements document (PRD) |
+| [plan.md](./plan.md) | Implementation plan and task breakdown |
+| [ADR-004](../../docs/adr/ADR-004-bubblewrap-sandbox-execution.md) | Architecture decision record |
+
+## Quick Links
+
+- **Status**: Proposed
+- **Priority**: High (security feature)
+- **Target**: Community edition
+- **Platforms**: Linux (bubblewrap), macOS (sandbox-exec)
+
+## Key Features
+
+1. **Filesystem isolation** - Commands can only access whitelisted paths
+2. **Network isolation** - Block network access by default
+3. **Process isolation** - Sandbox processes can't see host processes
+4. **Configurable profiles** - Strict, Moderate, Permissive presets
+5. **CLI integration** - `--sandbox`, `--no-sandbox`, `--sandbox-profile` flags
+
+## Getting Started
+
+### Prerequisites (Linux)
+
+```bash
+# Install bubblewrap
+sudo apt install bubblewrap  # Debian/Ubuntu
+sudo dnf install bubblewrap  # Fedora
+sudo pacman -S bubblewrap    # Arch
+
+# Verify user namespaces are enabled
+cat /proc/sys/kernel/unprivileged_userns_clone  # Should return 1
+```
+
+### Usage
+
+```bash
+# Default: sandbox enabled with moderate profile
+caro "find large files"
+
+# Explicit control
+caro "delete temp files" --sandbox-profile strict
+caro "curl api endpoint" --no-sandbox  # Disable for network access
+```
+
+## Timeline
+
+- **Phase 1**: Linux bubblewrap implementation
+- **Phase 2**: macOS sandbox-exec implementation
+- **Phase 3**: Production hardening, enable by default
+- **Phase 4**: Windows investigation (future)
+
+## Related
+
+- [Security Policy](../../SECURITY.md)
+- [Execution Module](../../src/execution/)
+- [Safety Patterns](../../src/safety/)

--- a/specs/008-bubblewrap-sandbox-execution/plan.md
+++ b/specs/008-bubblewrap-sandbox-execution/plan.md
@@ -1,0 +1,480 @@
+# Implementation Plan: Bubblewrap Sandbox Execution
+
+## Phase 1: Core Implementation (Linux)
+
+### Task 1.1: Sandbox Module Structure
+
+Create the module structure in `src/execution/sandbox/`:
+
+```
+src/execution/sandbox/
+├── mod.rs           # Public exports, SandboxExecutor
+├── backend.rs       # SandboxBackend trait definition
+├── config.rs        # SandboxConfig, SandboxProfile enums
+├── error.rs         # SandboxError types
+├── bubblewrap.rs    # Linux bubblewrap implementation
+├── passthrough.rs   # No-op backend for --no-sandbox
+└── macos.rs         # Placeholder for Phase 2
+```
+
+**Deliverables:**
+- [ ] Module structure with empty stubs
+- [ ] Re-exports in `src/execution/mod.rs`
+- [ ] Compiles with no warnings
+
+### Task 1.2: Configuration Types
+
+Define core configuration types:
+
+```rust
+// config.rs
+pub enum SandboxProfile {
+    Strict,
+    Moderate,
+    Permissive,
+    Custom,
+}
+
+pub struct SandboxConfig {
+    pub profile: SandboxProfile,
+    pub readonly_paths: Vec<PathBuf>,
+    pub writable_paths: Vec<PathBuf>,
+    pub blocked_paths: Vec<PathBuf>,
+    pub allow_network: bool,
+    pub timeout: Duration,
+    pub memory_limit_mb: Option<u32>,
+    pub share_pid: bool,
+    pub new_session: bool,
+}
+
+impl SandboxConfig {
+    pub fn strict() -> Self { ... }
+    pub fn moderate() -> Self { ... }
+    pub fn permissive() -> Self { ... }
+}
+```
+
+**Deliverables:**
+- [ ] SandboxProfile enum
+- [ ] SandboxConfig struct with builder pattern
+- [ ] Default implementations for each profile
+- [ ] Unit tests for config creation
+
+### Task 1.3: Backend Trait
+
+Define the sandbox backend abstraction:
+
+```rust
+// backend.rs
+#[async_trait]
+pub trait SandboxBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn is_available(&self) -> bool;
+
+    async fn execute(
+        &self,
+        command: &str,
+        shell: ShellType,
+        config: &SandboxConfig,
+        cwd: &Path,
+    ) -> Result<ExecutionResult, SandboxError>;
+}
+```
+
+**Deliverables:**
+- [ ] SandboxBackend trait definition
+- [ ] ExecutionResult reuse or extension
+- [ ] SandboxError enum with variants
+
+### Task 1.4: Bubblewrap Backend
+
+Implement Linux bubblewrap integration:
+
+```rust
+// bubblewrap.rs
+pub struct BubblewrapBackend {
+    bwrap_path: PathBuf,
+}
+
+impl BubblewrapBackend {
+    pub fn new() -> Result<Self, SandboxError> {
+        // Find bwrap in PATH
+        // Verify user namespace support
+    }
+
+    fn build_command(&self, config: &SandboxConfig) -> Command {
+        // Generate bwrap arguments from config
+    }
+}
+```
+
+**Key bwrap arguments:**
+- `--ro-bind <src> <dst>` - Read-only bind mount
+- `--bind <src> <dst>` - Read-write bind mount
+- `--dev /dev` - Mount minimal /dev
+- `--proc /proc` - Mount /proc
+- `--unshare-net` - Network namespace isolation
+- `--unshare-pid` - PID namespace isolation
+- `--die-with-parent` - Kill sandbox if parent dies
+- `--new-session` - New session ID
+
+**Deliverables:**
+- [ ] BubblewrapBackend struct
+- [ ] bwrap path detection
+- [ ] User namespace availability check
+- [ ] Command builder from SandboxConfig
+- [ ] Process execution with output capture
+- [ ] Timeout handling
+
+### Task 1.5: Passthrough Backend
+
+No-op backend for when sandbox is disabled:
+
+```rust
+// passthrough.rs
+pub struct PassthroughBackend;
+
+impl SandboxBackend for PassthroughBackend {
+    fn name(&self) -> &'static str { "passthrough" }
+    fn is_available(&self) -> bool { true }
+
+    async fn execute(...) -> Result<ExecutionResult, SandboxError> {
+        // Direct execution without sandbox
+    }
+}
+```
+
+**Deliverables:**
+- [ ] PassthroughBackend implementation
+- [ ] Delegates to existing CommandExecutor
+
+### Task 1.6: SandboxExecutor
+
+High-level executor that selects and uses backends:
+
+```rust
+// mod.rs
+pub struct SandboxExecutor {
+    backend: Box<dyn SandboxBackend>,
+    default_config: SandboxConfig,
+}
+
+impl SandboxExecutor {
+    pub fn new(enabled: bool) -> Result<Self, SandboxError> {
+        // Select appropriate backend for platform
+    }
+
+    pub async fn execute(
+        &self,
+        command: &str,
+        shell: ShellType,
+        config: Option<SandboxConfig>,
+    ) -> Result<ExecutionResult, SandboxError> {
+        // Use provided config or default
+        // Delegate to backend
+    }
+}
+```
+
+**Deliverables:**
+- [ ] SandboxExecutor struct
+- [ ] Backend selection logic
+- [ ] Config merging (CLI overrides)
+- [ ] Integration with existing execution pipeline
+
+### Task 1.7: Error Types
+
+Define comprehensive error handling:
+
+```rust
+// error.rs
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxError {
+    #[error("Sandbox backend not available: {reason}")]
+    Unavailable { reason: String },
+
+    #[error("Failed to initialize sandbox: {0}")]
+    InitializationFailed(String),
+
+    #[error("Command blocked by sandbox: {action} on {resource}")]
+    Blocked { action: String, resource: String },
+
+    #[error("Command timed out after {seconds}s")]
+    Timeout { seconds: u64 },
+
+    #[error("Sandbox execution failed: {0}")]
+    ExecutionFailed(#[from] std::io::Error),
+}
+```
+
+**Deliverables:**
+- [ ] SandboxError enum
+- [ ] Error to exit code mapping
+- [ ] User-friendly error messages
+
+## Phase 2: CLI Integration
+
+### Task 2.1: CLI Flags
+
+Add sandbox-related flags to CLI:
+
+```rust
+// cli/mod.rs additions
+#[derive(Parser)]
+struct Cli {
+    /// Enable sandbox execution (default: true on Linux)
+    #[arg(long)]
+    sandbox: bool,
+
+    /// Disable sandbox execution
+    #[arg(long)]
+    no_sandbox: bool,
+
+    /// Sandbox profile: strict, moderate, permissive
+    #[arg(long, default_value = "moderate")]
+    sandbox_profile: String,
+
+    /// Allow network access in sandbox
+    #[arg(long)]
+    sandbox_allow_network: bool,
+
+    /// Allow write access to path
+    #[arg(long, action = ArgAction::Append)]
+    sandbox_allow_write: Vec<PathBuf>,
+}
+```
+
+**Deliverables:**
+- [ ] CLI argument definitions
+- [ ] Argument parsing and validation
+- [ ] Help text for sandbox options
+
+### Task 2.2: Configuration File
+
+Add sandbox config to TOML schema:
+
+```rust
+// config/mod.rs additions
+#[derive(Deserialize)]
+pub struct ExecutionConfig {
+    pub sandbox: SandboxTomlConfig,
+}
+
+#[derive(Deserialize)]
+pub struct SandboxTomlConfig {
+    pub enabled: bool,
+    pub default_profile: String,
+    pub fallback_on_unavailable: String,
+    pub profiles: HashMap<String, ProfileConfig>,
+}
+```
+
+**Deliverables:**
+- [ ] TOML schema for sandbox config
+- [ ] Config loading and validation
+- [ ] Profile definition support
+- [ ] Default config values
+
+### Task 2.3: Integration with Execution Flow
+
+Modify command execution to use sandbox:
+
+```rust
+// Modify CliApp::execute_command()
+async fn execute_command(&self, command: &str) -> Result<()> {
+    let sandbox_config = self.build_sandbox_config()?;
+
+    let result = if self.args.no_sandbox {
+        self.executor.execute(command).await?
+    } else {
+        self.sandbox_executor.execute(command, sandbox_config).await?
+    };
+
+    // ... handle result
+}
+```
+
+**Deliverables:**
+- [ ] SandboxExecutor instantiation in CliApp
+- [ ] Config merging from file + CLI
+- [ ] Conditional sandbox/direct execution
+- [ ] Error handling for sandbox failures
+
+## Phase 3: Testing
+
+### Task 3.1: Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_strict_profile_defaults() { ... }
+
+    #[test]
+    fn test_bwrap_command_generation() { ... }
+
+    #[test]
+    fn test_config_merging() { ... }
+}
+```
+
+**Test coverage:**
+- [ ] SandboxConfig creation and defaults
+- [ ] Profile inheritance
+- [ ] CLI argument parsing
+- [ ] TOML config parsing
+- [ ] bwrap command generation
+- [ ] Error handling paths
+
+### Task 3.2: Integration Tests
+
+```rust
+#[tokio::test]
+async fn test_sandbox_blocks_etc_write() {
+    let executor = SandboxExecutor::new(true).unwrap();
+    let result = executor.execute(
+        "touch /etc/test",
+        ShellType::Bash,
+        Some(SandboxConfig::strict()),
+    ).await;
+
+    assert!(result.is_err());
+}
+```
+
+**Test scenarios:**
+- [ ] Write to read-only path blocked
+- [ ] Write to writable path succeeds
+- [ ] Network blocked when disabled
+- [ ] Network succeeds when allowed
+- [ ] Timeout enforcement
+- [ ] Exit code preservation
+- [ ] stdout/stderr capture
+
+### Task 3.3: Security Tests
+
+```rust
+#[tokio::test]
+async fn test_symlink_escape_blocked() {
+    // Create symlink pointing outside sandbox
+    // Attempt to read through symlink
+    // Verify access denied
+}
+```
+
+**Security scenarios:**
+- [ ] Symlink escape attempts
+- [ ] /proc access restrictions
+- [ ] Device access blocked
+- [ ] Setuid execution prevented
+- [ ] Process visibility isolation
+
+### Task 3.4: Performance Benchmarks
+
+```rust
+#[bench]
+fn bench_sandbox_overhead(b: &mut Bencher) {
+    b.iter(|| {
+        // Measure sandbox vs direct execution
+    });
+}
+```
+
+**Metrics:**
+- [ ] Sandbox setup time
+- [ ] Simple command overhead
+- [ ] Complex command overhead
+- [ ] Memory usage
+
+## Phase 4: macOS Support
+
+### Task 4.1: macOS Sandbox Backend
+
+```rust
+// macos.rs
+pub struct MacOSSandboxBackend;
+
+impl SandboxBackend for MacOSSandboxBackend {
+    fn is_available(&self) -> bool {
+        cfg!(target_os = "macos")
+    }
+
+    async fn execute(...) -> Result<ExecutionResult, SandboxError> {
+        // Generate sandbox-exec profile
+        // Execute with sandbox-exec
+    }
+}
+```
+
+**Deliverables:**
+- [ ] sandbox-exec profile generation
+- [ ] Profile to SandboxConfig mapping
+- [ ] macOS-specific path handling
+- [ ] Integration tests on macOS CI
+
+### Task 4.2: Cross-Platform Testing
+
+- [ ] Linux CI with bubblewrap
+- [ ] macOS CI with sandbox-exec
+- [ ] Platform detection tests
+- [ ] Graceful fallback tests
+
+## Phase 5: Documentation
+
+### Task 5.1: User Documentation
+
+- [ ] README section on sandbox feature
+- [ ] CLI help text
+- [ ] Configuration examples
+- [ ] Troubleshooting guide
+
+### Task 5.2: Developer Documentation
+
+- [ ] Module-level rustdoc
+- [ ] Architecture overview
+- [ ] Backend implementation guide
+- [ ] Security considerations
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] Commands execute in bubblewrap sandbox on Linux
+- [ ] Commands execute in sandbox-exec on macOS
+- [ ] Three profiles work as documented
+- [ ] CLI flags override config file
+- [ ] Sandbox failures produce clear errors
+
+### Performance
+
+- [ ] Overhead <500ms p99
+- [ ] Memory <10MB additional
+
+### Security
+
+- [ ] Blocks write to read-only paths
+- [ ] Blocks network when disabled
+- [ ] No known sandbox escape vectors
+
+## Dependencies
+
+### External
+
+- `bubblewrap` (Linux, system package)
+- `sandbox-exec` (macOS, built-in)
+
+### Internal
+
+- `src/execution/executor.rs` - Existing executor
+- `src/execution/shell.rs` - Shell detection
+- `src/config/` - Configuration loading
+- `src/cli/` - CLI argument parsing
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| User namespaces disabled | Sandbox unavailable | Detect and warn, configurable fallback |
+| Command failures in sandbox | User frustration | Clear errors, easy disable |
+| Performance regression | Poor UX | Benchmark in CI, optimize |
+| macOS sandbox-exec limitations | Reduced functionality | Document differences |

--- a/specs/008-bubblewrap-sandbox-execution/spec.md
+++ b/specs/008-bubblewrap-sandbox-execution/spec.md
@@ -1,0 +1,544 @@
+# Bubblewrap Sandbox Execution - Product Requirements Document
+
+## Executive Summary
+
+This specification defines the implementation of a sandbox execution layer for Caro using bubblewrap (bwrap) on Linux, with platform-specific alternatives for macOS. The sandbox provides defense-in-depth protection by isolating generated shell commands in a restricted environment, preventing dangerous commands from affecting the host system even if pattern-based validation fails.
+
+## Problem Statement
+
+### Current State
+
+Caro generates shell commands from natural language using LLM inference. The safety pipeline currently consists of:
+
+1. **Pattern-based validation** (52+ regex patterns)
+2. **User confirmation** for high-risk commands
+3. **Direct execution** in the user's shell
+
+### Gap Analysis
+
+| Threat | Current Mitigation | Gap |
+|--------|-------------------|-----|
+| Known dangerous patterns | Regex matching | Evasion via encoding/obfuscation |
+| Novel attack patterns | None | Zero-day dangerous commands |
+| LLM hallucination | User confirmation | Users may not recognize danger |
+| Environment-specific attacks | None | BSD vs GNU, PATH manipulation |
+| Supply chain (malicious models) | None | Model generates attack payload |
+
+### Impact
+
+- **Security**: Single point of failure (pattern matching)
+- **Trust**: Users hesitant to run generated commands
+- **Adoption**: Enterprise users require execution isolation
+
+## Goals
+
+### Primary Goals
+
+1. **Isolation**: Commands execute in a sandbox with restricted filesystem, network, and process access
+2. **Safety**: Even if a dangerous command bypasses validation, it cannot harm the host
+3. **Transparency**: Users understand what restrictions are applied
+4. **Performance**: Sandbox overhead <500ms per command execution
+5. **Usability**: Legitimate commands work without user intervention
+
+### Secondary Goals
+
+1. **Auditability**: Log sandbox events for security review
+2. **Configurability**: Power users can customize restrictions
+3. **Cross-platform**: Consistent behavior across Linux and macOS
+4. **Graceful degradation**: Clear behavior when sandbox unavailable
+
+### Non-Goals
+
+1. **Windows support in v1**: Defer to future release
+2. **GUI configuration**: CLI and config file only
+3. **Container image management**: Not a container runtime
+4. **Network filtering rules**: Block/allow only, no fine-grained firewall
+
+## User Stories
+
+### US-1: Safe Command Execution
+
+> As a Caro user, I want generated commands to run in a sandbox by default, so that even if the LLM generates something dangerous, my system is protected.
+
+**Acceptance Criteria:**
+- Commands execute in bubblewrap sandbox on Linux
+- Sandbox prevents writes outside current directory
+- Sandbox blocks network access by default
+- Command output is captured and displayed normally
+
+### US-2: Sandbox Visibility
+
+> As a security-conscious user, I want to see when commands run in a sandbox and what restrictions apply, so I can trust the execution environment.
+
+**Acceptance Criteria:**
+- CLI shows sandbox status indicator
+- Verbose mode displays active restrictions
+- Sandbox failures produce clear error messages
+
+### US-3: Profile Selection
+
+> As a power user, I want to choose different sandbox profiles for different use cases, so I can balance security and functionality.
+
+**Acceptance Criteria:**
+- Three built-in profiles: strict, moderate, permissive
+- Profile can be set via CLI flag or config file
+- Custom profiles can be defined in config
+
+### US-4: Sandbox Bypass
+
+> As a user running trusted commands, I want to disable the sandbox when needed, so I can run commands that require full system access.
+
+**Acceptance Criteria:**
+- `--no-sandbox` flag disables sandbox for single command
+- Config option to disable globally
+- Warning shown when sandbox disabled for high-risk commands
+
+### US-5: macOS Parity
+
+> As a macOS user, I want sandbox protection equivalent to Linux users, so I have the same security guarantees.
+
+**Acceptance Criteria:**
+- macOS uses `sandbox-exec` with equivalent restrictions
+- Same CLI flags and config options work
+- Clear documentation of platform differences
+
+### US-6: Unavailable Sandbox Handling
+
+> As a user on a system without sandbox support, I want clear feedback about the limitation, so I can make informed decisions.
+
+**Acceptance Criteria:**
+- Startup check detects sandbox availability
+- Warning shown if sandbox unavailable
+- Configurable behavior: block, warn, or allow execution
+
+## Functional Requirements
+
+### FR-1: Sandbox Backend Abstraction
+
+```rust
+pub trait SandboxBackend: Send + Sync {
+    /// Returns true if this backend is available on the current system
+    fn is_available(&self) -> bool;
+
+    /// Returns the backend name for logging
+    fn name(&self) -> &'static str;
+
+    /// Execute a command in the sandbox
+    async fn execute(
+        &self,
+        command: &str,
+        shell: ShellType,
+        config: &SandboxConfig,
+        cwd: &Path,
+    ) -> Result<ExecutionResult, SandboxError>;
+}
+```
+
+### FR-2: Sandbox Configuration
+
+```rust
+pub struct SandboxConfig {
+    /// Base profile to use
+    pub profile: SandboxProfile,
+
+    /// Paths mounted read-only
+    pub readonly_paths: Vec<PathBuf>,
+
+    /// Paths mounted read-write
+    pub writable_paths: Vec<PathBuf>,
+
+    /// Paths completely hidden
+    pub blocked_paths: Vec<PathBuf>,
+
+    /// Allow network access
+    pub allow_network: bool,
+
+    /// Execution timeout
+    pub timeout: Duration,
+
+    /// Memory limit in MB (None = unlimited)
+    pub memory_limit_mb: Option<u32>,
+
+    /// Share PID namespace with host
+    pub share_pid: bool,
+
+    /// New session (detach from controlling terminal)
+    pub new_session: bool,
+}
+```
+
+### FR-3: Predefined Profiles
+
+| Profile | `readonly_paths` | `writable_paths` | `network` | `blocked_paths` |
+|---------|------------------|------------------|-----------|-----------------|
+| Strict | `/usr`, `/lib*`, `/bin`, `/etc/alternatives` | None | No | `/home/*`, `/root`, `/var` |
+| Moderate | `/usr`, `/lib*`, `/bin`, `/sbin`, `/etc` | `$CWD` | No | `/root`, sensitive dirs |
+| Permissive | All | `$CWD`, `$HOME/.cache` | Yes | None |
+
+### FR-4: CLI Interface
+
+```bash
+# Default: sandbox enabled with moderate profile
+caro "find large files"
+
+# Explicit sandbox control
+caro "find files" --sandbox              # Enable (default)
+caro "find files" --no-sandbox           # Disable
+caro "find files" --sandbox-profile strict
+
+# Custom restrictions
+caro "build project" \
+  --sandbox-allow-write ./build \
+  --sandbox-allow-write ./dist \
+  --sandbox-allow-network
+
+# Dry-run sandbox (show what would happen)
+caro "rm -rf /" --sandbox-dry-run
+```
+
+### FR-5: Configuration File
+
+```toml
+[execution.sandbox]
+# Enable sandbox by default
+enabled = true
+
+# Default profile when not specified
+default_profile = "moderate"
+
+# Behavior when sandbox unavailable
+# Options: "block" | "warn" | "allow"
+fallback_on_unavailable = "warn"
+
+# Per-profile configurations
+[execution.sandbox.profiles.strict]
+allow_network = false
+readonly_paths = ["/usr", "/lib", "/lib64", "/bin", "/sbin"]
+blocked_paths = ["/home", "/root", "/var/log", "/var/run"]
+timeout_seconds = 30
+
+[execution.sandbox.profiles.moderate]
+allow_network = false
+readonly_paths = ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc"]
+writable_paths = ["$CWD"]
+timeout_seconds = 60
+
+[execution.sandbox.profiles.permissive]
+allow_network = true
+readonly_paths = ["/"]
+writable_paths = ["$CWD", "$HOME/.cache", "$HOME/.local"]
+timeout_seconds = 120
+```
+
+### FR-6: Bubblewrap Integration (Linux)
+
+Generate bwrap command from SandboxConfig:
+
+```bash
+bwrap \
+  --ro-bind /usr /usr \
+  --ro-bind /lib /lib \
+  --ro-bind /lib64 /lib64 \
+  --ro-bind /bin /bin \
+  --ro-bind /sbin /sbin \
+  --ro-bind /etc /etc \
+  --bind $CWD $CWD \
+  --proc /proc \
+  --dev /dev \
+  --tmpfs /tmp \
+  --unshare-net \
+  --unshare-pid \
+  --unshare-ipc \
+  --new-session \
+  --die-with-parent \
+  --chdir $CWD \
+  -- bash -c "user_command_here"
+```
+
+### FR-7: macOS Sandbox Integration
+
+Generate sandbox-exec profile from SandboxConfig:
+
+```scheme
+(version 1)
+(deny default)
+(allow process-fork)
+(allow process-exec)
+(allow file-read* (subpath "/usr"))
+(allow file-read* (subpath "/bin"))
+(allow file-read* (subpath "/Library"))
+(allow file-read* (subpath "/System"))
+(allow file-read-data (subpath "$CWD"))
+(allow file-write-data (subpath "$CWD"))
+(deny network*)
+```
+
+### FR-8: Error Handling
+
+| Error Condition | Behavior | User Message |
+|-----------------|----------|--------------|
+| Sandbox backend unavailable | Respect `fallback_on_unavailable` config | "Sandbox unavailable: [reason]. Execution [blocked/proceeding without sandbox]." |
+| Command fails in sandbox | Return non-zero exit, capture stderr | Normal error output |
+| Command blocked by sandbox | Return specific error code | "Command blocked by sandbox: attempted [action] on [resource]" |
+| Timeout exceeded | Kill process, return timeout error | "Command timed out after [N]s in sandbox" |
+| Sandbox setup fails | Block execution | "Failed to initialize sandbox: [reason]" |
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Sandbox setup overhead | <100ms | Time from execute call to process start |
+| Total command overhead | <500ms p99 | End-to-end with sandbox vs without |
+| Memory overhead | <10MB | Additional memory for sandbox wrapper |
+
+### NFR-2: Security
+
+- Sandbox must prevent filesystem writes outside allowed paths
+- Sandbox must prevent network access when disabled
+- Sandbox must isolate PID namespace (processes can't see host processes)
+- Sandbox must prevent privilege escalation (no setuid execution)
+- Sandbox escape vulnerabilities are P0 security issues
+
+### NFR-3: Reliability
+
+- Sandbox failures must not crash caro
+- Commands must not hang indefinitely (timeout enforced)
+- Sandbox state must not persist between commands
+
+### NFR-4: Compatibility
+
+- Linux: Kernel 3.8+ with user namespaces enabled
+- macOS: 10.15+ (Catalina) for sandbox-exec
+- Shells: bash, zsh, fish, sh in sandbox
+
+## Technical Architecture
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                           Caro CLI                                  │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │                      CliApp                                  │   │
+│  │  --sandbox, --no-sandbox, --sandbox-profile                 │   │
+│  └──────────────────────────┬──────────────────────────────────┘   │
+└─────────────────────────────┼───────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Execution Layer                                 │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │                  SandboxExecutor                             │   │
+│  │  ┌─────────────────────────────────────────────────────┐    │   │
+│  │  │              SandboxConfig                           │    │   │
+│  │  │  • profile: SandboxProfile                          │    │   │
+│  │  │  • readonly_paths, writable_paths, blocked_paths    │    │   │
+│  │  │  • allow_network, timeout, memory_limit             │    │   │
+│  │  └─────────────────────────────────────────────────────┘    │   │
+│  │                          │                                   │   │
+│  │         ┌────────────────┼────────────────┐                 │   │
+│  │         ▼                ▼                ▼                 │   │
+│  │  ┌────────────┐  ┌────────────┐  ┌────────────────┐        │   │
+│  │  │ Bubblewrap │  │ macOS      │  │ Passthrough    │        │   │
+│  │  │ Backend    │  │ Sandbox    │  │ (no sandbox)   │        │   │
+│  │  │ (Linux)    │  │ Backend    │  │                │        │   │
+│  │  └────────────┘  └────────────┘  └────────────────┘        │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Execution Flow
+
+```
+1. User runs: caro "find large files"
+
+2. CLI parses sandbox options:
+   - Check --sandbox / --no-sandbox flags
+   - Load default_profile from config
+   - Merge CLI overrides
+
+3. Command generation (existing pipeline):
+   - LLM generates: find . -size +100M
+   - Safety validation passes
+
+4. Sandbox execution:
+   a. Select backend (bubblewrap on Linux)
+   b. Check backend availability
+   c. Build SandboxConfig from profile + overrides
+   d. Generate bwrap command line
+   e. Spawn bwrap with command
+   f. Capture stdout/stderr
+   g. Wait for completion or timeout
+   h. Return ExecutionResult
+
+5. Display output to user
+```
+
+### File Structure
+
+```
+src/execution/
+├── mod.rs                 # Module exports
+├── executor.rs            # Existing CommandExecutor (unchanged)
+├── shell.rs               # Shell detection (unchanged)
+└── sandbox/
+    ├── mod.rs             # SandboxExecutor, public interface
+    ├── backend.rs         # SandboxBackend trait
+    ├── config.rs          # SandboxConfig, SandboxProfile
+    ├── bubblewrap.rs      # Linux bubblewrap implementation
+    ├── macos.rs           # macOS sandbox-exec implementation
+    ├── passthrough.rs     # No-op backend for --no-sandbox
+    └── error.rs           # SandboxError types
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test Case | Description |
+|-----------|-------------|
+| `config_parsing` | Parse SandboxConfig from TOML |
+| `profile_defaults` | Verify default values for each profile |
+| `bwrap_command_generation` | Generate correct bwrap arguments |
+| `macos_profile_generation` | Generate correct sandbox-exec profile |
+| `config_merging` | CLI overrides merge with config file |
+
+### Integration Tests
+
+| Test Case | Description |
+|-----------|-------------|
+| `sandbox_blocks_write` | Write to /etc fails in sandbox |
+| `sandbox_allows_cwd_write` | Write to CWD succeeds in moderate profile |
+| `sandbox_blocks_network` | Network connection fails when disabled |
+| `sandbox_captures_output` | stdout/stderr captured correctly |
+| `sandbox_timeout` | Long-running command times out |
+| `sandbox_exit_code` | Exit codes passed through correctly |
+
+### Security Tests
+
+| Test Case | Description |
+|-----------|-------------|
+| `escape_attempt_symlink` | Symlink to blocked path fails |
+| `escape_attempt_proc` | Reading /proc/1 fails |
+| `escape_attempt_device` | Writing to /dev/sda fails |
+| `privilege_escalation` | setuid execution blocked |
+| `namespace_isolation` | Can't see host processes |
+
+### Performance Tests
+
+| Test Case | Target |
+|-----------|--------|
+| `sandbox_overhead_simple` | <200ms for `echo hello` |
+| `sandbox_overhead_complex` | <500ms for `find . -name "*.rs"` |
+| `sandbox_memory` | <10MB additional memory |
+
+## Rollout Plan
+
+### Phase 1: Linux MVP (Target: 2 weeks)
+
+- [ ] Implement SandboxBackend trait
+- [ ] Implement BubblewrapBackend
+- [ ] Implement SandboxConfig and profiles
+- [ ] Add CLI flags: --sandbox, --no-sandbox, --sandbox-profile
+- [ ] Add config file support
+- [ ] Unit and integration tests
+- [ ] Documentation
+
+### Phase 2: macOS Support (Target: 1 week)
+
+- [ ] Implement MacOSSandboxBackend
+- [ ] Cross-platform testing
+- [ ] Platform-specific documentation
+
+### Phase 3: Production Hardening (Target: 1 week)
+
+- [ ] Performance optimization
+- [ ] Security audit
+- [ ] Error message polish
+- [ ] Enable by default with "moderate" profile
+
+### Phase 4: Future (Backlog)
+
+- [ ] Windows investigation (Job Objects, WSL2)
+- [ ] Custom profile wizard
+- [ ] Sandbox event logging/audit trail
+- [ ] Resource limits (CPU, memory, I/O)
+
+## Success Metrics
+
+| Metric | Target | Tracking |
+|--------|--------|----------|
+| Adoption rate | >60% of commands run in sandbox | Opt-in telemetry |
+| Overhead | <500ms p99 | CI benchmarks |
+| Security | 0 sandbox escapes | Bug bounty, security reviews |
+| False positives | <5% legitimate commands fail | User feedback |
+| Platform coverage | Linux + macOS GA | Release checklist |
+
+## Open Questions
+
+1. **Q: Should we vendor bubblewrap or require system installation?**
+   - Leaning: Require system install, provide installation instructions
+   - Rationale: Avoid binary bloat, easier updates, trust system package
+
+2. **Q: How to handle commands that legitimately need full access?**
+   - Leaning: --no-sandbox with warning for high-risk commands
+   - Alternative: Prompt user to confirm disabling sandbox
+
+3. **Q: Should sandbox be enabled by default?**
+   - Leaning: Yes, with "moderate" profile
+   - Risk: Some commands may unexpectedly fail
+
+4. **Q: How to handle ~/.bashrc, ~/.zshrc sourcing in sandbox?**
+   - Leaning: Mount home read-only, don't source rc files
+   - Alternative: Source with restrictions
+
+## Appendix
+
+### A: Bubblewrap Installation
+
+```bash
+# Debian/Ubuntu
+sudo apt install bubblewrap
+
+# Fedora
+sudo dnf install bubblewrap
+
+# Arch
+sudo pacman -S bubblewrap
+
+# macOS (not needed, uses built-in sandbox-exec)
+```
+
+### B: Checking User Namespace Support
+
+```bash
+# Check if user namespaces are enabled
+cat /proc/sys/kernel/unprivileged_userns_clone
+# Should return 1
+
+# If not, enable (requires root):
+echo 1 | sudo tee /proc/sys/kernel/unprivileged_userns_clone
+```
+
+### C: Example bwrap Invocations
+
+```bash
+# Minimal sandbox (read-only root)
+bwrap --ro-bind / / --dev /dev --proc /proc -- ls
+
+# Network isolated
+bwrap --ro-bind / / --unshare-net -- curl https://example.com
+# (fails: network unreachable)
+
+# Write-protected /etc
+bwrap --ro-bind / / --ro-bind /etc /etc -- touch /etc/test
+# (fails: read-only filesystem)
+```
+
+### D: Related Documents
+
+- [ADR-004: Bubblewrap Sandbox Execution](../../docs/adr/ADR-004-bubblewrap-sandbox-execution.md)
+- [SECURITY.md](../../SECURITY.md)
+- [Spec 003: Core Infrastructure](../003-implement-core-infrastructure/spec.md)


### PR DESCRIPTION
Introduces sandbox execution layer using bubblewrap (Linux) and sandbox-exec (macOS) for defense-in-depth protection.

**New Documents:**
- **ADR-004**: Architecture decision for sandbox implementation
- **Spec 008**: Full PRD with requirements, architecture, and implementation plan

**Key Features:**
- ✓ **Filesystem isolation**: Read-only mounts, blocked paths
- ✓ **Network isolation**: Disabled by default
- ✓ **Process isolation**: PID namespace
- ✓ **Three configurable profiles**: strict, moderate, permissive
- ✓ **CLI flags**: `--sandbox`, `--no-sandbox`, `--sandbox-profile`

**Platform Support:**
- **Linux**: bubblewrap (bwrap)
- **macOS**: sandbox-exec
- **Windows**: Not supported (documented limitation)

**Type:** Documentation (Planning)
**Lines changed:** +1,381

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-004 and a PRD that define the plan for a sandboxed command execution layer. Establishes Linux and macOS backends with a fail-safe design to protect users from dangerous commands.

- **New Features**
  - Filesystem, network, and PID isolation
  - Three profiles: strict, moderate, permissive
  - CLI flags: --sandbox, --no-sandbox, --sandbox-profile
  - Default-on behavior with clear failure handling
  - Platform support: Linux (bubblewrap), macOS (sandbox-exec); Windows not supported

<sup>Written for commit dd5c4bd9d91222799b03ba95b7863273f525f452. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

