### PR TITLE
docs(vercel): Update deployment skip documentation with complete workspace config

### DIFF
--- a/VERCEL_DEPLOYMENT_SKIP_SETUP.md
+++ b/VERCEL_DEPLOYMENT_SKIP_SETUP.md
@@ -2,7 +2,9 @@
 
 ## Changes Made
 
-Added `presentation` to npm workspaces array in `/package.json` to enable proper deployment skipping.
+Added `presentation` and `apps/devrel` to npm workspaces array in `/package.json` to enable proper deployment skipping.
+
+**Update (PR #684):** Added `apps/devrel` to fix cmdai deployment skipping.
 
 ## Why This Matters
 
@@ -20,15 +22,19 @@ For EACH Vercel project listed below, verify these settings in the Vercel Dashbo
 - **Root Directory:** `docs-site`
 - **Skip Deployment:** ✓ Enabled
 
-### 3. cmdai (landing page)
-- **Root Directory:** `landing`
+### 3. cmdai (DevRel site)
+- **Root Directory:** `apps/devrel`
 - **Skip Deployment:** ✓ Enabled
 
 ### 4. caro-slides (presentation)
 - **Root Directory:** `presentation`
 - **Skip Deployment:** ✓ Enabled
 
-### 5. caro-storybook
+### 5. cmdai-saas (landing page)
+- **Root Directory:** `landing`
+- **Skip Deployment:** ✓ Enabled
+
+### 6. caro-storybook
 - **Root Directory:** `website`
 - **Build Command:** Custom (likely `npm run build-storybook`)
 - **Skip Deployment:** ✓ Enabled (optional - will build with website changes)
@@ -91,11 +97,48 @@ Files outside the workspaces array are considered "global changes" and trigger a
 
 ## Workspace Configuration
 
-Current workspaces in `/package.json`:
-- `website` → caro-foss-website
+Complete workspaces in `/package.json`:
+- `website` → caro-foss-website, caro-storybook
 - `docs-site` → caro-docs
-- `landing` → cmdai
-- `presentation` → caro-slides ✨ **NEW**
+- `landing` → cmdai-saas
+- `presentation` → caro-slides
+- `apps/devrel` → cmdai ✨ **COMPLETE**
+
+### Workspace to Vercel Project Mapping
+
+| Workspace Folder | Vercel Projects | Notes |
+|------------------|-----------------|-------|
+| `website` | caro-foss-website, caro-storybook | Both build when website/ changes |
+| `docs-site` | caro-docs | Documentation site |
+| `landing` | cmdai-saas | Landing page |
+| `presentation` | caro-slides | Slidev presentations |
+| `apps/devrel` | cmdai | DevRel site |
+
+**Verified Working:** PR #685 confirmed all projects skip correctly when only presentation/ changes.
+
+## Troubleshooting
+
+### How to Verify Configuration
+
+Use the Vercel CLI to inspect monorepo configuration:
+
+```bash
+vercel link --repo
+cat .vercel/repo.json
+```
+
+This shows which directory each Vercel project is configured to watch.
+
+### Common Issues
+
+1. **Project still building when it shouldn't:**
+   - Check if the workspace folder is in `package.json` workspaces array
+   - Verify Vercel project's Root Directory matches the workspace folder
+   - Ensure "Skip deployment" toggle is enabled in Vercel dashboard
+
+2. **All projects building on every commit:**
+   - Changes to root-level files trigger all projects (expected)
+   - Check if a workspace folder is missing from the array
 
 ## References
 


### PR DESCRIPTION
## Summary

Updates `VERCEL_DEPLOYMENT_SKIP_SETUP.md` to reflect the complete workspace configuration including the `apps/devrel` fix from PR #684.

## Changes

- ✅ Updated cmdai to show correct Root Directory: `apps/devrel` (not `landing`)
- ✅ Added cmdai-saas project (landing page) as separate entry
- ✅ Added complete workspace-to-project mapping table
- ✅ Added troubleshooting section with Vercel CLI commands
- ✅ Referenced PR #685 verification results (confirmed working)

## Complete Workspace Configuration

```json
"workspaces": [
  "website",       // caro-foss-website, caro-storybook
  "docs-site",     // caro-docs
  "landing",       // cmdai-saas
  "presentation",  // caro-slides
  "apps/devrel"    // cmdai ✅ VERIFIED WORKING
]
```

## Verification

PR #685 confirmed that with `apps/devrel` in workspaces:
- ✅ Only caro-slides builds when presentation/ changes
- ✅ cmdai correctly **skips** when apps/devrel unchanged
- ✅ All other projects skip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Vercel deployment-skip docs with the full workspace-to-project mapping and the apps/devrel root fix for cmdai, so skip behavior works across the monorepo. Verified in PR #685.

- **Documentation Updates**
  - Fix cmdai Root Directory to apps/devrel; add cmdai-saas as a separate project
  - Add complete workspace → Vercel project mapping
  - Add quick troubleshooting with Vercel CLI and link verification results

<sup>Written for commit 6012d7d52cf61c0edcb4e2a164da58b7d9e46fea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

