### PR TITLE
test(glm): Add GLM-4.6V-Flash integration tests

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -208,6 +208,22 @@ pub static SMOLLM_135M_Q4: ModelInfo = ModelInfo {
     ci_suitable: true,
 };
 
+/// GLM-4.6V-Flash 9B Q4_K_M - Multimodal vision+text model (~6.2GB)
+/// Best for: High-quality command generation with vision capabilities
+/// Note: Requires --jinja flag for proper chat template handling
+/// May output in Chinese - use system prompt "Respond in English" if needed
+pub static GLM_4_6V_FLASH_Q4: ModelInfo = ModelInfo {
+    id: "glm-4.6v-flash-q4",
+    name: "GLM-4.6V-Flash 9B Q4",
+    hf_repo: "ggml-org/GLM-4.6V-Flash-GGUF",
+    filename: "GLM-4.6V-Flash-Q4_K_M.gguf",
+    size_mb: 6170,
+    size_category: ModelSize::Large,
+    description: "GLM-4.6V Flash multimodal, excellent reasoning and coding",
+    mlx_optimized: true,
+    ci_suitable: false,
+};
+
 // All models in order of size (smallest to largest)
 static ALL_MODELS: &[&ModelInfo] = &[
     &SMOLLM_135M_Q4,
@@ -217,6 +233,7 @@ static ALL_MODELS: &[&ModelInfo] = &[
     &QWEN_1_5B_Q4,
     &PHI_2_2_7B_Q4,
     &MISTRAL_7B_Q3,
+    &GLM_4_6V_FLASH_Q4,
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
Adds comprehensive integration tests for GLM-4.6V-Flash model support.

**New Tests:**
- `test_glm_model_in_catalog`: Verify catalog entry
- `test_glm_model_detection`: Verify EmbeddedConfig detection
- `test_glm_in_mlx_models`: Verify MLX model listing
- `test_glm_static_model_info`: Verify static reference
- `test_glm_command_generation`: Full generation test (ignored, requires 6.2GB download)
- `test_glm_implementation_status`: Status reporting

**Run Full Test:**
```bash
cargo test test_glm_command_generation -- --ignored
```

**Files Modified:**
- `tests/mlx_integration_test.rs`

**Type:** Test
**Lines changed:** +176 -1

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GLM-4.6V-Flash support to the MLX backend with a GLM-specific chat template, plus integration tests that cover detection, catalog listing, and end‑to‑end command generation.

- **New Features**
  - Added GLM-4.6V-Flash (id: glm-4.6v-flash-q4) to the model catalog as MLX-optimized.
  - EmbeddedConfig now supports model_id and is_glm_model() for template selection.
  - MLX backend builds prompts per model: GLM ([gMASK]<sop>… template) or ChatML by default; shared system prompt enforces English output.
  - Expanded test coverage in tests/mlx_integration_test.rs for catalog entry, detection, MLX listing, static info, E2E generation (ignored), and status reporting.

- **Migration**
  - No breaking changes.
  - To use GLM templating, set EmbeddedConfig.with_model_id("glm-4.6v-flash-q4") when calling MLX inference.
  - Optional E2E test (downloads ~6.2GB): cargo test test_glm_command_generation -- --ignored.

<sup>Written for commit 823183139022913381ae06f573bbb4f2b3d72c3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

