### PR TITLE
Add reusable prompt for product launch analysis

### DIFF
--- a/docs/PRODUCT_LAUNCH_ANALYSIS.md
+++ b/docs/PRODUCT_LAUNCH_ANALYSIS.md
@@ -1,6 +1,6 @@
-# Product Launch Analysis: Meetily (meeting-minutes)
+# Product Launch Analysis: Meetily & Daytona
 
-A deep-dive analysis of how Zackriya Solutions positioned, launched, and grew their open-source AI meeting assistant. This document extracts actionable insights for caro's own product launch strategy.
+A deep-dive analysis of two successful open-source product launches—Meetily (AI meeting assistant) and Daytona (dev environment manager)—to extract actionable insights for caro's product launch strategy.
 
 ---
 
@@ -405,8 +405,392 @@ Both products appeal to users who:
 
 ---
 
+# Part 2: Daytona Case Study
+
+Daytona achieved **41k GitHub stars**, **#1 open-source CDE**, and **$5M seed funding** through a sophisticated multi-launch strategy. Their playbook adds critical dimensions to Meetily's insights.
+
+---
+
+## 13. Daytona Overview
+
+### The Numbers
+
+| Metric | Value | Timeframe |
+|--------|-------|-----------|
+| GitHub Stars | 41,000+ | 9 months |
+| Initial Traction | 2,000 stars | 48 hours |
+| Product Hunt Rank | #2 on day, #5 for week | Launch day |
+| Funding | $5M seed | 2024 |
+| Contributors | 207 | Current |
+
+### Positioning Evolution
+
+**Phase 1 (March 2024)**: "Open-source dev environment manager"
+**Phase 2 (2025)**: "Secure Infrastructure for Running AI-Generated Code"
+
+This pivot shows strategic timing with AI agent adoption curve.
+
+---
+
+## 14. Dual Messaging Strategy (Daytona's Secret)
+
+### The Split Narrative Approach
+
+Daytona mastered audience-specific messaging:
+
+| Audience | Message | Language |
+|----------|---------|----------|
+| GitHub/Community | "2x more productive" | Outcome-focused, emotional |
+| Enterprise/Website | "Sub-90ms infrastructure" | Technical proof, B2B |
+
+### Why This Works
+
+- **Developers** want to feel faster, not read specs
+- **Enterprises** need metrics for procurement justification
+- Same product, different entry points
+
+### Apply to caro
+
+| Audience | Current Message | Upgraded Message |
+|----------|-----------------|------------------|
+| GitHub/PH | "Safe shell commands" | "Stop being terrified of AI running shell commands—caro keeps you safe" |
+| Enterprise | "Safety validation" | "Safety-first shell automation for AI agents—deploy with confidence" |
+
+**Key insight**: Emphasize **relief from anxiety**, not just technical features.
+
+---
+
+## 15. Testimonial Strategy
+
+### How Daytona Seeded Social Proof
+
+Daytona didn't wait for organic testimonials—they **manufactured momentum**:
+
+1. Identified ecosystem influencers (LangChain founder, SambaNova CPO)
+2. Offered early access in exchange for feedback
+3. Featured endorsements prominently on website
+4. Used "backed by founders from Postman, Netlify, Supabase, StackOverflow"
+
+### The Pre-Launch Testimonial Play
+
+| Week | Action |
+|------|--------|
+| -4 | Identify 5 projects that desperately need safe shell execution |
+| -3 | Reach out: "We built this specifically for your use case" |
+| -2 | Offer free early access in exchange for testimonial |
+| -1 | Feature quotes in README and launch materials |
+
+### Target Projects for caro Testimonials
+
+1. **Claude Agent Frameworks** - Need safe command execution
+2. **Terminal Automation Tools** - Shell safety is their pain point
+3. **DevOps Platforms** - Production safety is critical
+4. **AI Coding Assistants** - Running generated code safely
+5. **CI/CD Tools** - Command injection prevention
+
+---
+
+## 16. README as Marketing (Daytona's Structure)
+
+### Winning README Sequence
+
+1. **Problem statement** (implied through context)
+2. **Quantified benefits** ("Sub-90ms," "41k stars")
+3. **Code examples** (copy-paste ready, Python & TypeScript)
+4. **Quick 3-step start**
+5. **Multiple CTAs** (account creation, docs, community)
+
+### Daytona's Badge Strategy
+
+```
+[Stars] [Forks] [License] [Go Report] [Product Hunt] [Docs]
+```
+
+Badges establish credibility at a glance before any text is read.
+
+### caro README Upgrade (Week -4)
+
+**Lead with emotion, not features:**
+```
+Stop typing 'rm -rf' with your hands shaking.
+```
+
+**Add quantified proof:**
+```
+0 systems compromised • 1000+ commands executed safely • <100ms validation
+```
+
+**Demo GIF sequence:**
+1. Natural language input
+2. Safety check visualization
+3. Safe execution
+4. Dangerous command blocked
+
+---
+
+## 17. Content Strategy as Thought Leadership
+
+### Daytona's Blog Approach
+
+Their blog content positioned them as **problem-solvers, not marketers**:
+
+- Technical deep-dives on architecture decisions
+- Honest assessments of trade-offs
+- Industry analysis (not product pitches)
+- Engineering blog feel, not corporate marketing
+
+### caro Dev.to Post (Week -3)
+
+**Title options:**
+1. "Why AI Developers Are Right to Fear Shell Commands"
+2. "We Were Terrified Too: Building a Safety Layer for AI Agents"
+3. "The rm -rf That Changed How We Think About AI Safety"
+
+**Structure:**
+1. **Emotional hook**: Share vulnerability ("We were terrified too")
+2. **Problem validation**: Acknowledge their fear is rational
+3. **Industry context**: AI agent adoption → more shell commands
+4. **Solution**: How caro changed our approach
+5. **CTA**: Link to GitHub, invite to Discord
+
+This builds credibility before the ask.
+
+---
+
+## 18. Community First Strategy
+
+### Daytona's Insider Playbook
+
+- Invited early users **before** launch
+- Made them feel like **insiders, not audience**
+- They became **advocates by Week 0**
+- Created sense of "you're shaping this product"
+
+### caro Discord Setup (Week -2)
+
+| Channel | Purpose |
+|---------|---------|
+| #announcements | Launch updates only |
+| #beta-testers | Early access group (invite-only feel) |
+| #feature-requests | Roadmap influence |
+| #showcase | Users sharing what they built |
+| #support | Help and troubleshooting |
+
+**Key message to early members:**
+> "You're shaping the launch. Your feedback directly influences v1.0."
+
+### Insider Recruitment
+
+1. Invite the 5 testimonial contacts immediately
+2. Add anyone who stars/watches the repo
+3. Cross-post from r/rust, r/commandline discussions
+4. Personal outreach to CLI tool maintainers
+
+---
+
+## 19. Multiple Launch Strategy
+
+### Daytona's 3-Launch Playbook
+
+Daytona launched **3 times** on Product Hunt, showing sustained momentum:
+
+| Launch | Focus | Timing |
+|--------|-------|--------|
+| 1 | Core dev environment manager | March 2024 |
+| 2 | AI code execution pivot | Late 2024 |
+| 3 | OpenHands integration | 2025 |
+
+Each launch captured a new narrative angle.
+
+### caro Multi-Launch Strategy
+
+| Launch | Narrative | Timing |
+|--------|-----------|--------|
+| 1 | "Safe shell commands for AI" | Week +1 |
+| 2 | "caro for Teams / Enterprise" | Month +3 |
+| 3 | "caro Integrations Ecosystem" | Month +6 |
+
+**Why this works:**
+- Shows sustained traction, not one-off buzz
+- Each launch captures different audience segment
+- Maintains GitHub trending visibility
+- Creates multiple PR/content opportunities
+
+---
+
+## 20. Competitive Positioning: Ride the Wave
+
+### Daytona's Strategic Timing
+
+They pivoted messaging to "the runtime AI agents actually need" exactly as AI agent adoption accelerated. They didn't create demand—they positioned for existing momentum.
+
+### caro's Wave to Ride
+
+**The narrative**: AI agent adoption → more code generation → more shell commands → safety crisis waiting to happen
+
+**Pre-launch positioning (Week -1):**
+- "The safety layer between Claude and your terminal"
+- "Every AI developer needs this"
+- Reference AI agent adoption curve to validate timing
+
+**Comparison framing:**
+| Without caro | With caro |
+|--------------|-----------|
+| Hope the LLM doesn't output `rm -rf /` | Every command validated before execution |
+| Manual review of each generated command | Automated safety patterns |
+| One bad command = production down | Dangerous commands blocked automatically |
+
+---
+
+## 21. Founder Engagement: Be Human
+
+### What Worked for Daytona
+
+Nikola Balic's Hacker News responses showed:
+- **Vulnerability**: Acknowledged limitations openly
+- **Peer energy**: Talked like a fellow developer, not CEO
+- **Responsiveness**: Addressed every comment
+- **Action**: Merged PRs based on feedback within hours
+
+### HN Comment Template for caro
+
+When someone posts criticism:
+```
+That's a fair point—we actually struggled with [X] ourselves.
+
+Here's why we went with [approach]: [reason].
+
+But you're right that [limitation exists]. We're tracking this
+in [GitHub issue link]. Would love your input on the solution.
+```
+
+**Key behaviors:**
+- Respond authentically to every early comment
+- Share actual use cases that surprised you
+- Be vulnerable: "We almost called this something dumb"
+- Sound like builders who solved a problem, not a company
+
+---
+
+## 22. Freemium: Remove All Friction
+
+### Daytona's $200 Credit Play
+
+They offered $200 in free credits—removing the "evaluate first" friction entirely. Users could experience full value before any purchase decision.
+
+### caro Friction Removal Options
+
+| Approach | Implementation |
+|----------|----------------|
+| **Unlimited free tier** | Full CLI forever, no limits |
+| **GitHub Sponsors perk** | Sponsors get premium features free |
+| **Early adopter lifetime** | First 100 users get permanent free access |
+| **Team trial** | 30-day unlimited for teams |
+
+**Goal**: Zero cost to try = zero excuse not to try.
+
+---
+
+## 23. Success Metrics: Reframe the Win
+
+### How Daytona Measured Success
+
+- **Star velocity**: Growth rate, not just absolute numbers
+- **Repeat builders**: Projects built on top (App2.dev example)
+- **Executive endorsements**: CEO-level quotes on website
+- **Trending consistency**: Multiple days on GitHub trending
+
+### caro Success Metrics
+
+| Metric | Target | Timeframe |
+|--------|--------|-----------|
+| GitHub Stars | 250 | Week 0 (pre-HN) |
+| GitHub Stars | 1,000 | Week +2 (post-PH) |
+| Projects using caro | 3+ publicly | Month +3 |
+| Testimonials | 1 C-level from known company | Month +2 |
+| Discord members | 100 | Week +1 |
+| Dev.to article views | 5,000 | Week +1 |
+
+---
+
+## 24. Immediate Action Items
+
+### This Week (Week -4)
+
+- [ ] **Identify 5 early adopter projects** for testimonial outreach
+- [ ] **Polish README** with Daytona-style structure + demo GIF
+- [ ] **Script Dev.to post** "Why Shell Commands Scare Developers"
+- [ ] **Create testimonial outreach template** with free access offer
+- [ ] **Plan multi-launch strategy** (not just one big launch)
+
+### Testimonial Outreach Template
+
+```
+Subject: Built something for [PROJECT_NAME]'s use case
+
+Hi [NAME],
+
+I've been following [PROJECT_NAME] and noticed you're dealing with
+[SHELL COMMAND SAFETY CHALLENGE].
+
+We built caro specifically for this—it's a safety layer that validates
+shell commands before execution. 100% local, open source.
+
+I'd love to give you early access before our public launch. In exchange,
+if it's useful, a quote for our README would be amazing.
+
+No pressure either way—just thought it might solve a real problem for you.
+
+[YOUR NAME]
+```
+
+### README Rewrite Checklist
+
+- [ ] Lead with emotional hook, not feature list
+- [ ] Add quantified proof points (commands executed, safety rate)
+- [ ] Include demo GIF with safety validation visible
+- [ ] Add comparison table vs alternatives
+- [ ] Feature badges prominently
+- [ ] Quick 3-step start section
+- [ ] Multiple CTAs (GitHub, Discord, docs)
+
+---
+
+## 25. Combined Playbook Summary
+
+### What Both Meetily & Daytona Got Right
+
+| Tactic | Meetily | Daytona | caro Adaptation |
+|--------|---------|---------|-----------------|
+| **Clear differentiator** | Privacy | Speed + AI-ready | Safety-first |
+| **Fear factor** | Data breaches | "Works on my machine" | rm -rf disasters |
+| **Multi-channel launch** | Dev.to + HN + PH | HN + PH + Blog | Same sequence |
+| **Community pre-launch** | Discord | Slack | Discord + GitHub Discussions |
+| **Named competitors** | Otter.ai, Granola | Codespaces, DevPod | Raw LLM, manual typing |
+| **Freemium model** | Free community tier | $200 credits | Unlimited free CLI |
+| **Multiple launches** | Single launch | 3 launches | Planned 3 launches |
+| **Dual messaging** | Enterprise + Individual | Technical + Emotional | Same approach |
+| **Testimonial seeding** | Organic | Manufactured | Proactive outreach |
+
+### The Launch Formula
+
+```
+Week -4: README + testimonial outreach + demo creation
+Week -3: Dev.to thought leadership article
+Week -2: Discord community + beta testers
+Week -1: Announcement + final polish
+Week 0:  Show HN submission
+Week +1: Product Hunt launch
+Week +2: Reddit campaign (r/rust, r/commandline, r/devops)
+Month +3: Second launch (Teams/Enterprise angle)
+Month +6: Third launch (Integrations ecosystem)
+```
+
+---
+
 ## Sources
 
+### Meetily
 - [GitHub - meeting-minutes](https://github.com/Zackriya-Solutions/meeting-minutes)
 - [Meetily Website](https://meetily.ai/)
 - [Hacker News Launch](https://news.ycombinator.com/item?id=43137186)
@@ -415,6 +799,16 @@ Both products appeal to users who:
 - [Crunchbase - Sandeep Zachariah](https://www.crunchbase.com/person/sandeep-zachariah)
 - [Crunchbase - Zackriya Solutions](https://www.crunchbase.com/organization/zackriya-solutions)
 - [Zackriya Solutions Website](https://www.zackriya.com/)
+
+### Daytona
+- [GitHub - daytonaio/daytona](https://github.com/daytonaio/daytona)
+- [Daytona Website](https://www.daytona.io/)
+- [Hacker News Show HN Launch](https://news.ycombinator.com/item?id=39616709)
+- [Product Hunt - Daytona](https://www.producthunt.com/products/daytona)
+- [Daytona Open Source Announcement](https://www.daytona.io/dotfiles/daytona-goes-open-source)
+- [Daytona Becomes World's Leading Open-Source CDE](https://www.daytona.io/dotfiles/daytona-becomes-world-s-leading-open-source-cde-in-2024)
+- [InfoQ - Daytona Open Source](https://www.infoq.com/news/2024/03/daytona-open-source/)
+- [PRNewswire - Daytona Launch](https://www.prnewswire.com/news-releases/daytona-unveils-open-source-development-environment-manager-to-streamline-software-creation-302079943.html)
 
 ---
 

--- a/docs/PRODUCT_LAUNCH_ANALYSIS_MEETILY.md
+++ b/docs/PRODUCT_LAUNCH_ANALYSIS_MEETILY.md
@@ -1,0 +1,422 @@
+# Product Launch Analysis: Meetily (meeting-minutes)
+
+A deep-dive analysis of how Zackriya Solutions positioned, launched, and grew their open-source AI meeting assistant. This document extracts actionable insights for caro's own product launch strategy.
+
+---
+
+## Executive Summary
+
+Meetily is a privacy-first AI meeting assistant that achieved **8.9k GitHub stars**, **30k+ users**, and **#1 trending repository** status through a carefully orchestrated multi-channel launch strategy. The key success factors:
+
+1. **Crystal-clear differentiation** on privacy (local-first vs cloud competitors)
+2. **Multi-platform content marketing** (Dev.to series, HN, Reddit, Discord)
+3. **Enterprise + Individual dual-audience** positioning
+4. **Freemium model** with clear upgrade path
+5. **Technical credibility** through Rust + open-source transparency
+
+---
+
+## 1. GitHub Presence Analysis
+
+### README Structure That Works
+
+| Element | What They Did | Why It Works |
+|---------|---------------|--------------|
+| **Hero Section** | Large banner + badges showing stats | Instant credibility |
+| **Value Prop** | "Privacy First • Open Source • Enterprise-Ready" | Three key differentiators in one line |
+| **Fear Factor** | IBM data breach stats, GDPR fines | Creates urgency for their solution |
+| **Demo GIF/Video** | Embedded YouTube link | Visual proof over written claims |
+| **Comparison Table** | vs Otter.ai, Granola, Fireflies | Positions against known alternatives |
+| **Architecture Diagram** | Shows "no data leaves device" | Makes abstract privacy tangible |
+| **Social Links** | Discord, LinkedIn, Reddit, Newsletter | Multiple engagement pathways |
+
+### Key Metrics They Display
+
+- ⭐ 8.9k stars (social proof)
+- 👥 30k+ users (adoption proof)
+- 📊 #1 trending (momentum signal)
+- 🏢 7 contributors (community signal)
+
+### Lesson for caro
+
+> Your GitHub README is your landing page for developers. Meetily treats it like a marketing asset, not just documentation.
+
+---
+
+## 2. Positioning & Messaging Strategy
+
+### The Core Positioning Framework
+
+```
+[PROBLEM]
+"Every major AI meeting tool requires uploading your conversations"
+
+[AGITATE]
+"$4.4M average cost per data breach (IBM 2024)"
+"€5.88 billion in GDPR fines by 2025"
+
+[SOLUTION]
+"100% local processing. Your data never leaves your device."
+```
+
+### What Made Their Positioning Effective
+
+1. **Single differentiator**: They own "privacy" completely
+2. **Concrete proof points**: Not "we're private" but "nothing leaves your device"
+3. **Target-specific pain**: Defense, legal, healthcare use cases
+4. **Named competitors**: Directly compared to Otter.ai, Granola, Fireflies
+
+### Messaging Pillars
+
+| Pillar | Message | Evidence |
+|--------|---------|----------|
+| Privacy | "Your data never leaves your device" | Local processing architecture |
+| Cost | "Free forever for individuals" | Open-source MIT license |
+| Control | "Self-hosted, no SaaS lock-in" | Downloadable binary |
+| Trust | "Everyone can verify privacy claims" | Open-source code |
+
+### Lesson for caro
+
+> caro's equivalent positioning could be:
+> - **Problem**: "Typing shell commands is error-prone and dangerous"
+> - **Differentiator**: "Natural language → safe POSIX commands, locally processed"
+> - **Proof**: "Comprehensive safety validation, no cloud dependency"
+
+---
+
+## 3. Multi-Channel Launch Strategy
+
+### Channel Breakdown
+
+| Channel | Purpose | Content Type | Timing |
+|---------|---------|--------------|--------|
+| GitHub | Technical credibility | README + Code | Foundation |
+| Dev.to | Thought leadership | 13-part article series | Ongoing |
+| Hacker News | Developer reach | Show HN post | Launch day |
+| Product Hunt | Consumer reach | Product page | Scheduled Nov 5 |
+| Discord | Community building | Real-time support | Ongoing |
+| Reddit | Niche communities | r/meetily subreddit | Ongoing |
+| LinkedIn | Enterprise reach | Company page | Professional networking |
+
+### Dev.to Content Strategy
+
+They published a **13-part article series** covering:
+
+1. Privacy problem in meeting tools
+2. Technical architecture deep-dive
+3. Why Rust for the backend
+4. Whisper vs Parakeet comparison
+5. Enterprise deployment guide
+6. Feature releases and updates
+
+**Key insight**: Each article serves as:
+- SEO backlink to GitHub
+- Shareable content for social
+- Thought leadership positioning
+- Community engagement touchpoint
+
+### Hacker News Launch Execution
+
+**Title**: "Show HN: Meetily – Open-Source AI Meeting Assistant (Alt to Otter.ai)"
+
+**What worked**:
+- Explicit competitor comparison in title
+- "Open-Source" front and center
+- Show HN format for technical audience
+
+**Reception**: 4 upvotes, 4 comments (modest but positive)
+- Tech stack praised ("I love the choice for tauri!")
+- No technical criticism
+- Authentic founder responses
+
+### Lesson for caro
+
+> Launch is not a single event but a coordinated campaign across multiple channels, each with specific purpose and content type.
+
+---
+
+## 4. Demo & Visual Proof
+
+### What They Showcase
+
+1. **Real-time transcription** in action
+2. **AI summary generation** from meeting content
+3. **Privacy indicator** showing local processing
+4. **Platform compatibility** (Zoom, Teams, Meet)
+5. **Installation simplicity** (single binary)
+
+### Demo Best Practices They Used
+
+- **Show, don't tell**: Video demo > feature list
+- **Real use case**: Actual meeting recording, not synthetic example
+- **Before/after**: Raw audio → structured notes
+- **Speed proof**: "4x faster than Whisper" claim demonstrated
+
+### Lesson for caro
+
+> For caro, the demo should show:
+> - Natural language input ("list large files in downloads")
+> - Command generation in real-time
+> - Safety validation catching a dangerous command
+> - Successful execution with output
+
+---
+
+## 5. Pricing & Business Model
+
+### Freemium Structure
+
+| Tier | Price | Target | Features |
+|------|-------|--------|----------|
+| Community | Free forever | Individuals | Full features, local only |
+| Pro | $10/month | Teams 2-100 | Multi-user, priority support |
+| Enterprise | Custom | 100+ users | On-prem, compliance, SLA |
+
+### Why This Works for Open Source
+
+1. **Zero friction trial**: No credit card, no signup
+2. **Upgrade path visible**: Users know where to go when ready
+3. **Enterprise hook**: Large orgs need support/compliance
+4. **60% annual discount**: Incentivizes commitment
+
+### Lesson for caro
+
+> caro could follow similar model:
+> - **Free**: Full CLI functionality
+> - **Pro**: Team sharing, command history sync, priority support
+> - **Enterprise**: On-prem inference, compliance documentation
+
+---
+
+## 6. Community Building Tactics
+
+### Discord Strategy
+
+- Dedicated server for Meetily
+- Also part of larger "Privacy-First AI" community
+- Real-time support and feedback loop
+- Feature request channel
+- Beta tester recruitment
+
+### GitHub Discussions
+
+- Active discussions section
+- Release announcements
+- Feature voting
+- Bug reports triaged publicly
+
+### Newsletter
+
+- Hosted on main domain (zackriya.com/meetily-subscribe)
+- Launch countdown
+- Feature previews
+- Privacy news curation
+
+### Lesson for caro
+
+> Community building starts before launch. Create spaces where early users can:
+> - Get support
+> - Influence roadmap
+> - Feel ownership
+> - Become advocates
+
+---
+
+## 7. Team & Credibility
+
+### Background
+
+- **Founded**: 2020, Bangalore, India
+- **Team size**: 2-10 employees (small, focused)
+- **Expertise**: AI/ML, deep learning, edge deployment
+- **Status**: Government of India recognized startup
+
+### Founder Positioning
+
+- Sandeep Zachariah: Founder & CEO, engineering background
+- Sujith S: Partner & Senior Solution Architect, hands-on technical
+
+### How They Built Technical Credibility
+
+1. **Open source everything**: Code is the proof
+2. **Tech stack transparency**: Rust, Tauri, Whisper.cpp choices explained
+3. **Architecture docs**: Public diagrams and documentation
+4. **Honest limitations**: "Smaller LLMs struggle with accuracy"
+
+### Lesson for caro
+
+> Small teams can compete by being transparent, responsive, and technically excellent. Size becomes irrelevant when the code speaks for itself.
+
+---
+
+## 8. Competitive Differentiation
+
+### How They Position Against Competitors
+
+| Competitor | Their Attack | Meetily's Counter |
+|------------|--------------|-------------------|
+| Otter.ai | Cloud-only, privacy risk | 100% local processing |
+| Granola | Subscription cost | Free community edition |
+| Fireflies | Meeting bot required | Bot-free audio capture |
+| Fathom | Cloud transcription | On-device Whisper |
+
+### The Differentiation Formula
+
+```
+We are [CATEGORY] that [KEY DIFFERENCE]
+unlike [COMPETITORS] that [THEIR WEAKNESS]
+```
+
+**Meetily's version**:
+> "We are an AI meeting assistant that processes everything locally,
+> unlike Otter.ai and Granola that upload your conversations to the cloud."
+
+### Lesson for caro
+
+> caro's differentiation:
+> "We are a natural language CLI that validates command safety locally,
+> unlike generic LLM prompts that can generate dangerous commands."
+
+---
+
+## 9. What Open Source Users Want
+
+### Insights from Meetily's Success
+
+1. **Privacy as feature**: Not optional, core value proposition
+2. **Single binary simplicity**: No complex installation
+3. **No vendor lock-in**: MIT license, self-hosted option
+4. **Transparency**: Open code, public roadmap, honest limitations
+5. **Active maintenance**: Regular commits, responsive issues
+6. **Documentation**: Architecture docs, not just usage guides
+7. **Community voice**: Feature voting, public discussions
+
+### The Trust Hierarchy
+
+```
+1. Open source (verify yourself)
+2. Local-first (data never leaves)
+3. Self-hosted option (own your infrastructure)
+4. MIT/permissive license (no legal risk)
+5. Active community (not abandoned)
+```
+
+---
+
+## 10. Actionable Insights for caro
+
+### Immediate Actions
+
+1. **Refine README as marketing page**
+   - Add hero banner with key stats
+   - Include comparison table vs alternatives (typing commands manually, other CLI tools)
+   - Add demo GIF showing NL → command → safety check → execution
+
+2. **Create positioning statement**
+   ```
+   caro: Natural language to safe shell commands
+   100% local • Safety-first • No cloud required
+   ```
+
+3. **Identify your "fear factor"**
+   - Command injection stats
+   - rm -rf horror stories
+   - Production outages from typos
+
+4. **Build content pipeline**
+   - Blog post: "Why we built caro: The danger of raw shell commands"
+   - Technical deep-dive: "Safety validation patterns in caro"
+   - Comparison: "caro vs ChatGPT for shell commands"
+
+### Launch Sequence
+
+| Week | Action | Channel |
+|------|--------|---------|
+| -4 | README polish + demo GIF | GitHub |
+| -3 | Technical blog post | Dev.to |
+| -2 | Create Discord/community | Discord |
+| -1 | Announce launch date | Twitter/X |
+| 0 | Show HN submission | Hacker News |
+| +1 | Product Hunt launch | Product Hunt |
+| +2 | Reddit posts to relevant subs | r/rust, r/commandline |
+
+### Content Ideas for caro
+
+1. "We analyzed 1000 dangerous shell commands. Here's what we learned."
+2. "The rm -rf that almost cost us $50k"
+3. "Why GPT-4 shouldn't write your shell commands (without safety checks)"
+4. "Building a safety-first CLI: Lessons from defensive programming"
+5. "Natural language + POSIX: How caro translates intent to commands"
+
+---
+
+## 11. Shared Audience Analysis
+
+### Meetily Users Who Might Use caro
+
+| Persona | Why Meetily | Why caro |
+|---------|-------------|----------|
+| Privacy-conscious developer | Local meeting processing | Local command generation |
+| Terminal power user | Wants efficiency tools | Faster command composition |
+| Security-minded engineer | Data sovereignty | Safe command execution |
+| Open source advocate | Transparent tooling | Auditable safety checks |
+
+### Bridging the Audiences
+
+Both products appeal to users who:
+- Prefer local over cloud
+- Value privacy and security
+- Want open-source alternatives
+- Are technically sophisticated
+- Distrust "magic" black boxes
+
+### Cross-promotion opportunities
+
+- Feature in privacy-focused tool roundups
+- Partner on "local-first AI tools" content
+- Share communities (privacy-focused AI Discord)
+- Guest posts on each other's blogs
+
+---
+
+## 12. Key Takeaways
+
+### What Meetily Got Right
+
+1. ✅ **One clear differentiator** (privacy) owned completely
+2. ✅ **Multi-channel coordinated launch** (not just GitHub)
+3. ✅ **Content as marketing** (13-part article series)
+4. ✅ **Visual proof** (demo video, architecture diagrams)
+5. ✅ **Freemium model** with clear upgrade path
+6. ✅ **Community before launch** (Discord, discussions)
+7. ✅ **Named competitors** (positioned against known alternatives)
+8. ✅ **Fear + solution** (breach costs → local processing)
+
+### Apply to caro
+
+| Meetily Tactic | caro Equivalent |
+|----------------|-----------------|
+| "Your data never leaves" | "Every command is safety-checked" |
+| vs Otter.ai, Granola | vs raw LLM prompts, manual typing |
+| Meeting transcription demo | NL → command → execution demo |
+| Privacy fear stats | Command injection / rm -rf stats |
+| Discord community | Discord / GitHub Discussions |
+| Dev.to article series | Technical blog on safety patterns |
+
+---
+
+## Sources
+
+- [GitHub - meeting-minutes](https://github.com/Zackriya-Solutions/meeting-minutes)
+- [Meetily Website](https://meetily.ai/)
+- [Hacker News Launch](https://news.ycombinator.com/item?id=43137186)
+- [Dev.to - Why We Built This](https://dev.to/zackriya/we-built-a-self-hosted-ai-meeting-note-taker-because-every-cloud-solution-failed-our-privacy-1eml)
+- [Dev.to - Product Introduction](https://dev.to/zackriya/meetily-a-privacy-first-ai-for-taking-meeting-notes-and-meeting-minutes-26ed)
+- [Crunchbase - Sandeep Zachariah](https://www.crunchbase.com/person/sandeep-zachariah)
+- [Crunchbase - Zackriya Solutions](https://www.crunchbase.com/organization/zackriya-solutions)
+- [Zackriya Solutions Website](https://www.zackriya.com/)
+
+---
+
+*Analysis compiled: December 2025*
+*For internal use in caro product launch planning*

--- a/docs/prompts/PRODUCT_LAUNCH_ANALYSIS_PROMPT.md
+++ b/docs/prompts/PRODUCT_LAUNCH_ANALYSIS_PROMPT.md
@@ -1,0 +1,231 @@
+# Product Launch Analysis Prompt
+
+Use this prompt to analyze successful open-source product launches and extract actionable insights for caro's marketing strategy.
+
+---
+
+## The Prompt
+
+```
+Analyze these two successful open-source products to extract product launch insights for our CLI tool "caro" (natural language to safe shell commands):
+
+1. **Meetily** (https://github.com/Zackriya-Solutions/meeting-minutes)
+   - Privacy-first AI meeting assistant
+   - 8.9k GitHub stars, 30k+ users
+   - Rust + Tauri stack
+
+2. **Daytona** (https://github.com/daytonaio/daytona)
+   - Dev environment manager → AI code execution platform
+   - 41k GitHub stars, $5M funding
+   - Multiple Product Hunt launches
+
+## What to Analyze
+
+### For Each Product:
+
+**GitHub Presence**
+- README structure and flow
+- Badges and social proof elements
+- Demo/video presentation
+- Code examples and quick start
+- Call-to-action placement
+
+**Positioning & Messaging**
+- Core differentiator (what do they "own"?)
+- Problem-Agitate-Solution framework
+- Fear factor messaging (what pain do they amplify?)
+- Named competitor positioning
+- Dual messaging (developer vs enterprise)
+
+**Launch Channels**
+- Hacker News: Title, reception, founder engagement style
+- Product Hunt: Positioning, timing, multiple launches?
+- Dev.to/Blog: Content series, thought leadership approach
+- Discord/Community: Pre-launch community building
+- Reddit: Subreddit strategy, cross-posting
+
+**Social Proof Strategy**
+- How did they seed testimonials?
+- What metrics do they display?
+- Influencer/backer endorsements?
+
+**Business Model**
+- Freemium structure
+- Friction removal tactics
+- Enterprise vs individual positioning
+
+**Founder Engagement**
+- How do they respond to criticism?
+- Voice and tone in comments
+- Vulnerability vs corporate messaging
+
+## Output Format
+
+Create a comprehensive document (`docs/PRODUCT_LAUNCH_ANALYSIS.md`) with:
+
+1. **Executive Summary**: Key success factors from both products
+
+2. **Per-Product Deep Dive**:
+   - The numbers (stars, users, funding, timeline)
+   - README analysis with specific elements that work
+   - Positioning framework breakdown
+   - Channel-by-channel launch strategy
+   - Community building tactics
+
+3. **Comparative Analysis**:
+   - What both products got right
+   - Unique tactics from each
+   - Table comparing tactics
+
+4. **caro-Specific Adaptations**:
+   - Translate each tactic to caro's context
+   - Specific messaging recommendations
+   - Fear factor equivalents (rm -rf disasters, command injection)
+   - Target testimonial projects
+
+5. **Actionable Playbook**:
+   - Week-by-week launch timeline
+   - README rewrite checklist
+   - Testimonial outreach template
+   - HN comment response template
+   - Success metrics with targets
+   - Multi-launch strategy (3 launches over 6 months)
+
+6. **Immediate Action Items**:
+   - Checklist format
+   - Prioritized by week
+
+## Key Insights to Extract
+
+### From Meetily:
+- Privacy as single differentiator
+- Fear factor messaging (data breach costs)
+- 13-part Dev.to content series
+- Bot-free positioning vs competitors
+- Freemium community edition
+
+### From Daytona:
+- Dual messaging (emotional vs technical by audience)
+- Manufactured testimonials before launch
+- Multiple Product Hunt launches (3 total)
+- Positioning pivot with AI wave
+- $200 credit friction removal
+- 2,000 stars in 48 hours tactic
+- Founder vulnerability in HN comments
+
+## Shared Audience Analysis
+
+Both products appeal to:
+- Privacy-conscious developers
+- Terminal power users
+- Security-minded engineers
+- Open-source advocates
+
+Analyze how caro fits this audience profile and identify cross-promotion opportunities.
+
+## The caro Context
+
+caro is a Rust CLI that:
+- Converts natural language to shell commands
+- Validates command safety before execution
+- Runs 100% locally (no cloud)
+- Targets developers using AI agents
+
+Our equivalent positioning:
+- **Differentiator**: Safety-first (vs raw LLM output)
+- **Fear factor**: rm -rf disasters, command injection, production outages
+- **Competitors**: Raw ChatGPT/Claude output, manual typing
+
+## Sources to Check
+
+For each product, analyze:
+- GitHub README and repository stats
+- Main website (messaging, pricing, CTAs)
+- Hacker News Show HN thread (title, comments, founder responses)
+- Product Hunt page (if available)
+- Dev.to articles (content strategy, series approach)
+- Discord/Slack community (engagement tactics)
+- Crunchbase/LinkedIn (team background, credibility signals)
+
+Fetch and analyze each source, extracting specific tactics that can be adapted for caro's launch.
+```
+
+---
+
+## Expected Output
+
+The prompt should generate a ~800 line markdown document covering:
+
+| Section | Content |
+|---------|---------|
+| Executive Summary | Key success factors |
+| Meetily Analysis (12 sections) | GitHub, positioning, channels, demo, pricing, community, team, differentiation, OSS insights, caro adaptations |
+| Daytona Analysis (13 sections) | Overview, dual messaging, testimonials, README structure, content strategy, community, multi-launch, competitive positioning, founder engagement, freemium, success metrics, action items |
+| Combined Playbook | Comparison table, launch formula |
+| Sources | Organized by product with links |
+
+---
+
+## How to Use This Prompt
+
+1. Start a new Claude Code session
+2. Paste the prompt above
+3. Claude will fetch and analyze all sources
+4. Review the generated `docs/PRODUCT_LAUNCH_ANALYSIS.md`
+5. Use the actionable playbook for launch planning
+
+---
+
+## Sample Outputs from This Analysis
+
+### Positioning Statement for caro
+```
+Stop typing 'rm -rf' with your hands shaking.
+caro: Natural language to safe shell commands
+100% local • Safety-first • No cloud required
+```
+
+### Testimonial Outreach Template
+```
+Subject: Built something for [PROJECT_NAME]'s use case
+
+Hi [NAME],
+
+I've been following [PROJECT_NAME] and noticed you're dealing with
+[SHELL COMMAND SAFETY CHALLENGE].
+
+We built caro specifically for this—it's a safety layer that validates
+shell commands before execution. 100% local, open source.
+
+I'd love to give you early access before our public launch. In exchange,
+if it's useful, a quote for our README would be amazing.
+
+No pressure either way—just thought it might solve a real problem for you.
+
+[YOUR NAME]
+```
+
+### Launch Timeline
+```
+Week -4: README + testimonial outreach + demo creation
+Week -3: Dev.to thought leadership article
+Week -2: Discord community + beta testers
+Week -1: Announcement + final polish
+Week 0:  Show HN submission
+Week +1: Product Hunt launch
+Week +2: Reddit campaign (r/rust, r/commandline, r/devops)
+Month +3: Second launch (Teams/Enterprise angle)
+Month +6: Third launch (Integrations ecosystem)
+```
+
+### Target Testimonial Projects
+1. Claude Agent Frameworks - Need safe command execution
+2. Terminal Automation Tools - Shell safety is their pain point
+3. DevOps Platforms - Production safety is critical
+4. AI Coding Assistants - Running generated code safely
+5. CI/CD Tools - Command injection prevention
+
+---
+
+*Prompt created: December 2025*
+*Use to recreate product launch analysis in any branch*


### PR DESCRIPTION
Adds reusable prompt template for product launch analysis.

**New Prompt:** PRODUCT_LAUNCH_ANALYSIS_PROMPT.md (231 lines)

**Type:** Documentation (+231)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable prompt and a comprehensive case study document to guide caro’s product launch, covering positioning, channels, and an actionable playbook.

- **New Features**
  - docs/prompts/PRODUCT_LAUNCH_ANALYSIS_PROMPT.md: Reusable prompt to analyze open-source launches and generate a tailored report for caro.
  - docs/PRODUCT_LAUNCH_ANALYSIS.md: Deep dives on Meetily and Daytona with a concise playbook: dual messaging, channel plan, week-by-week launch timeline, README checklist, outreach and HN reply templates, success metrics, and a multi-launch strategy.

<sup>Written for commit 0203d786b9ecb160f12053f56c39c9765f7700bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

