### PR TITLE
Add Developer Certificate of Origin (DCO) requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,6 +42,10 @@
 - [ ] I have run `cargo test` (all tests pass)
 - [ ] I have run `cargo audit` (no security vulnerabilities in dependencies)
 
+### Developer Certificate of Origin
+
+- [ ] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
+
 ### Testing
 
 - [ ] I have added tests that prove my fix is effective or that my feature works
@@ -136,14 +140,14 @@ After:  48.1 MB (+0.9 MB)
 ### Before
 
 ```bash
-$ cmdai "list files"
+$ caro "list files"
 Error: command generation failed
 ```
 
 ### After
 
 ```bash
-$ cmdai "list files"
+$ caro "list files"
 Generated command:
   find . -type f -name "*"
 
@@ -163,7 +167,7 @@ Execute this command? (y/N)
 ```
 $ cargo test
     Finished test [unoptimized + debuginfo] target(s) in 2.34s
-     Running unittests src/lib.rs (target/debug/deps/cmdai-...)
+     Running unittests src/lib.rs (target/debug/deps/caro-...)
 
 running 42 tests
 test cache::tests::test_cache_manager_retrieves_model ... ok
@@ -218,13 +222,14 @@ test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 **By submitting this PR, I confirm that:**
 
-- [ ] My code follows the style guidelines of this project (see [AGENTS.md](https://github.com/wildcard/cmdai/blob/main/AGENTS.md))
+- [ ] My code follows the style guidelines of this project (see [AGENTS.md](https://github.com/wildcard/caro/blob/main/docs/development/AGENTS.md))
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My changes generate no new warnings or errors
-- [ ] I have read and followed the [contributing guidelines](https://github.com/wildcard/cmdai/blob/main/CONTRIBUTING.md)
-- [ ] I agree to the [Code of Conduct](https://github.com/wildcard/cmdai/blob/main/CODE_OF_CONDUCT.md)
+- [ ] I have read and followed the [contributing guidelines](https://github.com/wildcard/caro/blob/main/CONTRIBUTING.md)
+- [ ] I agree to the [Code of Conduct](https://github.com/wildcard/caro/blob/main/CODE_OF_CONDUCT.md)
+- [ ] All my commits are signed off under the [Developer Certificate of Origin](https://developercertificate.org/)
 
 ---
 
-<!-- Thank you for contributing to cmdai! 🚀 -->
+<!-- Thank you for contributing to caro! -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ All contributors must:
 ## Table of Contents
 
 - [Security-Critical Project Notice](#security-critical-project-notice)
+- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
 - [Project Vision](#project-vision)
 - [Security Development Practices](#security-development-practices)
 - [Getting Started](#getting-started)
@@ -26,6 +27,98 @@ All contributors must:
 - [Agent Collaboration](#agent-collaboration)
 - [Spec-Driven Development](#spec-driven-development)
 - [Recognition](#recognition)
+
+---
+
+## Developer Certificate of Origin (DCO)
+
+All contributions to caro **must** be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). This is a lightweight way for contributors to certify that they have the right to submit their contribution under the project's license.
+
+### Why We Require DCO
+
+As a security-critical tool that executes shell commands, caro requires clear provenance and accountability for all code contributions. The DCO provides:
+
+- **Legal clarity** - Protects contributors and the project from IP disputes
+- **Accountability** - Establishes traceable authorship aligned with our security-first philosophy
+- **Industry standard** - Used by Linux kernel, GitLab, CNCF projects, and many others
+
+### The DCO Text
+
+By signing off your contributions, you certify the following:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+### How to Sign Off Your Commits
+
+Add a `Signed-off-by` line to every commit message:
+
+```
+Add fork bomb detection to safety validator
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+**The easiest way**: Use the `-s` flag with `git commit`:
+
+```bash
+git commit -s -m "Add fork bomb detection to safety validator"
+```
+
+**For multiple commits**, you can sign off interactively during rebase:
+
+```bash
+git rebase --signoff HEAD~3
+```
+
+**If you forgot to sign off**, amend your commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+### DCO Check Enforcement
+
+Pull requests are automatically checked for DCO compliance. If any commit is missing a sign-off:
+
+1. The DCO check will fail
+2. You'll need to sign off the missing commits
+3. Force-push the corrected commits to your PR branch
+
+**Note**: The sign-off email must match a verified email on your GitHub account.
 
 ---
 
@@ -501,9 +594,9 @@ async fn test_cache_manager_handles_missing_model() {
 
 2. **Make your changes** following TDD workflow
 
-3. **Commit with clear messages**:
+3. **Commit with clear messages and DCO sign-off**:
    ```bash
-   git commit -m "Add fork bomb detection to safety validator"
+   git commit -s -m "Add fork bomb detection to safety validator"
    ```
 
    **Commit message guidelines**:
@@ -512,7 +605,9 @@ async fn test_cache_manager_handles_missing_model() {
    - Title Case for subjects
    - Reference issues/PRs in parentheses: `(#42)`
    - Optional leading emoji for visual categorization
+   - **Always include DCO sign-off** (use `git commit -s`)
    - See [AGENTS.md](docs/development/AGENTS.md) for detailed conventions
+   - See [Developer Certificate of Origin](#developer-certificate-of-origin-dco) for DCO details
 
 4. **Push to your fork**:
    ```bash
@@ -527,7 +622,7 @@ Your PR will use the template from `.github/PULL_REQUEST_TEMPLATE.md`. Include:
 
 - **Description**: What does this PR do and why?
 - **Type of change**: Feature, bug fix, documentation, refactor, test
-- **Checklist**: Tests added, tests pass, clippy clean, rustfmt applied
+- **Checklist**: Tests added, tests pass, clippy clean, rustfmt applied, **DCO signed**
 - **Breaking changes**: Any API changes requiring migration?
 - **Related issues/specs**: Link to relevant specifications or issues
 - **Performance impact**: Does this affect startup time, validation speed, or inference?


### PR DESCRIPTION
Adds DCO requirements to contribution process.

**Updates:** CONTRIBUTING.md, PR template with DCO sign-off

**Type:** Documentation (+110 -10)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DCO requirements to the contribution workflow to ensure all commits are signed off. Updates CONTRIBUTING.md and the PR template, and fixes template examples from cmdai to caro.

- **Migration**
  - Sign off all commits with `git commit -s` or add `Signed-off-by` manually.
  - If a commit is missing sign-off, amend or `git rebase --signoff` and force-push.
  - The sign-off email must match a verified GitHub email.

<sup>Written for commit 25fbb95712fd7df4a986ee2f1777899996200ffd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

