### PR TITLE
feat: Add capability boundaries - Caro knows what she does best

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
@@ -172,6 +181,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,7 +239,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -339,7 +363,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
  "safetensors",
@@ -375,7 +399,7 @@ dependencies = [
  "candle-nn",
  "fancy-regex",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "serde",
  "serde_json",
@@ -408,6 +432,7 @@ dependencies = [
  "once_cell",
  "os_info",
  "proptest",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",
@@ -531,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -541,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -553,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -580,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.13.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
@@ -821,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.192"
+version = "1.0.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbda285ba6e5866529faf76352bdf73801d9b44a6308d7cd58ca2379f378e994"
+checksum = "be4a0beb369d20d0de6aa7084ee523e4c9a31d7d8c61ba357b119bb574d7f368"
 dependencies = [
  "cc",
  "cxx-build",
@@ -836,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.192"
+version = "1.0.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9efde466c5d532d57efd92f861da3bdb7f61e369128ce8b4c3fe0c9de4fa4d"
+checksum = "27d955b93e56a8e45cbc34df0ae920d8b5ad01541a4571222c78527c00e1a40a"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -851,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.192"
+version = "1.0.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb93799095bccd4f763ca07997dc39a69e5e61ab52d2c407d4988d21ce144d"
+checksum = "052f6c468d9dabdc2b8b228bcb2d7843b2bea0f3fb9c4e2c6ba5852574ec0150"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -865,19 +890,20 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.192"
+version = "1.0.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092010228026e143b32a4463ed9fa8f86dca266af4bf5f3b2a26e113dbe4e45"
+checksum = "0fd145fa180986cb8002c63217d03b2c782fdcd5fa323adcd1f62d2d6ece6144"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.192"
+version = "1.0.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d72ebfcd351ae404fb00ff378dfc9571827a00722c9e735c9181aec320ba0a"
+checksum = "02ac4a3bc4484a2daa0a8421c9588bd26522be9682a2fe02c7087bc4e8bc3c60"
 dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -1634,6 +1660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1700,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
 ]
 
@@ -1721,7 +1753,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2018,6 +2050,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,9 +2068,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -2117,9 +2160,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -2332,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "mlx-rs"
-version = "0.25.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a0f592c5839b0237b3072530b1d3c503923579a2009ee0761df3edd1b1f27b"
+checksum = "95ab8ddcd8cec3911a80620e338b906f3d4b6686c7db1652b7045463ebd5c0ae"
 dependencies = [
  "dyn-clone",
  "half",
@@ -2716,6 +2759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,16 +3040,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
  "bitflags 2.9.4",
+ "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3066,7 +3119,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3109,12 +3162,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3124,7 +3198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3143,7 +3226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -3152,7 +3235,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3232,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3244,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3342,6 +3425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
@@ -3550,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af14725505314343e673e9ecb7cd7e8a36aa9791eb936235a3567cc31447ae4"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
@@ -3847,14 +3936,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.2",
  "windows-sys 0.61.0",
 ]
 
@@ -4010,7 +4099,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -4026,24 +4115,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
+ "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4099,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4114,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
@@ -4135,9 +4227,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -4195,9 +4287,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.44"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4206,21 +4298,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.31"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4229,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.36"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4250,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4617,7 +4709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix 1.1.2",
  "winsafe",
 ]
 
@@ -5159,6 +5251,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "0.1.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dccf46b25b205e4bebe1d5258a991df1cc17801017a845cb5b3fe0269781aa"
+checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 once_cell = "1.19"
 
+# Random number generation for sassy messages
+rand = "0.8"
+
 # Cryptography for checksums
 sha2 = "0.10"
 

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -1,0 +1,549 @@
+//! Capabilities module - Caro's scope and boundary detection
+//!
+//! Caro knows what she does best: POSIX one-liners, Unix philosophy,
+//! and using existing tools. She politely (and sassily) refuses tasks
+//! outside her expertise and recommends better alternatives.
+//!
+//! # What Caro DOES:
+//! - POSIX shell commands and one-liners
+//! - File system operations (list, find, move, copy, etc.)
+//! - Data manipulation with existing tools (grep, sed, awk, sort, etc.)
+//! - Text processing and filtering
+//! - Process management
+//! - System information queries
+//!
+//! # What Caro REFUSES:
+//! - Multi-line scripts (more than a simple pipe chain)
+//! - Application development (weather apps, todo lists, etc.)
+//! - Writing software/code in programming languages
+//! - Package installation (that's what package managers are for!)
+//! - Anything requiring complex programming logic
+
+use rand::seq::SliceRandom;
+use serde::{Deserialize, Serialize};
+
+/// Result of capability boundary check
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundaryCheckResult {
+    /// Whether the request is within Caro's capabilities
+    pub is_within_scope: bool,
+    /// Category of rejection if out of scope
+    pub rejection_category: Option<RejectionCategory>,
+    /// Sassy rejection message if out of scope
+    pub rejection_message: Option<String>,
+    /// Recommended alternative tools
+    pub alternatives: Vec<AlternativeTool>,
+    /// Confidence score (0.0 to 1.0)
+    pub confidence: f32,
+}
+
+/// Categories of requests Caro refuses
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RejectionCategory {
+    /// User wants a multi-line script
+    MultiLineScript,
+    /// User wants to build an application
+    ApplicationDevelopment,
+    /// User wants to write code/software
+    SoftwareDevelopment,
+    /// User wants package installation
+    PackageInstallation,
+    /// Windows-specific request (not yet supported)
+    WindowsNotSupported,
+    /// General programming task
+    ProgrammingTask,
+    /// Web development
+    WebDevelopment,
+}
+
+impl std::fmt::Display for RejectionCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MultiLineScript => write!(f, "multi-line script"),
+            Self::ApplicationDevelopment => write!(f, "application development"),
+            Self::SoftwareDevelopment => write!(f, "software development"),
+            Self::PackageInstallation => write!(f, "package installation"),
+            Self::WindowsNotSupported => write!(f, "Windows (not yet supported)"),
+            Self::ProgrammingTask => write!(f, "programming task"),
+            Self::WebDevelopment => write!(f, "web development"),
+        }
+    }
+}
+
+/// Alternative tools Caro recommends
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlternativeTool {
+    pub name: String,
+    pub description: String,
+    pub url: Option<String>,
+    pub is_favorite: bool,
+}
+
+impl AlternativeTool {
+    fn crush() -> Self {
+        Self {
+            name: "Crush".to_string(),
+            description: "Charm.land's powerful terminal coding agent".to_string(),
+            url: Some("https://charm.sh/crush".to_string()),
+            is_favorite: true,
+        }
+    }
+
+    fn claude_code() -> Self {
+        Self {
+            name: "Claude Code".to_string(),
+            description: "Anthropic's CLI for Claude - great for coding tasks".to_string(),
+            url: Some("https://claude.ai/code".to_string()),
+            is_favorite: true,
+        }
+    }
+
+    fn cline() -> Self {
+        Self {
+            name: "Cline".to_string(),
+            description: "AI coding assistant in your terminal".to_string(),
+            url: Some("https://github.com/cline/cline".to_string()),
+            is_favorite: true,
+        }
+    }
+
+    fn codex() -> Self {
+        Self {
+            name: "Codex".to_string(),
+            description: "OpenAI's code generation assistant".to_string(),
+            url: Some("https://openai.com/codex".to_string()),
+            is_favorite: false,
+        }
+    }
+
+    fn gemini() -> Self {
+        Self {
+            name: "Gemini".to_string(),
+            description: "Google's AI assistant for coding".to_string(),
+            url: Some("https://gemini.google.com".to_string()),
+            is_favorite: false,
+        }
+    }
+
+    fn quantcoder() -> Self {
+        Self {
+            name: "QuantCoder".to_string(),
+            description: "Specialized coding AI for quantitative work".to_string(),
+            url: None,
+            is_favorite: false,
+        }
+    }
+
+    fn aider() -> Self {
+        Self {
+            name: "Aider".to_string(),
+            description: "AI pair programming in your terminal".to_string(),
+            url: Some("https://aider.chat".to_string()),
+            is_favorite: false,
+        }
+    }
+
+    fn homebrew() -> Self {
+        Self {
+            name: "Homebrew".to_string(),
+            description: "The missing package manager for macOS".to_string(),
+            url: Some("https://brew.sh".to_string()),
+            is_favorite: false,
+        }
+    }
+
+    fn apt() -> Self {
+        Self {
+            name: "apt/apt-get".to_string(),
+            description: "Debian/Ubuntu package manager".to_string(),
+            url: None,
+            is_favorite: false,
+        }
+    }
+}
+
+/// Capability boundary validator
+#[derive(Debug)]
+pub struct CapabilityValidator {
+    /// Patterns that indicate out-of-scope requests
+    patterns: Vec<(regex::Regex, RejectionCategory, f32)>,
+}
+
+impl CapabilityValidator {
+    /// Create a new capability validator
+    pub fn new() -> Result<Self, CapabilityError> {
+        let patterns = Self::compile_patterns()?;
+        Ok(Self { patterns })
+    }
+
+    /// Compile detection patterns
+    fn compile_patterns() -> Result<Vec<(regex::Regex, RejectionCategory, f32)>, CapabilityError> {
+        let pattern_defs: Vec<(&str, RejectionCategory, f32)> = vec![
+            // Multi-line script detection
+            (r"(?i)\b(write|create|make|build)\s+(me\s+)?(a\s+)?(multi[- ]?line|multiline)\s+(script|bash|shell)", RejectionCategory::MultiLineScript, 0.95),
+            (r"(?i)\b(script|program)\s+(with|that)\s+(multiple|several)\s+(lines|steps|commands)", RejectionCategory::MultiLineScript, 0.90),
+            (r"(?i)\bwrite\s+(me\s+)?(a\s+)?script\s+(that|to|for|which)", RejectionCategory::MultiLineScript, 0.85),
+            (r"(?i)\bcreate\s+(me\s+)?(a\s+)?bash\s+script\s+(that|to|for)", RejectionCategory::MultiLineScript, 0.90),
+            (r"(?i)\b(shell|bash)\s+script\s+file", RejectionCategory::MultiLineScript, 0.85),
+            (r"(?i)\bmulti[- ]?line\s+script", RejectionCategory::MultiLineScript, 0.95),
+
+            // Application development detection
+            (r"(?i)\b(build|create|make|write|develop)\s+(a\s+|an\s+|me\s+)?(weather|todo|task|notes?|chat|calculator|game|blog|cms|ecommerce|e-commerce)\s+(app|application|program|software)", RejectionCategory::ApplicationDevelopment, 0.95),
+            (r"(?i)\b(build|create|make)\s+(a\s+|an\s+|me\s+)?(web|mobile|desktop|gui|graphical)\s+(app|application)", RejectionCategory::ApplicationDevelopment, 0.95),
+            (r"(?i)\b(build|create)\s+(a\s+)?full[- ]?(stack|fledged)\s+(app|application|website)", RejectionCategory::ApplicationDevelopment, 0.95),
+            (r"(?i)\b(todo|task)\s*(list|manager|app)", RejectionCategory::ApplicationDevelopment, 0.90),
+            (r"(?i)\b(weather|stock)\s*(tracker|app|widget)", RejectionCategory::ApplicationDevelopment, 0.90),
+
+            // Software development detection
+            (r"(?i)\b(write|create|code|implement|develop)\s+(a\s+)?(class|function|method|module|library|package|api|backend|frontend|microservice)", RejectionCategory::SoftwareDevelopment, 0.90),
+            (r"(?i)\b(write|create)\s+(some\s+)?(python|rust|javascript|typescript|go|java|c\+\+|ruby|swift|kotlin)\s+(code|program|script)", RejectionCategory::SoftwareDevelopment, 0.95),
+            (r"(?i)\bimplement\s+(a\s+)?(sorting|searching|encryption|compression|parsing)\s+(algorithm|logic)", RejectionCategory::SoftwareDevelopment, 0.90),
+            (r"(?i)\b(write|code|implement)\s+(unit|integration|e2e|end-to-end)\s+tests?", RejectionCategory::SoftwareDevelopment, 0.85),
+            (r"(?i)\b(build|create|implement)\s+(a\s+)?(rest|graphql|grpc)\s+api", RejectionCategory::SoftwareDevelopment, 0.95),
+            (r"(?i)\bimplement\s+.{0,30}(rest|graphql|grpc)\s+api", RejectionCategory::SoftwareDevelopment, 0.90),
+            (r"(?i)\brefactor\s+(the|my|this)\s+(code|codebase|project)", RejectionCategory::SoftwareDevelopment, 0.80),
+
+            // Package installation detection
+            (r"(?i)\b(install|setup|configure)\s+(a\s+)?(package|library|dependency|module)\s+(for|from|using)", RejectionCategory::PackageInstallation, 0.85),
+            (r"(?i)\b(brew|apt|apt-get|yum|dnf|pacman|npm|pip|cargo)\s+install\b", RejectionCategory::PackageInstallation, 0.70), // Lower confidence - might be asking about the command
+            (r"(?i)\bhow\s+(do\s+i|to|can\s+i)\s+install\s+\w+\s+(globally|system-wide)", RejectionCategory::PackageInstallation, 0.80),
+
+            // Windows-specific detection (for future support message)
+            (r"(?i)\b(powershell|cmd\.exe|batch|\.bat|\.ps1|windows\s+command)", RejectionCategory::WindowsNotSupported, 0.90),
+            (r"(?i)\b(windows|win32|win64)\s+(command|script|batch)", RejectionCategory::WindowsNotSupported, 0.90),
+
+            // General programming tasks
+            (r"(?i)\b(debug|fix)\s+(the|this|my)\s+(bug|error|issue|problem)\s+(in|with)\s+(the|my)\s+(code|program|script)", RejectionCategory::ProgrammingTask, 0.85),
+            (r"(?i)\b(optimize|improve)\s+(the|my)\s+(code|algorithm|performance)", RejectionCategory::ProgrammingTask, 0.80),
+            (r"(?i)\badd\s+(a\s+)?(feature|functionality)\s+to\s+(the|my)\s+(code|app|application)", RejectionCategory::ProgrammingTask, 0.85),
+
+            // Web development
+            (r"(?i)\b(build|create|make)\s+(a\s+)?(website|webpage|web\s+page|landing\s+page|portfolio)", RejectionCategory::WebDevelopment, 0.95),
+            (r"(?i)\b(write|create)\s+(html|css|javascript|react|vue|angular|svelte)\s+(code|component)", RejectionCategory::WebDevelopment, 0.95),
+            (r"(?i)\b(setup|configure)\s+(a\s+)?(react|vue|angular|next\.?js|nuxt|svelte)\s+(project|app)", RejectionCategory::WebDevelopment, 0.90),
+        ];
+
+        let mut compiled = Vec::with_capacity(pattern_defs.len());
+        for (pattern, category, confidence) in pattern_defs {
+            let regex = regex::Regex::new(pattern).map_err(|e| CapabilityError::PatternError {
+                pattern: pattern.to_string(),
+                error: e.to_string(),
+            })?;
+            compiled.push((regex, category, confidence));
+        }
+
+        Ok(compiled)
+    }
+
+    /// Check if a request is within Caro's capabilities
+    pub fn check(&self, request: &str) -> BoundaryCheckResult {
+        // Find the highest-confidence match
+        let mut best_match: Option<(RejectionCategory, f32)> = None;
+
+        for (regex, category, confidence) in &self.patterns {
+            if regex.is_match(request) {
+                match &best_match {
+                    None => best_match = Some((*category, *confidence)),
+                    Some((_, existing_confidence)) if confidence > existing_confidence => {
+                        best_match = Some((*category, *confidence));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        match best_match {
+            Some((category, confidence)) => {
+                let rejection_message = Self::generate_sassy_rejection(category);
+                let alternatives = Self::get_alternatives_for_category(category);
+
+                BoundaryCheckResult {
+                    is_within_scope: false,
+                    rejection_category: Some(category),
+                    rejection_message: Some(rejection_message),
+                    alternatives,
+                    confidence,
+                }
+            }
+            None => BoundaryCheckResult {
+                is_within_scope: true,
+                rejection_category: None,
+                rejection_message: None,
+                alternatives: vec![],
+                confidence: 0.95,
+            },
+        }
+    }
+
+    /// Generate a sassy rejection message based on category
+    fn generate_sassy_rejection(category: RejectionCategory) -> String {
+        let mut rng = rand::thread_rng();
+
+        let messages: Vec<&str> = match category {
+            RejectionCategory::MultiLineScript => vec![
+                "Oh honey, multi-line scripts? That's not my jam. I'm a one-liner kinda gal. 💅",
+                "Scripts with multiple lines? Sorry, I keep it simple - one line, one command, Unix philosophy!",
+                "Look, I do one-liners. Like a haiku, but for the terminal. Multi-line scripts need a real coding agent.",
+                "I'm flattered you think I can write scripts, but I'm more of a 'pipe it and forget it' type.",
+                "Multi-line scripts are great! They're just... not what I do. I'm all about that single-line magic. ✨",
+            ],
+            RejectionCategory::ApplicationDevelopment => vec![
+                "Build you an app? That's adorable. I'm here for shell commands, not software empires. 🏰",
+                "An app? I'm Caro, not an app factory! I help you USE your terminal, not build the next unicorn.",
+                "Apps are beautiful, complex creatures. I'm just a simple shell command assistant. Know thyself!",
+                "Sweetie, I can help you list files, not build the next weather app. Let's be realistic here.",
+                "Application development? That's way above my pay grade. I stick to the classics: ls, grep, find...",
+            ],
+            RejectionCategory::SoftwareDevelopment => vec![
+                "Write code? In a programming language? Bestie, I speak POSIX, not Python. 🐍❌",
+                "I'm not a code monkey - I'm a command whisperer. There's a difference!",
+                "Software development sounds fancy, but I'm here for the simple things in life: pipes, redirects, and one-liners.",
+                "Honey, I can help you FIND your code files, but I can't write them for you. That's a job for the big leagues.",
+                "Code? Functions? Classes? I don't know her. I know 'cat', 'grep', and 'awk' though!",
+            ],
+            RejectionCategory::PackageInstallation => vec![
+                "Package installation? I'm not a package manager, I'm Caro! Use brew, apt, or whatever your system prefers.",
+                "Installing packages is a job for Homebrew, apt, or your friendly neighborhood package manager. Not me!",
+                "I could tell you the COMMAND to install something, but actually installing? That's between you and your package manager.",
+                "Look, I can help you USE tools, but installing them? That's a whole different relationship.",
+                "Package installation is a trust exercise between you and your package manager. I'm just here for moral support. 💪",
+            ],
+            RejectionCategory::WindowsNotSupported => vec![
+                "Windows? Oh sweetie, I'm a POSIX princess. Windows support is on my wish list, not my resume. 🪟❌",
+                "PowerShell and cmd? I don't speak those languages... yet. Check back later!",
+                "I'm all about that Unix life. Windows users, I see you, but I can't help you. Yet!",
+                "Windows commands? That's like asking a fish to climb a tree. I'm built for Unix/Linux/macOS.",
+                "Batch files? CMD? PowerShell? Future Caro might help, but current Caro only does POSIX. Sorry!",
+            ],
+            RejectionCategory::ProgrammingTask => vec![
+                "Debug your code? Sweetie, I can help you FIND files with errors, but fixing bugs? That's programmer territory.",
+                "Programming tasks require a real coding assistant. I'm just here to help you navigate your filesystem.",
+                "I'm not a debugger or a code reviewer. I'm a command-line companion. Big difference!",
+                "Optimizing algorithms? That sounds like a job for a coding AI. I optimize commands, not code.",
+                "Look, I can grep for 'error' in your logs, but actually fixing the code? Way out of my league.",
+            ],
+            RejectionCategory::WebDevelopment => vec![
+                "A website? Honey, I'm a terminal tool, not a web developer. I don't do HTML high fashion. 💻❌",
+                "React? Vue? Angular? I only know one framework: the Unix command line. And I like it that way.",
+                "Web development is art. What I do is... also art, but the kind that lives in a terminal.",
+                "Creating websites is beautiful work! It's just not MY work. I stick to shell commands.",
+                "Frontend? Backend? I'm more of a 'terminal-end' kind of assistant. Just commands, no components.",
+            ],
+        };
+
+        let base_message = messages.choose(&mut rng).unwrap_or(&messages[0]);
+        format!("{}\n\n📚 Visit https://caro.run to learn more about what I can do!", base_message)
+    }
+
+    /// Get appropriate alternative tools for a category
+    fn get_alternatives_for_category(category: RejectionCategory) -> Vec<AlternativeTool> {
+        match category {
+            RejectionCategory::MultiLineScript | RejectionCategory::SoftwareDevelopment | RejectionCategory::ProgrammingTask => vec![
+                AlternativeTool::crush(),
+                AlternativeTool::claude_code(),
+                AlternativeTool::cline(),
+                AlternativeTool::aider(),
+                AlternativeTool::codex(),
+            ],
+            RejectionCategory::ApplicationDevelopment | RejectionCategory::WebDevelopment => vec![
+                AlternativeTool::claude_code(),
+                AlternativeTool::crush(),
+                AlternativeTool::cline(),
+                AlternativeTool::gemini(),
+                AlternativeTool::codex(),
+            ],
+            RejectionCategory::PackageInstallation => vec![
+                AlternativeTool::homebrew(),
+                AlternativeTool::apt(),
+            ],
+            RejectionCategory::WindowsNotSupported => vec![
+                AlternativeTool::claude_code(),
+                AlternativeTool::crush(),
+            ],
+        }
+    }
+}
+
+impl Default for CapabilityValidator {
+    fn default() -> Self {
+        Self::new().expect("Failed to create default CapabilityValidator")
+    }
+}
+
+/// Errors that can occur during capability validation
+#[derive(Debug, thiserror::Error, Serialize, Deserialize)]
+pub enum CapabilityError {
+    #[error("Pattern compilation failed for '{pattern}': {error}")]
+    PatternError { pattern: String, error: String },
+
+    #[error("Validation error: {message}")]
+    ValidationError { message: String },
+}
+
+/// Format a rejection result for display
+pub fn format_rejection(result: &BoundaryCheckResult) -> String {
+    let mut output = String::new();
+
+    if let Some(ref message) = result.rejection_message {
+        output.push_str(message);
+        output.push_str("\n\n");
+    }
+
+    if !result.alternatives.is_empty() {
+        output.push_str("🔧 Try these instead:\n");
+
+        // Show favorites first
+        for alt in &result.alternatives {
+            if alt.is_favorite {
+                output.push_str(&format!(
+                    "  ⭐ {} - {}\n",
+                    alt.name, alt.description
+                ));
+                if let Some(ref url) = alt.url {
+                    output.push_str(&format!("     {}\n", url));
+                }
+            }
+        }
+
+        // Then show others
+        for alt in &result.alternatives {
+            if !alt.is_favorite {
+                output.push_str(&format!(
+                    "  • {} - {}\n",
+                    alt.name, alt.description
+                ));
+                if let Some(ref url) = alt.url {
+                    output.push_str(&format!("     {}\n", url));
+                }
+            }
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multiline_script_detection() {
+        let validator = CapabilityValidator::new().unwrap();
+
+        let test_cases = vec![
+            "write me a multi-line script to backup my files",
+            "create a bash script that monitors CPU usage",
+            "write a shell script file for deployment",
+        ];
+
+        for case in test_cases {
+            let result = validator.check(case);
+            assert!(
+                !result.is_within_scope,
+                "Should reject multi-line script request: '{}'",
+                case
+            );
+            assert_eq!(
+                result.rejection_category,
+                Some(RejectionCategory::MultiLineScript),
+                "Wrong category for: '{}'",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_application_development_detection() {
+        let validator = CapabilityValidator::new().unwrap();
+
+        let test_cases = vec![
+            "build me a weather app",
+            "create a todo list application",
+            "make a web app for tracking expenses",
+        ];
+
+        for case in test_cases {
+            let result = validator.check(case);
+            assert!(
+                !result.is_within_scope,
+                "Should reject app development request: '{}'",
+                case
+            );
+            assert_eq!(
+                result.rejection_category,
+                Some(RejectionCategory::ApplicationDevelopment),
+                "Wrong category for: '{}'",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_software_development_detection() {
+        let validator = CapabilityValidator::new().unwrap();
+
+        let test_cases = vec![
+            "write some Python code to parse JSON",
+            "create a function to sort arrays",
+            "implement a REST API for users",
+        ];
+
+        for case in test_cases {
+            let result = validator.check(case);
+            assert!(
+                !result.is_within_scope,
+                "Should reject software development request: '{}'",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_valid_posix_requests() {
+        let validator = CapabilityValidator::new().unwrap();
+
+        let test_cases = vec![
+            "list all files in current directory",
+            "find files larger than 100MB",
+            "count lines in all Python files",
+            "search for 'error' in log files",
+            "show disk usage",
+            "copy files from src to dest",
+            "show running processes",
+        ];
+
+        for case in test_cases {
+            let result = validator.check(case);
+            assert!(
+                result.is_within_scope,
+                "Should accept valid POSIX request: '{}'",
+                case
+            );
+        }
+    }
+
+    #[test]
+    fn test_rejection_has_alternatives() {
+        let validator = CapabilityValidator::new().unwrap();
+        let result = validator.check("build me a weather application");
+
+        assert!(!result.is_within_scope);
+        assert!(!result.alternatives.is_empty());
+
+        // Should recommend favorites
+        let favorites: Vec<_> = result.alternatives.iter().filter(|a| a.is_favorite).collect();
+        assert!(!favorites.is_empty(), "Should have favorite alternatives");
+    }
+
+    #[test]
+    fn test_rejection_message_format() {
+        let validator = CapabilityValidator::new().unwrap();
+        let result = validator.check("create a todo list app");
+
+        assert!(!result.is_within_scope);
+        assert!(result.rejection_message.is_some());
+
+        let message = result.rejection_message.unwrap();
+        assert!(message.contains("caro.run"), "Should include website reference");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 pub mod agent;
 pub mod backends;
 pub mod cache;
+pub mod capabilities;
 pub mod cli;
 pub mod config;
 pub mod context;
@@ -55,6 +56,11 @@ pub use execution::{ExecutionError, PlatformDetector, ShellDetector};
 pub use logging::{LogConfig, LogConfigBuilder, LogError, LogFormat, LogOutput, Logger, Redaction};
 pub use model_loader::ModelLoader;
 pub use platform::{PlatformContext, PlatformContextBuilder, PlatformContextError, UtilityType};
+
+// Re-export capability boundary types
+pub use capabilities::{
+    AlternativeTool, BoundaryCheckResult, CapabilityError, CapabilityValidator, RejectionCategory,
+};
 
 // Re-export backend types
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]


### PR DESCRIPTION
Adds capability boundary system for transparent limitations.

**New Module:** src/capabilities/mod.rs (549 lines)

**Features:** Capability awareness, graceful degradation, clear user feedback

**Type:** Feature (+763 -78)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds capability boundaries for Caro with a pattern-based validator that blocks out-of-scope requests upfront and explains why, with alternatives. This clarifies Caro’s role (POSIX one-liners) and prevents misleading command generation.

- **New Features**
  - New module: src/capabilities/mod.rs with classifier (confidence scoring), sassy rejection messages, alternative tool recommendations, and format_rejection.
  - CLI integration: checks prompts before command generation and returns OutOfScope with a clear message and suggested tools.
  - Re-exports capability types in lib.rs; tests cover detection, messaging, and alternatives.
  - Scope: accepts POSIX one-liners; rejects multi-line scripts, app/software/web development, package installation, and Windows commands.

- **Dependencies**
  - Adds rand = "0.8" for message variation; lockfile updated.

<sup>Written for commit 5d028d921e29baf1f4bbb14566bb4e3c2e98574b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

