### PR TITLE
docs: Add ADR-008 for self-update mechanism

### DIFF
--- a/docs/adr/ADR-008-self-update-mechanism.md
+++ b/docs/adr/ADR-008-self-update-mechanism.md
@@ -1,0 +1,579 @@
+# ADR-008: Self-Update Mechanism
+
+| **Status**     | Proposed                            |
+|----------------|-------------------------------------|
+| **Date**       | January 2026                        |
+| **Authors**    | Caro Maintainers                    |
+| **Target**     | Community                           |
+| **Supersedes** | N/A                                 |
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Context and Problem Statement](#context-and-problem-statement)
+3. [Decision Drivers](#decision-drivers)
+4. [Crate Evaluation](#crate-evaluation)
+5. [Recommended Decision](#recommended-decision)
+6. [Implementation Strategy](#implementation-strategy)
+7. [Security Considerations](#security-considerations)
+8. [Consequences](#consequences)
+9. [Alternatives Considered](#alternatives-considered)
+10. [References](#references)
+
+---
+
+## Executive Summary
+
+This ADR evaluates adding self-update functionality to Caro, enabling the CLI to check for and apply updates without requiring users to manually run `cargo install` or download binaries. After evaluating the available Rust ecosystem, **`self_update`** emerges as the recommended crate due to its maturity, GitHub release integration, cross-platform support, and active maintenance.
+
+**Core Tenets:**
+- **User convenience** through seamless update experience
+- **Security-first** with signature verification and checksums
+- **Optional behavior** - updates are user-initiated, never automatic
+- **GitHub releases** as the primary distribution mechanism
+- **Fallback to cargo install** for source-based installations
+
+---
+
+## Context and Problem Statement
+
+### The Challenge
+
+Caro is distributed through three channels:
+
+1. **crates.io** (`cargo install caro`) - Source-based installation
+2. **GitHub Releases** - Pre-compiled binaries for macOS/Linux/Windows
+3. **Homebrew** (planned) - Package manager distribution
+
+Currently, users must manually check for updates by:
+- Visiting GitHub or crates.io
+- Comparing versions
+- Running `cargo install caro --force` or downloading new binaries
+- Replacing their existing installation
+
+This creates friction and leads to users running outdated versions with potential bugs or security issues.
+
+### The Goal
+
+Implement a `caro update` (or `caro --update`) command that:
+1. Checks for new versions on GitHub releases
+2. Downloads the appropriate binary for the user's platform
+3. Verifies integrity (checksum/signature)
+4. Replaces the current binary in-place
+5. Reports success or failure clearly
+
+---
+
+## Decision Drivers
+
+### Primary Drivers
+
+1. **User Experience**: One-command updates reduce friction
+2. **Security**: Users should be on latest security patches quickly
+3. **Cross-Platform**: Must work on macOS (ARM64/x86_64), Linux, Windows
+4. **GitHub Integration**: Our primary release channel is GitHub Releases
+5. **Minimal Dependencies**: Caro already uses `reqwest` for remote backends
+
+### Secondary Drivers
+
+- Binary size impact (< 1MB increase acceptable)
+- Build complexity (no new C dependencies)
+- Maintenance burden (well-maintained upstream)
+- Feature flag support (can be disabled for embedded builds)
+
+---
+
+## Crate Evaluation
+
+### Primary Candidate: `self_update`
+
+**Repository**: [github.com/jaemk/self_update](https://github.com/jaemk/self_update)
+
+| Metric | Value |
+|--------|-------|
+| **Version** | 0.42.0 (Dec 31, 2024) |
+| **Total Downloads** | 6.5M+ |
+| **Recent Downloads** | 962K (last 90 days) |
+| **GitHub Stars** | 910 |
+| **Dependents** | 2,500+ |
+| **License** | MIT |
+| **Rust LOC** | 3,551 |
+| **Last Updated** | Active (December 2024) |
+
+#### Supported Backends
+
+| Backend | Description | Caro Usage |
+|---------|-------------|------------|
+| **GitHub** | Fetches from `api.github.com/repos/{owner}/{repo}/releases` | **Primary** |
+| **GitLab** | Equivalent functionality for GitLab instances | Not needed |
+| **Amazon S3** | Cloud storage with bucket and prefix configuration | Future option |
+| **Google GCS** | Cloud-based release distribution | Not needed |
+| **DigitalOcean Spaces** | S3-compatible object storage | Not needed |
+
+#### Key Features
+
+```rust
+// GitHub Release Update Pattern
+self_update::backends::github::Update::configure()
+    .repo_owner("wildcard")
+    .repo_name("caro")
+    .bin_name("caro")
+    .show_download_progress(true)
+    .show_output(true)
+    .current_version(cargo_crate_version!())
+    .build()?
+    .update()?;
+```
+
+**Archive Support:**
+- `archive-tar` - TAR format (used for Linux releases)
+- `archive-zip` - ZIP format (used for Windows releases)
+
+**Compression Support:**
+- `compression-flate2` - gzip (`.tar.gz`)
+- `compression-zip-deflate` - zip deflate
+- `compression-zip-bzip2` - zip bzip2
+
+**Security Features:**
+- `signatures` - Ed25519 artifact verification via zipsign
+- `rustls` - Pure Rust TLS (no OpenSSL dependency)
+- Checksum validation on downloads
+
+**Additional Features:**
+- `ReleaseList` - Enumerate all available releases
+- `Download` - Custom header support for private repos
+- `Extract` - Archive decompression utilities
+- Re-exports `self_replace` for in-place binary replacement
+
+#### Feature Flag Configuration for Caro
+
+```toml
+[dependencies]
+self_update = {
+    version = "0.42",
+    default-features = false,
+    features = [
+        "archive-tar",          # Linux releases
+        "archive-zip",          # Windows releases
+        "compression-flate2",   # gzip compression
+        "rustls",               # Pure Rust TLS
+    ],
+    optional = true
+}
+
+[features]
+self-update = ["self_update"]
+full = ["remote-backends", "embedded-mlx", "embedded-cpu", "self-update"]
+```
+
+### Alternative Candidates
+
+#### `self-replace` (v1.5.0)
+
+**Repository**: [github.com/mitsuhiko/self-replace](https://github.com/mitsuhiko/self-replace)
+
+| Metric | Value |
+|--------|-------|
+| **Downloads** | 6M+ |
+| **Maintainer** | Armin Ronacher (@mitsuhiko) |
+| **Purpose** | Low-level binary replacement only |
+
+**Assessment**: `self-replace` is a **lower-level primitive** that handles the OS-specific complexities of replacing a running executable. It does NOT handle:
+- Version checking
+- Downloading releases
+- GitHub/GitLab integration
+- Archive extraction
+
+**Verdict**: Not suitable as standalone solution. Note that `self_update` re-exports and uses `self-replace` internally.
+
+#### `patchify`
+
+**Repository**: [github.com/danwilliams/patchify](https://github.com/danwilliams/patchify)
+
+| Metric | Value |
+|--------|-------|
+| **Architecture** | Client + Server components |
+| **Platform Support** | Linux only (macOS untested, Windows not supported) |
+| **Focus** | Self-hosted update server infrastructure |
+
+**Features:**
+- Autonomous update checking with configurable intervals
+- Critical actions counter (defer updates during operations)
+- Ed25519 signature verification
+- SHA256 hash verification
+- Status event broadcasting
+
+**Assessment**: Patchify is designed for organizations running their own update infrastructure with a server component. It's overkill for Caro's GitHub-based release model and lacks cross-platform support.
+
+**Verdict**: Not suitable. Too complex, limited platform support.
+
+#### `cli-autoupdate`
+
+**Repository**: [docs.rs/cli-autoupdate](https://docs.rs/cli-autoupdate)
+
+| Metric | Value |
+|--------|-------|
+| **Ecosystem** | Less mature |
+| **Documentation** | Limited |
+| **Community** | Smaller |
+
+**Assessment**: Less established than `self_update` with fewer features and smaller community.
+
+**Verdict**: Not recommended over `self_update`.
+
+#### `updater-lp`
+
+**Assessment**: GitHub-focused like `self_update` but less mature and fewer downloads.
+
+**Verdict**: `self_update` is the more established choice.
+
+### Comparison Matrix
+
+| Feature | self_update | self-replace | patchify | cli-autoupdate |
+|---------|-------------|--------------|----------|----------------|
+| **GitHub Releases** | ✅ Native | ❌ | ❌ | ✅ |
+| **Version Checking** | ✅ | ❌ | ✅ | ✅ |
+| **Archive Extraction** | ✅ | ❌ | ✅ | ⚠️ |
+| **Signature Verification** | ✅ | ❌ | ✅ | ❌ |
+| **macOS Support** | ✅ | ✅ | ⚠️ | ✅ |
+| **Windows Support** | ✅ | ✅ | ❌ | ✅ |
+| **Linux Support** | ✅ | ✅ | ✅ | ✅ |
+| **Pure Rust TLS** | ✅ | N/A | ⚠️ | ⚠️ |
+| **Active Maintenance** | ✅ | ✅ | ✅ | ⚠️ |
+| **Downloads** | 6.5M+ | 6M+ | Low | Low |
+| **Complexity** | Medium | Low | High | Low |
+
+---
+
+## Recommended Decision
+
+**Use `self_update` crate (v0.42+) for implementing Caro's self-update mechanism.**
+
+### Rationale
+
+1. **Proven at Scale**: 6.5M+ downloads, 2,500+ dependents, battle-tested
+2. **GitHub Native**: Built specifically for GitHub Releases workflow we already use
+3. **Cross-Platform**: Handles macOS, Linux, Windows with platform-specific quirks
+4. **Pure Rust**: `rustls` feature avoids OpenSSL dependency (aligns with Caro's approach)
+5. **Security Ready**: Signature verification support for future hardening
+6. **Minimal Footprint**: ~3,500 lines of Rust, modular feature flags
+7. **Active Maintenance**: Updated December 2024, responsive maintainer
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Basic Update Command
+
+```rust
+// src/cli/update.rs
+use self_update::backends::github::Update;
+use crate::version;
+
+pub async fn check_for_updates(auto_install: bool) -> Result<UpdateStatus> {
+    let status = Update::configure()
+        .repo_owner("wildcard")
+        .repo_name("caro")
+        .bin_name("caro")
+        .show_download_progress(true)
+        .no_confirm(auto_install)
+        .current_version(version::info().version)
+        .build()?
+        .update()?;
+
+    match status {
+        self_update::Status::UpToDate(v) => {
+            println!("Already running latest version: {}", v);
+            Ok(UpdateStatus::Current)
+        }
+        self_update::Status::Updated(v) => {
+            println!("Updated to version: {}", v);
+            Ok(UpdateStatus::Updated(v))
+        }
+    }
+}
+```
+
+### Phase 2: CLI Integration
+
+```bash
+# Check for updates (interactive)
+caro update
+
+# Check only, don't install
+caro update --check
+
+# Force update even if current
+caro update --force
+
+# Quiet mode for scripts
+caro update --quiet
+```
+
+### Phase 3: Optional Startup Check (Future)
+
+```rust
+// Optional: Check for updates on startup (configurable)
+if config.check_updates_on_startup {
+    if let Some(new_version) = check_for_new_version().await? {
+        eprintln!("New version {} available! Run 'caro update' to install.", new_version);
+    }
+}
+```
+
+### Release Artifact Naming Convention
+
+`self_update` expects consistent artifact naming. Our GitHub releases should follow:
+
+```
+caro-{version}-{target}.tar.gz       # Linux/macOS
+caro-{version}-{target}.zip          # Windows
+
+Examples:
+caro-1.0.4-aarch64-apple-darwin.tar.gz
+caro-1.0.4-x86_64-unknown-linux-gnu.tar.gz
+caro-1.0.4-x86_64-pc-windows-msvc.zip
+```
+
+### Build Type Awareness
+
+The update mechanism should respect build type from `version.rs`:
+
+| Build Type | Update Behavior |
+|------------|-----------------|
+| `binary (official release)` | Full self-update support |
+| `source (cargo install)` | Suggest `cargo install caro --force` |
+| `dev (local build)` | Disable updates, show warning |
+
+```rust
+pub fn can_self_update() -> bool {
+    matches!(version::info().build_type(), "binary (official release)")
+}
+```
+
+---
+
+## Security Considerations
+
+### Current Release Security Model
+
+Caro's existing release process (documented in `RELEASE_PROCESS.md`) provides:
+
+1. **GPG-signed tags** for releases
+2. **SHA256 checksums** in release notes
+3. **CI-based builds** (no local machine builds)
+4. **Token-protected publishing** to crates.io
+5. **Multi-step verification** before release
+
+### Self-Update Security Enhancements
+
+#### Immediate (Phase 1)
+
+- **HTTPS-only** downloads via `rustls`
+- **Version comparison** to prevent downgrades
+- **GitHub API verification** (authenticated release data)
+- **User confirmation** before replacing binary
+
+#### Future (Phase 2)
+
+- **Ed25519 signatures** via `zipsign` integration
+- **Checksum verification** against release notes
+- **Certificate pinning** for GitHub API
+
+#### Implementation Example
+
+```rust
+// Prevent downgrade attacks
+fn is_valid_upgrade(current: &str, new: &str) -> bool {
+    let current = semver::Version::parse(current).ok()?;
+    let new = semver::Version::parse(new).ok()?;
+    new > current
+}
+
+// Verify download integrity
+fn verify_checksum(data: &[u8], expected: &str) -> bool {
+    use sha2::{Sha256, Digest};
+    let hash = hex::encode(Sha256::digest(data));
+    hash == expected
+}
+```
+
+### Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| **Compromised GitHub release** | Ed25519 signatures (future), checksum verification |
+| **MITM attack** | HTTPS/TLS only, rustls (no OpenSSL) |
+| **Downgrade attack** | Semantic version comparison |
+| **Partial download** | Checksum validation before replacement |
+| **Interrupted update** | `self-replace` handles atomic replacement |
+
+---
+
+## Consequences
+
+### Benefits
+
+1. **Improved UX**: Users can update with single command
+2. **Security Velocity**: Security patches reach users faster
+3. **Reduced Support**: Fewer "works on latest version" issues
+4. **Version Visibility**: Users know when updates are available
+5. **Ecosystem Alignment**: Follows patterns from rustup, cargo
+
+### Trade-offs
+
+1. **Binary Size**: ~500KB-1MB increase (acceptable)
+2. **New Dependency**: `self_update` crate + transitive deps
+3. **Feature Complexity**: Need to handle build type awareness
+4. **Testing Burden**: Need integration tests for update flow
+
+### Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| `self_update` becomes unmaintained | Low | Medium | Fork if needed, active community |
+| GitHub API rate limits | Low | Low | Cache version checks |
+| Platform-specific bugs | Medium | Low | Thorough cross-platform testing |
+| Update mechanism exploited | Very Low | High | Signature verification in Phase 2 |
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: No Self-Update
+
+**Description**: Users continue using `cargo install` or manual downloads.
+
+**Pros:**
+- No additional complexity
+- No new dependencies
+- No security surface area increase
+
+**Cons:**
+- Poor user experience
+- Slower security patch adoption
+- More support burden
+
+**Verdict**: Not recommended - UX is important for CLI tools.
+
+### Alternative 2: Custom Implementation
+
+**Description**: Build update mechanism from scratch using `reqwest` + `self-replace`.
+
+**Pros:**
+- Full control over implementation
+- No external dependency on `self_update`
+- Exactly what we need, nothing more
+
+**Cons:**
+- Significant development effort
+- Reinventing well-tested wheel
+- Maintenance burden on our team
+- Likely to have bugs in edge cases
+
+**Verdict**: Not recommended - `self_update` is mature and well-tested.
+
+### Alternative 3: Patchify with Self-Hosted Server
+
+**Description**: Deploy update server infrastructure using `patchify`.
+
+**Pros:**
+- More control over update distribution
+- Could support delta updates
+- Signature verification built-in
+
+**Cons:**
+- Requires server infrastructure
+- Complex for single CLI tool
+- No macOS/Windows support
+- Overkill for our scale
+
+**Verdict**: Not recommended - too complex for our needs.
+
+---
+
+## Implementation Notes
+
+### Feature Flag
+
+```toml
+[features]
+default = ["embedded-mlx", "embedded-cpu"]
+self-update = ["dep:self_update"]
+full = ["remote-backends", "embedded-mlx", "embedded-cpu", "self-update"]
+```
+
+### Conditional Compilation
+
+```rust
+#[cfg(feature = "self-update")]
+mod update;
+
+#[cfg(feature = "self-update")]
+pub use update::check_for_updates;
+```
+
+### Testing Strategy
+
+1. **Unit Tests**: Version comparison, build type detection
+2. **Integration Tests**: Mock GitHub API responses
+3. **Manual Testing**: Cross-platform update flows
+4. **CI Verification**: Ensure release artifacts match naming convention
+
+### Rollout Plan
+
+1. **v1.1.0**: Basic update check command (`caro update --check`)
+2. **v1.2.0**: Full self-update functionality
+3. **v1.3.0**: Optional startup version check
+4. **v2.0.0**: Ed25519 signature verification
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Update command works | 100% | Cross-platform CI tests |
+| User adoption | 30%+ use update command | Telemetry (optional) |
+| Time to update | < 30 seconds | Manual benchmarks |
+| Update failure rate | < 1% | Error tracking |
+| Security incidents | 0 | Incident reports |
+
+---
+
+## References
+
+### Crates
+
+- [self_update on crates.io](https://crates.io/crates/self_update)
+- [self_update on GitHub](https://github.com/jaemk/self_update)
+- [self-replace on crates.io](https://crates.io/crates/self-replace)
+- [patchify on GitHub](https://github.com/danwilliams/patchify)
+
+### Related Caro Documents
+
+- [Release Process](../RELEASE_PROCESS.md)
+- [ADR-001: LLM Inference Architecture](./001-llm-inference-architecture.md)
+- [Version Module](../../src/version.rs)
+
+### Prior Art
+
+- [rustup self-update](https://github.com/rust-lang/rustup/blob/master/src/cli/self_update.rs)
+- [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+### Discussions
+
+- [Hacker News: self_update announcement](https://news.ycombinator.com/item?id=22182728)
+- [Rust Forum: How to auto-update apps](https://users.rust-lang.org/t/how-to-auto-update-my-app/43100)
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-02 | Caro Maintainers | Initial draft |
+
+---
+
+*This ADR was authored in January 2026 and recommends `self_update` v0.42+ based on the Rust ecosystem state at that time.*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@ Example: `ADR-001-enterprise-community-architecture.md`
 | [ADR-005](./ADR-005-hayagriva-bibliography-integration.md) | Hayagriva Bibliography Integration | Proposed | 2026-01-02 |
 | [ADR-006](./ADR-006-olmo3-model-support.md) | OLMo 3 Model Support | Proposed | 2026-01-03 |
 | [ADR-007](./ADR-007-ast-parser-shell-validation.md) | AST Parser for Shell Command Validation | Proposed | 2026-01-02 |
+| [ADR-008](./ADR-008-self-update-mechanism.md) | Self-Update Mechanism | Proposed | 2026-01-22 |
 
 ## Contributing to ADRs
 

--- a/specs/008-self-update-mechanism/README.md
+++ b/specs/008-self-update-mechanism/README.md
@@ -1,0 +1,50 @@
+# 008: Self-Update Mechanism
+
+**Status**: Specified
+**Priority**: Medium
+**Target Version**: v1.1.0 (Phase 1), v1.2.0 (Phase 2)
+
+## Overview
+
+Add self-update functionality to Caro, allowing users to update their installation with a single command (`caro update`).
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [spec.md](./spec.md) | Product Requirements Document |
+| [plan.md](./plan.md) | Implementation Architecture |
+| [tasks.md](./tasks.md) | Actionable Implementation Tasks |
+
+## Related
+
+- [ADR-004: Self-Update Mechanism](../../docs/adr/ADR-004-self-update-mechanism.md) - Architecture decision record
+- [Release Process](../../docs/RELEASE_PROCESS.md) - Current release workflow
+
+## Quick Summary
+
+**Problem**: Users must manually check and download updates.
+
+**Solution**: `caro update` command using `self_update` crate to check GitHub Releases and replace binary in-place.
+
+**Scope**:
+- `caro update` - Install latest version
+- `caro update --check` - Check without installing
+- `caro update --force` - Force reinstall
+- Build type awareness (binary vs source vs dev)
+
+## Key Decisions
+
+1. **Crate**: `self_update` v0.42+ (6.5M+ downloads, GitHub native)
+2. **Backend**: GitHub Releases (existing release channel)
+3. **Feature**: Optional via `--features self-update`
+4. **Security**: HTTPS only, user confirmation, future signature verification
+
+## Phases
+
+| Phase | Version | Scope |
+|-------|---------|-------|
+| 1 | v1.1.0 | `--check` only, build type detection |
+| 2 | v1.2.0 | Full self-update with progress |
+| 3 | v1.3.0 | Quiet mode, optional startup check |
+| 4 | v2.0.0 | Ed25519 signature verification |

--- a/specs/008-self-update-mechanism/plan.md
+++ b/specs/008-self-update-mechanism/plan.md
@@ -1,0 +1,418 @@
+# Self-Update Implementation Plan
+
+## Overview
+
+This document outlines the implementation strategy for adding self-update functionality to Caro using the `self_update` crate.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         caro update                              │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Build Type Detection                          │
+│  ┌─────────────────┬─────────────────┬─────────────────────┐    │
+│  │ Official Binary │  Cargo Install  │    Dev Build        │    │
+│  │ (CARO_RELEASE=1)│  (release mode) │  (debug/unknown)    │    │
+│  └────────┬────────┴────────┬────────┴──────────┬──────────┘    │
+│           │                 │                   │               │
+│           ▼                 ▼                   ▼               │
+│      Self-Update       Show cargo          Refuse with         │
+│      Enabled           install hint        warning             │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    GitHub Release Check                          │
+│  • GET api.github.com/repos/wildcard/caro/releases/latest       │
+│  • Parse version from tag (v1.0.5 → 1.0.5)                      │
+│  • Compare with current version (semver)                        │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │                       │
+                    ▼                       ▼
+            ┌───────────────┐       ┌───────────────┐
+            │ Up-to-date    │       │ Update Avail  │
+            │ Exit(0)       │       │ Continue      │
+            └───────────────┘       └───────┬───────┘
+                                            │
+                                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Download Binary                               │
+│  • Select asset by target triple                                 │
+│  • Show progress bar with speed                                  │
+│  • Write to temp file                                            │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Verify & Extract                              │
+│  • Checksum verification (future)                                │
+│  • Extract from tar.gz/zip                                       │
+│  • Verify extracted binary exists                                │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Replace Binary                                │
+│  • Use self-replace crate                                        │
+│  • Atomic replacement                                            │
+│  • Handle Windows special cases                                  │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Success                                       │
+│  • Print new version info                                        │
+│  • Suggest shell restart                                         │
+│  • Exit(0)                                                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Module Structure
+
+```
+src/
+├── cli/
+│   ├── mod.rs              # Add UpdateArgs
+│   └── update.rs           # NEW: Update command implementation
+├── update/                 # NEW: Update module
+│   ├── mod.rs             # Module exports
+│   ├── checker.rs         # Version checking logic
+│   ├── installer.rs       # Download and install logic
+│   └── progress.rs        # Progress bar rendering
+└── version.rs             # Existing, add can_self_update()
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation (v1.1.0)
+
+**Goal**: Implement `caro update --check` and build type detection.
+
+**Files to Create/Modify**:
+
+1. **Cargo.toml**: Add optional `self_update` dependency
+2. **src/cli/mod.rs**: Add `UpdateArgs` struct and subcommand
+3. **src/update/mod.rs**: Module root
+4. **src/update/checker.rs**: Version check logic
+5. **src/version.rs**: Add `can_self_update()` method
+
+**Key Code**:
+
+```rust
+// src/update/checker.rs
+use self_update::backends::github::ReleaseList;
+
+pub struct UpdateChecker {
+    current_version: String,
+}
+
+impl UpdateChecker {
+    pub fn new() -> Self {
+        Self {
+            current_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    pub async fn check_for_update(&self) -> Result<Option<String>> {
+        let releases = ReleaseList::configure()
+            .repo_owner("wildcard")
+            .repo_name("caro")
+            .build()?
+            .fetch()?;
+
+        if let Some(latest) = releases.first() {
+            let latest_version = latest.version.trim_start_matches('v');
+            if is_newer(latest_version, &self.current_version)? {
+                return Ok(Some(latest_version.to_string()));
+            }
+        }
+        Ok(None)
+    }
+}
+```
+
+### Phase 2: Self-Update (v1.2.0)
+
+**Goal**: Full download and install functionality.
+
+**Files to Create/Modify**:
+
+1. **src/update/installer.rs**: Download and install logic
+2. **src/update/progress.rs**: Progress bar with indicatif
+3. **src/cli/update.rs**: Full update command handler
+
+**Key Code**:
+
+```rust
+// src/update/installer.rs
+use self_update::backends::github::Update;
+
+pub async fn install_update(target_version: &str, force: bool) -> Result<()> {
+    let status = Update::configure()
+        .repo_owner("wildcard")
+        .repo_name("caro")
+        .bin_name("caro")
+        .show_download_progress(true)
+        .show_output(true)
+        .no_confirm(false)
+        .current_version(env!("CARGO_PKG_VERSION"))
+        .build()?
+        .update()?;
+
+    match status {
+        self_update::Status::Updated(v) => {
+            println!("\nUpdated successfully!");
+            println!("caro {} - restart your shell to use the new version", v);
+        }
+        self_update::Status::UpToDate(v) => {
+            println!("\nAlready running the latest version: {}", v);
+        }
+    }
+
+    Ok(())
+}
+```
+
+### Phase 3: Polish (v1.3.0)
+
+**Goal**: Quiet mode, optional startup check, better UX.
+
+**Additions**:
+
+1. **Config option**: `check_updates_on_startup: bool`
+2. **Quiet mode**: `--quiet` flag for scripting
+3. **Startup hint**: Show "update available" at startup (optional)
+
+### Phase 4: Security (v2.0.0)
+
+**Goal**: Signature verification.
+
+**Additions**:
+
+1. Enable `signatures` feature in self_update
+2. Generate Ed25519 keypair for releases
+3. Sign releases with `zipsign`
+4. Verify signatures before install
+
+## CLI Integration
+
+### Clap Argument Definition
+
+```rust
+// src/cli/mod.rs
+
+#[derive(Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Check for and install updates
+    #[cfg(feature = "self-update")]
+    Update(UpdateArgs),
+    // ... existing commands
+}
+
+#[derive(Args)]
+#[cfg(feature = "self-update")]
+pub struct UpdateArgs {
+    /// Check for updates without installing
+    #[arg(short, long)]
+    pub check: bool,
+
+    /// Force reinstall even if up-to-date
+    #[arg(short, long)]
+    pub force: bool,
+
+    /// Minimal output for scripts
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Skip confirmation prompts
+    #[arg(short, long)]
+    pub yes: bool,
+}
+```
+
+### Command Handler
+
+```rust
+// src/cli/update.rs
+
+pub async fn handle_update(args: UpdateArgs) -> Result<i32> {
+    // Check build type
+    let version_info = crate::version::info();
+
+    match version_info.build_type() {
+        "dev (local build)" => {
+            eprintln!("Self-update is disabled for development builds.");
+            return Ok(5);
+        }
+        "source (cargo install)" => {
+            eprintln!("You installed from source. To update, run:");
+            eprintln!("    cargo install caro --force");
+            return Ok(5);
+        }
+        _ => {} // Continue for binary releases
+    }
+
+    let checker = UpdateChecker::new();
+
+    match checker.check_for_update().await? {
+        Some(new_version) => {
+            if args.check {
+                if !args.quiet {
+                    println!("Update available: {} -> {}",
+                             version_info.version, new_version);
+                } else {
+                    println!("{} {}", version_info.version, new_version);
+                }
+                return Ok(1); // Update available
+            }
+
+            // Proceed with update
+            install_update(&new_version, args.force).await?;
+            Ok(0)
+        }
+        None => {
+            if !args.quiet {
+                println!("Already running the latest version: {}",
+                         version_info.version);
+            }
+            Ok(0)
+        }
+    }
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_comparison() {
+        assert!(is_newer("1.0.5", "1.0.3").unwrap());
+        assert!(!is_newer("1.0.3", "1.0.5").unwrap());
+        assert!(!is_newer("1.0.3", "1.0.3").unwrap());
+    }
+
+    #[test]
+    fn test_build_type_detection() {
+        // Test via version module
+    }
+}
+```
+
+### Integration Tests
+
+```rust
+// tests/update_integration.rs
+
+#[tokio::test]
+#[ignore] // Requires network
+async fn test_check_for_update() {
+    let checker = UpdateChecker::new();
+    let result = checker.check_for_update().await;
+    assert!(result.is_ok());
+}
+```
+
+### Manual Testing Checklist
+
+- [ ] macOS ARM64: Full update cycle
+- [ ] macOS x86_64: Full update cycle
+- [ ] Linux x86_64: Full update cycle
+- [ ] Windows x86_64: Full update cycle
+- [ ] Offline behavior: Clear error message
+- [ ] Permission denied: Helpful message
+- [ ] Already up-to-date: Correct output
+- [ ] Force reinstall: Works correctly
+- [ ] Quiet mode: Minimal output
+- [ ] Dev build: Refuses with warning
+- [ ] Source install: Shows cargo command
+
+## Dependencies
+
+### Added to Cargo.toml
+
+```toml
+[dependencies.self_update]
+version = "0.42"
+optional = true
+default-features = false
+features = [
+    "archive-tar",
+    "archive-zip",
+    "compression-flate2",
+    "rustls",
+]
+
+[features]
+self-update = ["dep:self_update"]
+full = ["remote-backends", "embedded-mlx", "embedded-cpu", "self-update"]
+```
+
+### Transitive Dependencies
+
+- `reqwest` (already in project via remote-backends)
+- `flate2` (compression)
+- `tar` (archive extraction)
+- `zip` (Windows archives)
+- `self-replace` (atomic binary replacement)
+- `semver` (version comparison)
+
+## Binary Size Impact
+
+Estimated increase: **500KB - 1MB** with self_update features.
+
+This is acceptable given the feature value.
+
+## CI/CD Changes
+
+### Release Workflow Updates
+
+1. Ensure asset naming matches expected pattern
+2. Add checksums to release notes
+3. Future: Add signature generation
+
+### Test Workflow
+
+```yaml
+# .github/workflows/test.yml
+- name: Test self-update feature
+  run: cargo test --features self-update
+```
+
+## Rollback Plan
+
+If self-update causes issues:
+
+1. Users can always `cargo install caro --force`
+2. Previous releases remain on GitHub
+3. Feature can be disabled in build
+
+## Timeline
+
+| Phase | Version | Estimated Effort |
+|-------|---------|------------------|
+| Phase 1: Foundation | v1.1.0 | 2-3 days |
+| Phase 2: Self-Update | v1.2.0 | 3-4 days |
+| Phase 3: Polish | v1.3.0 | 2-3 days |
+| Phase 4: Security | v2.0.0 | 4-5 days |
+
+---
+
+*Implementation plan created January 2026*

--- a/specs/008-self-update-mechanism/spec.md
+++ b/specs/008-self-update-mechanism/spec.md
@@ -1,0 +1,465 @@
+# Caro Self-Update Mechanism - Product Requirements Document
+
+## Executive Summary
+
+This specification defines the product requirements for adding self-update functionality to Caro, enabling users to update their installation with a single command. The feature uses the `self_update` crate to check GitHub Releases and replace the binary in-place, providing a seamless upgrade experience.
+
+**Key Value Proposition**: Users can stay current with security patches and new features without manual download/install steps.
+
+## Goals
+
+### Primary Goals
+
+1. **One-Command Updates**: `caro update` checks for and installs the latest version
+2. **Security Velocity**: Get security patches to users within minutes of release
+3. **Zero Configuration**: Works out-of-the-box for GitHub Release installations
+4. **Cross-Platform**: Consistent experience on macOS, Linux, and Windows
+5. **User Control**: Updates are always user-initiated, never automatic
+
+### Secondary Goals
+
+1. **Version Awareness**: Users can easily check if updates are available
+2. **Rollback Information**: Clear guidance if update causes issues
+3. **Progress Feedback**: Download progress and status during update
+4. **Offline Graceful**: Clear error messages when offline
+
+### Non-Goals
+
+1. **Automatic Background Updates**: We don't update without user consent
+2. **Delta/Patch Updates**: Full binary replacement only (simplicity over bandwidth)
+3. **Version Pinning**: Users can't pin to specific versions via this mechanism
+4. **Downgrade Support**: Only upgrades, not downgrades
+5. **cargo install Updates**: Source-based installations use `cargo install --force`
+
+## User Stories
+
+### US-1: Check for Updates
+
+**As a** Caro user
+**I want to** check if a new version is available
+**So that** I know when to update without actually updating
+
+**Acceptance Criteria:**
+- [ ] `caro update --check` shows current vs latest version
+- [ ] Exit code 0 if up-to-date, exit code 1 if update available
+- [ ] Works without network shows clear offline error
+- [ ] Completes in < 5 seconds on normal network
+
+**Example Output:**
+```
+$ caro update --check
+Current version: 1.0.3
+Latest version:  1.0.5
+
+Update available! Run 'caro update' to install.
+```
+
+### US-2: Install Update
+
+**As a** Caro user
+**I want to** update to the latest version with one command
+**So that** I get new features and security fixes quickly
+
+**Acceptance Criteria:**
+- [ ] `caro update` downloads and installs latest version
+- [ ] Shows download progress with percentage and speed
+- [ ] Verifies download integrity before replacing
+- [ ] Preserves executable permissions after update
+- [ ] Shows success message with new version number
+
+**Example Output:**
+```
+$ caro update
+Checking for updates...
+Current version: 1.0.3
+Latest version:  1.0.5
+
+Downloading caro v1.0.5...
+[████████████████████████████████████████] 100% (12.5 MB, 2.1 MB/s)
+
+Verifying download...
+Installing update...
+
+Updated successfully!
+caro 1.0.5 (abc1234 2026-01-15)
+
+Restart your shell or run 'caro --version' to verify.
+```
+
+### US-3: Already Up-to-Date
+
+**As a** Caro user
+**I want to** know when I'm already on the latest version
+**So that** I don't waste time or bandwidth
+
+**Acceptance Criteria:**
+- [ ] `caro update` shows "already up-to-date" if current
+- [ ] No download occurs when already current
+- [ ] Exit code 0 for success
+
+**Example Output:**
+```
+$ caro update
+Checking for updates...
+
+You're already running the latest version!
+caro 1.0.5 (abc1234 2026-01-15)
+```
+
+### US-4: Force Reinstall
+
+**As a** Caro user
+**I want to** force reinstall even if up-to-date
+**So that** I can repair a corrupted installation
+
+**Acceptance Criteria:**
+- [ ] `caro update --force` downloads even if current version
+- [ ] Confirmation prompt before force update
+- [ ] Same download/install flow as normal update
+
+**Example Output:**
+```
+$ caro update --force
+You are already running the latest version (1.0.5).
+
+Force reinstall anyway? [y/N] y
+
+Downloading caro v1.0.5...
+[████████████████████████████████████████] 100%
+
+Reinstalled successfully!
+```
+
+### US-5: Source Installation Guidance
+
+**As a** developer who installed via `cargo install`
+**I want to** know the correct update command for my installation type
+**So that** I don't break my setup
+
+**Acceptance Criteria:**
+- [ ] Detects source-based installation
+- [ ] Shows `cargo install caro --force` guidance
+- [ ] Does not attempt binary replacement for source installs
+
+**Example Output:**
+```
+$ caro update
+Checking for updates...
+
+You installed Caro from source (cargo install).
+To update, run:
+
+    cargo install caro --force
+
+Self-update only works for binary releases from GitHub.
+```
+
+### US-6: Development Build Warning
+
+**As a** developer with a local dev build
+**I want to** be warned that self-update doesn't apply
+**So that** I don't accidentally overwrite my development version
+
+**Acceptance Criteria:**
+- [ ] Detects development/debug builds
+- [ ] Shows warning and refuses to update
+- [ ] Explains why (dev builds shouldn't be replaced)
+
+**Example Output:**
+```
+$ caro update
+
+This is a development build (dev local build).
+Self-update is disabled for development versions.
+
+To test updates, build a release version or install from GitHub.
+```
+
+### US-7: Quiet Mode for Scripts
+
+**As a** system administrator
+**I want to** run update checks in scripts without interactive prompts
+**So that** I can automate update notifications
+
+**Acceptance Criteria:**
+- [ ] `caro update --check --quiet` outputs only version info
+- [ ] Exit codes indicate update status (0 = current, 1 = available)
+- [ ] No color codes or progress bars in quiet mode
+
+**Example Output:**
+```
+$ caro update --check --quiet
+1.0.3 1.0.5
+$ echo $?
+1
+```
+
+### US-8: Network Failure Handling
+
+**As a** Caro user
+**I want to** get clear error messages when offline
+**So that** I understand why the update failed
+
+**Acceptance Criteria:**
+- [ ] Clear error message for network failures
+- [ ] Retry suggestion for transient failures
+- [ ] Exit code non-zero for failures
+
+**Example Output:**
+```
+$ caro update
+Checking for updates...
+
+Error: Unable to reach GitHub API
+  - Check your internet connection
+  - GitHub status: https://githubstatus.com
+
+No changes made to your installation.
+```
+
+## User Experience
+
+### Command Interface
+
+```
+USAGE:
+    caro update [OPTIONS]
+
+OPTIONS:
+    -c, --check     Check for updates without installing
+    -f, --force     Force reinstall even if up-to-date
+    -q, --quiet     Minimal output (for scripts)
+    -y, --yes       Skip confirmation prompts
+    -h, --help      Print help information
+
+EXAMPLES:
+    caro update              # Interactive update
+    caro update --check      # Check only, don't install
+    caro update --force      # Force reinstall
+    caro update -y           # Auto-confirm (non-interactive)
+```
+
+### Progress Indicators
+
+**Download Progress:**
+```
+Downloading caro v1.0.5...
+[████████████████░░░░░░░░░░░░░░░░░░░░░░░░] 42% (5.2 MB / 12.5 MB) 1.8 MB/s
+```
+
+**Verification:**
+```
+Verifying download... OK
+```
+
+**Installation:**
+```
+Installing update... OK
+```
+
+### Error States
+
+| State | Message | Exit Code |
+|-------|---------|-----------|
+| Up-to-date | "Already running latest version" | 0 |
+| Update available | "Update available! Run 'caro update'" | 1 |
+| Update success | "Updated successfully!" | 0 |
+| Network error | "Unable to reach GitHub API" | 2 |
+| Permission error | "Permission denied. Try with sudo?" | 3 |
+| Checksum mismatch | "Download verification failed" | 4 |
+| Unsupported install | "Self-update not supported for this installation" | 5 |
+
+### Integration with Caro Personality
+
+Update messages should reflect Caro's helpful personality:
+
+**Checking:**
+```
+Hey! Let me check if there's a newer version of me...
+```
+
+**Up-to-date:**
+```
+You're all set! Running the latest version (1.0.5)
+```
+
+**Update available:**
+```
+Good news! Version 1.0.5 is available (you have 1.0.3)
+Ready to update? [Y/n]
+```
+
+**Success:**
+```
+All done! I'm now running version 1.0.5
+Thanks for keeping me up-to-date!
+```
+
+## Technical Requirements
+
+### Platform Support
+
+| Platform | Binary Format | Archive Type | Status |
+|----------|--------------|--------------|--------|
+| macOS ARM64 | Universal | `.tar.gz` | Required |
+| macOS x86_64 | Universal | `.tar.gz` | Required |
+| Linux x86_64 | ELF | `.tar.gz` | Required |
+| Linux ARM64 | ELF | `.tar.gz` | Best-effort |
+| Windows x86_64 | PE | `.zip` | Best-effort |
+
+### Release Artifact Naming
+
+GitHub Release assets must follow this convention:
+
+```
+caro-{version}-{target}.{ext}
+
+Examples:
+caro-1.0.5-aarch64-apple-darwin.tar.gz
+caro-1.0.5-x86_64-apple-darwin.tar.gz
+caro-1.0.5-x86_64-unknown-linux-gnu.tar.gz
+caro-1.0.5-aarch64-unknown-linux-gnu.tar.gz
+caro-1.0.5-x86_64-pc-windows-msvc.zip
+```
+
+### Feature Flags
+
+```toml
+[features]
+default = ["embedded-mlx", "embedded-cpu"]
+self-update = ["dep:self_update"]
+full = ["remote-backends", "embedded-mlx", "embedded-cpu", "self-update"]
+```
+
+Self-update is opt-in to keep binary size minimal for embedded use cases.
+
+### Dependencies
+
+```toml
+[dependencies.self_update]
+version = "0.42"
+optional = true
+default-features = false
+features = [
+    "archive-tar",
+    "archive-zip",
+    "compression-flate2",
+    "rustls",
+]
+```
+
+### Build Type Detection
+
+Update behavior varies by installation method:
+
+| Build Type | Detection | Update Behavior |
+|------------|-----------|-----------------|
+| `binary (official release)` | `CARO_RELEASE=1` | Full self-update |
+| `source (cargo install)` | Release profile, no flag | Suggest cargo install |
+| `dev (local build)` | Debug profile or unknown git | Refuse, warn |
+
+## Security Requirements
+
+### SR-1: HTTPS Only
+
+All downloads must use HTTPS. HTTP requests should fail or upgrade.
+
+### SR-2: Version Comparison
+
+Only allow upgrades (new version > current version). Downgrades require manual intervention.
+
+### SR-3: Checksum Verification
+
+Downloaded binaries must be verified against checksums from release notes.
+
+### SR-4: User Confirmation
+
+Default to requiring user confirmation before replacing binary. `--yes` flag for automation.
+
+### SR-5: Atomic Replacement
+
+Use `self-replace` crate for atomic binary replacement to prevent corruption.
+
+### SR-6: Future: Signature Verification
+
+Roadmap item: Ed25519 signatures for releases using `zipsign`.
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Update success rate | > 99% | Telemetry (opt-in) |
+| Time to check | < 3 seconds | CI benchmarks |
+| Time to update | < 60 seconds | Manual testing |
+| User adoption | 30%+ use update command | Telemetry (opt-in) |
+| Error message clarity | > 90% understand | User feedback |
+
+## Rollout Plan
+
+### Phase 1: v1.1.0 - Check Only
+
+- Implement `caro update --check`
+- Build type detection
+- Basic error handling
+- Documentation
+
+### Phase 2: v1.2.0 - Full Self-Update
+
+- Implement `caro update` with download/install
+- Progress indicators
+- Force reinstall support
+- Cross-platform testing
+
+### Phase 3: v1.3.0 - Polish
+
+- Optional startup check (config option)
+- Quiet mode for scripts
+- Improved error messages
+- Performance optimization
+
+### Phase 4: v2.0.0 - Security Hardening
+
+- Ed25519 signature verification
+- Checksum validation
+- Certificate pinning
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Corrupted download | Low | High | Checksum verification, atomic replace |
+| Permissions issues | Medium | Medium | Clear error messages, sudo guidance |
+| Platform edge cases | Medium | Low | Extensive cross-platform testing |
+| Rate limiting | Low | Low | Cache version checks, exponential backoff |
+| Breaking changes | Low | High | Semantic versioning, changelog |
+
+## Open Questions
+
+1. **Startup check frequency**: How often should optional startup check run? Daily? Weekly?
+2. **Rollback mechanism**: Should we provide `caro update --rollback`?
+3. **Channel support**: Should we support beta/nightly channels in future?
+4. **Proxy support**: How do we handle corporate proxies?
+
+## Appendix A: Competitive Analysis
+
+| Tool | Update Mechanism | Notes |
+|------|------------------|-------|
+| **rustup** | `rustup update` | Self-updates toolchain and self |
+| **cargo** | Via rustup | No direct self-update |
+| **gh** (GitHub CLI) | `gh upgrade` | GitHub Releases |
+| **starship** | Manual/package manager | No built-in update |
+| **zoxide** | Manual/package manager | No built-in update |
+| **bat** | Manual/package manager | No built-in update |
+| **ripgrep** | Manual/package manager | No built-in update |
+
+Caro's approach aligns with `gh` and `rustup` patterns.
+
+## Appendix B: Related Documents
+
+- [ADR-004: Self-Update Mechanism](../../docs/adr/ADR-004-self-update-mechanism.md)
+- [Release Process](../../docs/RELEASE_PROCESS.md)
+- [Version Module](../../src/version.rs)
+
+---
+
+*This PRD was authored in January 2026 and defines requirements for the self-update feature.*

--- a/specs/008-self-update-mechanism/tasks.md
+++ b/specs/008-self-update-mechanism/tasks.md
@@ -1,0 +1,508 @@
+# Self-Update Implementation Tasks
+
+## Phase 1: Foundation (v1.1.0)
+
+### P1-1: Add self_update dependency
+
+**Status**: `pending`
+
+**Description**: Add the `self_update` crate as an optional dependency with appropriate feature flags.
+
+**Files**:
+- `Cargo.toml`
+
+**Acceptance Criteria**:
+- [ ] `self_update = "0.42"` added with correct features
+- [ ] `self-update` feature flag created
+- [ ] Feature added to `full` feature set
+- [ ] `cargo check --features self-update` passes
+
+**Implementation**:
+```toml
+[dependencies.self_update]
+version = "0.42"
+optional = true
+default-features = false
+features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"]
+
+[features]
+self-update = ["dep:self_update"]
+full = ["remote-backends", "embedded-mlx", "embedded-cpu", "self-update"]
+```
+
+---
+
+### P1-2: Add can_self_update() to version module
+
+**Status**: `pending`
+
+**Description**: Extend the version module to detect if self-update is supported for the current build type.
+
+**Files**:
+- `src/version.rs`
+
+**Acceptance Criteria**:
+- [ ] `can_self_update()` returns `true` only for official binary releases
+- [ ] `update_instructions()` returns appropriate message per build type
+- [ ] Unit tests cover all three build types
+
+**Implementation**:
+```rust
+impl VersionInfo {
+    /// Check if self-update is supported for this build
+    pub fn can_self_update(&self) -> bool {
+        self.build_type() == "binary (official release)"
+    }
+
+    /// Get update instructions appropriate for build type
+    pub fn update_instructions(&self) -> &'static str {
+        match self.build_type() {
+            "binary (official release)" => "Run 'caro update' to update",
+            "source (cargo install)" => "Run 'cargo install caro --force' to update",
+            "dev (local build)" => "Rebuild from source to update",
+            _ => "Unknown build type",
+        }
+    }
+}
+```
+
+---
+
+### P1-3: Create update module structure
+
+**Status**: `pending`
+
+**Description**: Create the update module with version checking functionality.
+
+**Files**:
+- `src/update/mod.rs` (new)
+- `src/update/checker.rs` (new)
+- `src/lib.rs` (add module)
+
+**Acceptance Criteria**:
+- [ ] Module compiles with `--features self-update`
+- [ ] Module is behind `#[cfg(feature = "self-update")]`
+- [ ] `UpdateChecker` struct can fetch latest version from GitHub
+
+**Implementation**:
+```rust
+// src/update/mod.rs
+#[cfg(feature = "self-update")]
+mod checker;
+
+#[cfg(feature = "self-update")]
+pub use checker::UpdateChecker;
+```
+
+---
+
+### P1-4: Implement version checking
+
+**Status**: `pending`
+
+**Description**: Implement the `UpdateChecker` that queries GitHub for the latest release.
+
+**Files**:
+- `src/update/checker.rs`
+
+**Acceptance Criteria**:
+- [ ] `check_for_update()` returns `Some(version)` if newer available
+- [ ] `check_for_update()` returns `None` if up-to-date
+- [ ] Proper error handling for network failures
+- [ ] Semver comparison handles edge cases
+
+**Implementation**:
+```rust
+use anyhow::Result;
+use self_update::backends::github::ReleaseList;
+
+pub struct UpdateChecker {
+    current_version: semver::Version,
+}
+
+impl UpdateChecker {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            current_version: semver::Version::parse(env!("CARGO_PKG_VERSION"))?,
+        })
+    }
+
+    pub fn check_for_update(&self) -> Result<Option<String>> {
+        let releases = ReleaseList::configure()
+            .repo_owner("wildcard")
+            .repo_name("caro")
+            .build()?
+            .fetch()?;
+
+        if let Some(latest) = releases.first() {
+            let latest_str = latest.version.trim_start_matches('v');
+            let latest_version = semver::Version::parse(latest_str)?;
+
+            if latest_version > self.current_version {
+                return Ok(Some(latest_str.to_string()));
+            }
+        }
+        Ok(None)
+    }
+}
+```
+
+---
+
+### P1-5: Add update CLI subcommand
+
+**Status**: `pending`
+
+**Description**: Add the `update` subcommand to the CLI with `--check` flag.
+
+**Files**:
+- `src/cli/mod.rs`
+- `src/cli/update.rs` (new)
+- `src/main.rs` (add handler)
+
+**Acceptance Criteria**:
+- [ ] `caro update --check` works and shows version info
+- [ ] `caro update --help` shows proper help text
+- [ ] Exit codes match spec (0 = current, 1 = update available)
+- [ ] Build type detection prevents update on wrong builds
+
+---
+
+### P1-6: Write tests for Phase 1
+
+**Status**: `pending`
+
+**Description**: Add unit and integration tests for version checking.
+
+**Files**:
+- `src/update/checker.rs` (add tests)
+- `src/version.rs` (add tests)
+- `tests/update_check.rs` (new, optional)
+
+**Acceptance Criteria**:
+- [ ] Version comparison tests pass
+- [ ] Build type detection tests pass
+- [ ] `cargo test --features self-update` passes
+
+---
+
+## Phase 2: Self-Update (v1.2.0)
+
+### P2-1: Implement download and install
+
+**Status**: `pending`
+
+**Description**: Add the ability to download and install updates.
+
+**Files**:
+- `src/update/installer.rs` (new)
+- `src/update/mod.rs` (add export)
+
+**Acceptance Criteria**:
+- [ ] Downloads correct binary for target platform
+- [ ] Shows progress bar during download
+- [ ] Extracts binary from archive
+- [ ] Replaces current binary atomically
+
+**Implementation**:
+```rust
+use self_update::backends::github::Update;
+
+pub fn install_update() -> Result<self_update::Status> {
+    Update::configure()
+        .repo_owner("wildcard")
+        .repo_name("caro")
+        .bin_name("caro")
+        .show_download_progress(true)
+        .show_output(true)
+        .current_version(env!("CARGO_PKG_VERSION"))
+        .build()?
+        .update()
+}
+```
+
+---
+
+### P2-2: Add progress bar integration
+
+**Status**: `pending`
+
+**Description**: Create custom progress bar using indicatif for better UX.
+
+**Files**:
+- `src/update/progress.rs` (new)
+- `src/update/installer.rs` (integrate)
+
+**Acceptance Criteria**:
+- [ ] Progress bar shows percentage, bytes, speed
+- [ ] Matches Caro's visual style
+- [ ] Works in quiet mode (hidden)
+
+---
+
+### P2-3: Implement force reinstall
+
+**Status**: `pending`
+
+**Description**: Add `--force` flag to reinstall even if up-to-date.
+
+**Files**:
+- `src/cli/update.rs`
+
+**Acceptance Criteria**:
+- [ ] `--force` flag works
+- [ ] Confirmation prompt before force reinstall
+- [ ] `--yes` skips confirmation
+
+---
+
+### P2-4: Handle edge cases
+
+**Status**: `pending`
+
+**Description**: Handle platform-specific edge cases and errors.
+
+**Files**:
+- `src/update/installer.rs`
+- `src/cli/update.rs`
+
+**Acceptance Criteria**:
+- [ ] Windows binary replacement works
+- [ ] Permission errors show helpful message
+- [ ] Network errors show retry guidance
+- [ ] Partial downloads are cleaned up
+
+---
+
+### P2-5: Cross-platform testing
+
+**Status**: `pending`
+
+**Description**: Test full update cycle on all platforms.
+
+**Acceptance Criteria**:
+- [ ] macOS ARM64 tested
+- [ ] macOS x86_64 tested
+- [ ] Linux x86_64 tested
+- [ ] Windows x86_64 tested (best effort)
+
+---
+
+## Phase 3: Polish (v1.3.0)
+
+### P3-1: Add quiet mode
+
+**Status**: `pending`
+
+**Description**: Implement `--quiet` flag for script usage.
+
+**Files**:
+- `src/cli/update.rs`
+
+**Acceptance Criteria**:
+- [ ] `--quiet` outputs only essential info
+- [ ] No colors or progress bars in quiet mode
+- [ ] Exit codes still work for script logic
+
+---
+
+### P3-2: Optional startup check
+
+**Status**: `pending`
+
+**Description**: Add config option to check for updates on startup.
+
+**Files**:
+- `src/config/mod.rs`
+- `src/main.rs`
+
+**Acceptance Criteria**:
+- [ ] `check_updates_on_startup: bool` config option
+- [ ] Shows non-intrusive message if update available
+- [ ] Respects rate limiting (once per day max)
+- [ ] Doesn't block startup
+
+---
+
+### P3-3: Improve error messages
+
+**Status**: `pending`
+
+**Description**: Enhance error messages with actionable guidance.
+
+**Files**:
+- `src/update/installer.rs`
+- `src/cli/update.rs`
+
+**Acceptance Criteria**:
+- [ ] Network errors suggest checking connection
+- [ ] Permission errors suggest sudo or path check
+- [ ] Rate limit errors suggest waiting
+
+---
+
+### P3-4: Add update to help text
+
+**Status**: `pending`
+
+**Description**: Ensure update command is visible in main help.
+
+**Files**:
+- `src/cli/mod.rs`
+
+**Acceptance Criteria**:
+- [ ] `caro --help` shows update command
+- [ ] Help text explains what update does
+
+---
+
+## Phase 4: Security (v2.0.0)
+
+### P4-1: Generate signing keypair
+
+**Status**: `pending`
+
+**Description**: Generate Ed25519 keypair for release signing.
+
+**Acceptance Criteria**:
+- [ ] Private key securely stored in GitHub Secrets
+- [ ] Public key embedded in binary
+- [ ] Key rotation procedure documented
+
+---
+
+### P4-2: Sign releases
+
+**Status**: `pending`
+
+**Description**: Integrate signing into release workflow.
+
+**Files**:
+- `.github/workflows/release.yml`
+
+**Acceptance Criteria**:
+- [ ] Each release asset is signed with zipsign
+- [ ] Signatures published alongside assets
+
+---
+
+### P4-3: Verify signatures on update
+
+**Status**: `pending`
+
+**Description**: Verify Ed25519 signatures before installing updates.
+
+**Files**:
+- `src/update/installer.rs`
+- `Cargo.toml` (add signatures feature)
+
+**Acceptance Criteria**:
+- [ ] `signatures` feature enabled
+- [ ] Invalid signatures abort update
+- [ ] Clear error message on signature mismatch
+
+---
+
+### P4-4: Add checksum verification
+
+**Status**: `pending`
+
+**Description**: Verify SHA256 checksums from release notes.
+
+**Files**:
+- `src/update/installer.rs`
+
+**Acceptance Criteria**:
+- [ ] Parse checksums from release body
+- [ ] Verify downloaded file matches
+- [ ] Fail with clear error on mismatch
+
+---
+
+## Documentation Tasks
+
+### D-1: Update README
+
+**Status**: `pending`
+
+**Description**: Document the update command in README.
+
+**Files**:
+- `README.md`
+
+**Acceptance Criteria**:
+- [ ] `caro update` documented
+- [ ] Installation method differences explained
+
+---
+
+### D-2: Add UPDATING.md
+
+**Status**: `pending`
+
+**Description**: Create dedicated updating documentation.
+
+**Files**:
+- `docs/UPDATING.md` (new)
+
+**Acceptance Criteria**:
+- [ ] Explains all update methods
+- [ ] Covers troubleshooting
+- [ ] Documents rollback procedure
+
+---
+
+### D-3: Update man page
+
+**Status**: `pending`
+
+**Description**: Add update command to man page if applicable.
+
+---
+
+## CI/CD Tasks
+
+### C-1: Verify asset naming in release
+
+**Status**: `pending`
+
+**Description**: Ensure release workflow produces correctly named assets.
+
+**Files**:
+- `.github/workflows/release.yml`
+
+**Acceptance Criteria**:
+- [ ] Asset names match `caro-{version}-{target}.{ext}`
+- [ ] All platforms produce assets
+
+---
+
+### C-2: Add self-update feature to CI
+
+**Status**: `pending`
+
+**Description**: Test self-update feature in CI.
+
+**Files**:
+- `.github/workflows/ci.yml`
+
+**Acceptance Criteria**:
+- [ ] `cargo test --features self-update` runs in CI
+- [ ] Feature compiles on all platforms
+
+---
+
+## Summary
+
+| Phase | Tasks | Priority |
+|-------|-------|----------|
+| Phase 1 | P1-1 through P1-6 | High |
+| Phase 2 | P2-1 through P2-5 | High |
+| Phase 3 | P3-1 through P3-4 | Medium |
+| Phase 4 | P4-1 through P4-4 | Low |
+| Docs | D-1 through D-3 | Medium |
+| CI/CD | C-1 through C-2 | Medium |
+
+---
+
+*Task list created January 2026*


### PR DESCRIPTION
## Summary

Adds ADR-008 documenting the evaluation and recommendation for adding self-update functionality to Caro.

## Changes

- **ADR-008**: Comprehensive evaluation of self-update crates
- **Specs**: Implementation plan and tasks for self-update feature
- **README Update**: Added ADR-008 to the ADR index

## Key Decisions

After evaluating the Rust ecosystem, **`self_update`** is recommended for:
- GitHub releases integration
- Cross-platform support (macOS/Linux/Windows)
- Signature verification and checksums
- Active maintenance and maturity

## Testing

- Documentation-only changes
- No code modifications

---

Supersedes PR #623 (which was too stale to merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-008 and specs for a self-update feature, defining the design, security model, and rollout for a `caro update` command. Recommends the self_update crate for GitHub Releases with macOS/Linux/Windows support; documentation-only.

- **New Features**
  - Documents `caro update` and `--check/--force/--quiet` options with build-type awareness.
  - Phased rollout: check-only (v1.1.0), full update (v1.2.0), polish (v1.3.0), signatures (v2.0.0).

- **Dependencies**
  - Recommend self_update v0.42+ with rustls, archive-tar/zip, flate2; GitHub Releases backend.
  - Gate behind an optional self-update feature flag and include in the "full" feature set.

<sup>Written for commit 97f4e3b71e0807ad43ff749ad1c01af9013e623f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

