### PR TITLE
Add installer workflow to test install scripts

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,77 @@
+name: Install
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/installer.yml'
+      - 'install.sh'
+      - 'setup.sh'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  install:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install zsh for ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Test install.sh on bash
+        run: |
+          export CARO_INTERACTIVE=false
+          /bin/bash ./install.sh
+          export PATH="$HOME/.local/bin:$PATH"
+          caro --help
+
+      - name: Clean up for next test
+        run: |
+          rm -rf "$HOME/.local/bin/caro"
+          rm -rf "$HOME/.cargo/bin/caro"
+
+      - name: Test install.sh on zsh
+        shell: zsh {0}
+        run: |
+          export CARO_INTERACTIVE=false
+          /bin/bash ./install.sh
+          export PATH="$HOME/.local/bin:$PATH"
+          caro --help
+
+      - name: Clean up for setup.sh test
+        run: |
+          rm -rf "$HOME/.local/bin/caro"
+          rm -rf "$HOME/.cargo/bin/caro"
+
+      - name: Test setup.sh on bash
+        run: |
+          /bin/bash ./setup.sh
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          caro --help
+
+      - name: Clean up for next test
+        run: |
+          rm -rf "$HOME/.local/bin/caro"
+          rm -rf "$HOME/.cargo/bin/caro"
+
+      - name: Test setup.sh on zsh
+        shell: zsh {0}
+        run: |
+          /bin/bash ./setup.sh
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          caro --help


### PR DESCRIPTION
Adds CI workflow to test install.sh and setup.sh across platforms and shells.

**New Workflow:**
- `.github/workflows/installer.yml`

**Test Matrix:**
- **Platforms**: Ubuntu, macOS
- **Shells**: bash, zsh

**Benefit:** Verifies installation scripts work correctly across different platforms and shell environments.

**Inspired by:** Atuin's installer workflow

**Type:** CI
**Lines changed:** +77

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow to verify install.sh and setup.sh on Ubuntu and macOS with both bash and zsh. This prevents cross-platform and shell-specific install regressions.

- **New Features**
  - Adds .github/workflows/installer.yml, triggered on main pushes and PRs touching installer files.
  - Matrix: ubuntu-latest and macos-14; tests bash and zsh (installs zsh on Ubuntu).
  - Installs Rust, runs scripts non-interactively, validates with `caro --help`, and cleans up between runs.

<sup>Written for commit 090b3be8fb17b810251b6b826d04edad2870564f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

