### PR TITLE
docs: Add lessons learned from "Night of the Runbooks" article

### DIFF
--- a/docs/lessons-learned/README.md
+++ b/docs/lessons-learned/README.md
@@ -1,0 +1,36 @@
+# Lessons Learned
+
+This directory contains lessons learned from industry articles, real-world incidents, and community experiences that demonstrate how Caro can help solve common operational challenges.
+
+## Documents
+
+| Document | Source | Key Takeaway |
+|----------|--------|--------------|
+| [Runbook Lessons Learned](RUNBOOK_LESSONS_LEARNED.md) | [Bitfield Consulting](https://bitfieldconsulting.com/posts/night-of-the-runbooks) | How Caro bridges the gap between runbook intent and executable commands |
+
+## Purpose
+
+These documents serve to:
+
+1. **Connect theory to practice** - Show how Caro addresses real-world problems
+2. **Provide actionable examples** - Demonstrate specific use cases
+3. **Build institutional knowledge** - Capture insights from the community
+4. **Guide adoption** - Help teams understand where Caro fits in their workflow
+
+## Contributing
+
+Found an article or experience that highlights problems Caro can solve? We welcome contributions:
+
+1. Create a new markdown file following the naming convention: `TOPIC_LESSONS_LEARNED.md`
+2. Include:
+   - Link to the source material
+   - Problem identification
+   - How Caro addresses each issue
+   - Practical examples
+3. Submit a PR with the new document
+
+## Related Resources
+
+- [Safety Validation](/docs-site/src/content/docs/reference/safety.md)
+- [Configuration Guide](/docs-site/src/content/docs/reference/configuration.md)
+- [Backend Options](/docs-site/src/content/docs/reference/backends.md)

--- a/docs/lessons-learned/RUNBOOK_LESSONS_LEARNED.md
+++ b/docs/lessons-learned/RUNBOOK_LESSONS_LEARNED.md
@@ -1,0 +1,321 @@
+# Lessons Learned: Night of the Runbooks
+
+> How Caro helps prevent incident response nightmares
+
+**Source:** [Night of the Runbooks](https://bitfieldconsulting.com/posts/night-of-the-runbooks) by John Arundel
+
+## Executive Summary
+
+The "Night of the Runbooks" article illustrates a common DevOps scenario: an on-call engineer faces a critical alert. With a well-designed runbook, they resolve the issue quickly. Without one, they're left scrambling in the dark.
+
+**Caro bridges this gap** by translating intent into safe, executable commands—turning every operator into an effective incident responder.
+
+---
+
+## The Problem: Runbook Challenges
+
+### 1. Command Knowledge Gap
+
+**Issue:** Engineers often know *what* they need to do but not the exact *syntax*.
+
+```
+Runbook says: "Check the payment service logs"
+Engineer thinks: "How do I filter by timestamp on this Linux distro again?"
+```
+
+**With Caro:**
+```bash
+$ caro "show payment service logs from the last hour with errors"
+
+Generated command:
+  journalctl -u payment-service --since "1 hour ago" | grep -i error
+
+Execute this command? (y/N)
+```
+
+### 2. Platform Inconsistencies
+
+**Issue:** Commands differ across macOS, Linux distributions, and container environments. Runbooks can't cover every variation.
+
+```
+macOS:      ps aux | sort -nrk 3,3 | head -6
+Linux:      ps aux | sort -nrk 3 | head -6
+Container:  (may not have ps available)
+```
+
+**Caro Solution:** Platform-aware command generation automatically adapts to your environment.
+
+```bash
+# Caro detects: macOS 14.2, ARM64, zsh
+$ caro "show top 5 processes by CPU"
+
+Generated command:
+  ps aux | sort -nrk 3,3 | head -6   # BSD-compatible syntax
+```
+
+### 3. High-Stress Command Entry Errors
+
+**Issue:** Under pressure, engineers make typos or misremember dangerous commands.
+
+```
+Intended: rm -rf /var/log/old/*
+Typed:    rm -rf /var/log/old *    # Space creates TWO arguments!
+```
+
+**Caro Solution:** 52+ safety patterns prevent catastrophic mistakes.
+
+```bash
+$ caro "remove old log files from /var/log"
+
+Generated command:
+  find /var/log -name "*.log" -mtime +30 -delete
+
+Execute this command? (y/N)
+# Safe, specific, no recursive rm
+```
+
+### 4. Missing Runbook Syndrome
+
+**Issue:** The twist in the article—Morgan faces a second alert but there's no runbook for it.
+
+**Caro Solution:** Natural language interface means no runbook needed for common operations.
+
+```bash
+# No runbook? No problem.
+$ caro "check if the API server is responding"
+$ caro "show memory usage of the database container"
+$ caro "restart the nginx service"
+```
+
+---
+
+## How Caro Transforms Incident Response
+
+### Before Caro: The Traditional Runbook Approach
+
+```
+1. Alert fires
+2. Find the runbook (if it exists)
+3. Parse through documentation
+4. Copy commands (hoping for correct platform)
+5. Validate commands manually
+6. Execute with fingers crossed
+```
+
+### With Caro: Intent-Driven Response
+
+```
+1. Alert fires
+2. Describe what you need in plain English
+3. Caro generates platform-aware command
+4. Review the safe, validated command
+5. Execute with confidence
+```
+
+---
+
+## Practical Incident Response Scenarios
+
+### Scenario 1: Service Health Check
+
+**Runbook step:** "Verify the payment service is running"
+
+```bash
+$ caro "check if payment-service systemd unit is running and show recent logs"
+
+Generated command:
+  systemctl status payment-service && journalctl -u payment-service -n 20
+
+Execute this command? (y/N)
+```
+
+### Scenario 2: Rollback Deployment
+
+**Runbook step:** "Roll back to previous version if tests fail"
+
+```bash
+$ caro "show last 5 kubernetes deployments for payment-api namespace"
+
+Generated command:
+  kubectl rollout history deployment/payment-api -n production | tail -5
+
+Execute this command? (y/N)
+
+$ caro "rollback payment-api deployment to previous revision"
+
+Generated command:
+  kubectl rollout undo deployment/payment-api -n production
+
+Execute this command? (y/N)
+```
+
+### Scenario 3: Resource Investigation
+
+**Runbook step:** "Check for resource exhaustion"
+
+```bash
+$ caro "show disk usage by directory in /var sorted by size"
+
+Generated command:
+  du -h /var --max-depth=1 | sort -hr | head -20
+
+Execute this command? (y/N)
+
+$ caro "find files larger than 100MB modified in the last day"
+
+Generated command:
+  find / -type f -size +100M -mtime -1 2>/dev/null
+
+Execute this command? (y/N)
+```
+
+### Scenario 4: Network Diagnostics
+
+**Runbook step:** "Check connectivity to downstream services"
+
+```bash
+$ caro "check if database port 5432 is accessible on db.internal"
+
+Generated command:
+  nc -zv db.internal 5432
+
+Execute this command? (y/N)
+```
+
+---
+
+## Safety Features for Incident Response
+
+### Risk Level Visibility
+
+Caro color-codes commands by risk level:
+
+| Level | Color | Example |
+|-------|-------|---------|
+| Safe | Green | `ls`, `cat`, `grep` |
+| Moderate | Yellow | `cp`, `mv`, file modifications |
+| High | Orange | `sudo`, system paths |
+| Critical | Red | Destructive operations (blocked) |
+
+### Dangerous Pattern Protection
+
+During incidents, tired engineers make mistakes. Caro blocks:
+
+- `rm -rf /` and variants
+- Fork bombs
+- Disk-wiping operations
+- Accidental privilege escalation
+
+### Confirmation Workflow
+
+```bash
+$ caro "remove all containers and images"
+
+Generated command:
+  docker system prune -a --volumes
+
+⚠️  HIGH RISK: This will remove all unused containers, images, and volumes
+
+Execute this command? (y/N)
+```
+
+---
+
+## Building Caro-Enhanced Runbooks
+
+### Traditional Runbook Entry
+
+```markdown
+### Step 3: Clear Application Cache
+
+Run the following command to clear the Redis cache:
+
+```bash
+redis-cli FLUSHDB
+```
+
+**Warning:** Ensure you're connected to the correct Redis instance.
+```
+
+### Caro-Enhanced Runbook Entry
+
+```markdown
+### Step 3: Clear Application Cache
+
+Use caro to safely clear the cache:
+
+```bash
+caro "flush the redis database for the app cache"
+```
+
+Caro will:
+- Generate the appropriate redis-cli command
+- Confirm before execution
+- Work across different Redis configurations
+```
+
+---
+
+## Key Takeaways
+
+### 1. Intent Over Syntax
+
+Runbooks document *what* needs to happen. Caro translates *what* into *how* for your specific environment.
+
+### 2. Safety Net for Stress
+
+When adrenaline is high, Caro's validation prevents costly mistakes.
+
+### 3. Platform Agnostic Operations
+
+One natural language description works across macOS, Linux, and containers.
+
+### 4. Reduced Runbook Maintenance
+
+Instead of maintaining commands for every platform version, document the intent. Caro handles the rest.
+
+### 5. On-Call Confidence
+
+New engineers can respond to incidents effectively without memorizing command syntax.
+
+---
+
+## Getting Started
+
+### Installation
+
+```bash
+# Quick install (recommended)
+curl -fsSL https://raw.githubusercontent.com/wildcard/caro/main/install.sh | bash
+
+# Or via cargo
+cargo install caro
+```
+
+### First Incident Response Commands
+
+```bash
+# System health
+caro "show system load and memory usage"
+
+# Service status
+caro "check status of all running docker containers"
+
+# Log investigation
+caro "search syslog for errors in the last 30 minutes"
+
+# Network debugging
+caro "show all listening TCP ports"
+```
+
+---
+
+## References
+
+- [Night of the Runbooks](https://bitfieldconsulting.com/posts/night-of-the-runbooks) - Original article by John Arundel
+- [Caro Safety Documentation](/docs-site/src/content/docs/reference/safety.md) - Safety validation details
+- [Caro Quick Start](/README.md) - Installation and usage guide
+
+---
+
+*"The best runbook is one that lets you focus on the problem, not the syntax."*


### PR DESCRIPTION
Documents key lessons from runbook automation practices.

**New Docs:**
- RUNBOOK_LESSONS_LEARNED.md (321 lines)
- README.md for lessons-learned directory

**Type:** Documentation (+357)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Lessons Learned” docs set based on “Night of the Runbooks,” showing how Caro turns runbook intent into safe, platform-aware commands for faster incident response. Improves onboarding with practical scenarios, safety guidance, and links to reference docs.

- **New Docs**
  - Added docs/lessons-learned/RUNBOOK_LESSONS_LEARNED.md with scenarios (health checks, rollbacks, resource/network diagnostics), safety features, and starter commands.
  - Added docs/lessons-learned/README.md with purpose, contribution guide, and references.
  - Maps article challenges (syntax gaps, platform differences, stress errors, missing runbooks) to Caro’s capabilities.

<sup>Written for commit 84fdc087f8e59eb8f1d89727e7c51f8d1ca222e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

