### PR TITLE
Skip welcome comment for maintainers in issue workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -24,6 +24,19 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            // Check if issue author is a maintainer/collaborator
+            let isMaintainer = false;
+            try {
+              const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: owner,
+                repo: repo,
+                username: issueAuthor
+              });
+              isMaintainer = ['admin', 'write', 'maintain'].includes(permissionLevel.permission);
+            } catch (error) {
+              console.log('Could not check maintainer status:', error.message);
+            }
+
             // Check if this is the user's first issue
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: owner,
@@ -33,6 +46,12 @@ jobs:
             });
 
             const isFirstIssue = issues.length === 1;
+
+            // Skip comment for maintainers (unless it's their first issue - unlikely but handle it)
+            if (isMaintainer && !isFirstIssue) {
+              console.log('Skipping welcome comment for maintainer: ' + issueAuthor);
+              return;
+            }
 
             let message = '';
             if (isFirstIssue) {


### PR DESCRIPTION
## Description

This PR updates the GitHub Actions welcome workflow to skip posting welcome comments for repository maintainers and collaborators, while still welcoming first-time contributors.

### Motivation

Welcome comments are primarily intended for new contributors to help them get oriented with the project. Maintainers and collaborators who have write/admin permissions don't need these welcome messages, reducing noise in the issue tracker while still providing a good experience for first-time contributors.

### Changes Made

- Added logic to check if the issue author is a maintainer/collaborator by querying their permission level
- Skip the welcome comment for maintainers unless it's their first issue (edge case handling)
- Added error handling for permission level checks with appropriate logging
- Maintains welcome message for first-time contributors regardless of their permission level

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code restructuring without changing behavior)
- [ ] Documentation update (changes to docs, comments, or guides)
- [ ] Performance improvement (makes code faster or more efficient)
- [ ] Test coverage (adds or improves tests)
- [x] CI/CD or tooling (changes to build, release, or development tools)

---

## Related Issues and Specs

<!-- Link to related issues if applicable -->

---

## Additional Context

This change improves the user experience by:
1. Reducing unnecessary notifications for maintainers
2. Keeping the welcome workflow focused on first-time contributors
3. Maintaining a clean issue history without redundant welcome messages for team members

The implementation includes proper error handling in case the permission check fails, ensuring the workflow continues gracefully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip welcome comments on issues for maintainers and collaborators, while still welcoming first-time contributors. This reduces noise for team members and keeps onboarding focused on new contributors.

- **New Features**
  - Check author permissions via getCollaboratorPermissionLevel (admin/write/maintain treated as maintainers).
  - Skip comment for maintainers unless it’s their first issue.
  - Add error handling and logging if permission checks fail.

<sup>Written for commit 1e811950342b1f503eb6df6b4716b96075a2b152. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

