### PR TITLE
feat: Session Wrangler plugin for multi-session management

### DIFF
--- a/.claude/plugins/session-wrangler/.claude-plugin/plugin.json
+++ b/.claude/plugins/session-wrangler/.claude-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "session-wrangler",
+  "version": "1.0.0",
+  "description": "Meta-manager for multiple Claude sessions - discover, inspect, revive, and navigate",
+  "author": "Caro Project",
+  "commands": [
+    {
+      "name": "sessions",
+      "description": "List all Claude sessions (running, stuck, zombie, resumable)",
+      "path": "../commands/sessions.md"
+    },
+    {
+      "name": "sessions.inspect",
+      "description": "Deep dive into a specific session to understand its state",
+      "path": "../commands/inspect.md"
+    },
+    {
+      "name": "sessions.revive",
+      "description": "Revive a stuck session by spawning terminal and providing instructions",
+      "path": "../commands/revive.md"
+    },
+    {
+      "name": "sessions.cleanup",
+      "description": "Clean up zombie processes and corrupted session files",
+      "path": "../commands/cleanup.md"
+    },
+    {
+      "name": "sessions.switch",
+      "description": "Navigate to another session's terminal",
+      "path": "../commands/switch.md"
+    }
+  ],
+  "skills": [
+    {
+      "name": "session-discovery",
+      "description": "Core skill for discovering and analyzing Claude sessions",
+      "path": "../skills/session-discovery/SKILL.md"
+    }
+  ]
+}

--- a/.claude/plugins/session-wrangler/README.md
+++ b/.claude/plugins/session-wrangler/README.md
@@ -1,0 +1,328 @@
+# Session Wrangler Plugin
+
+A meta-management plugin for Claude Code that helps users wrangle multiple parallel Claude sessions across worktrees.
+
+## Overview
+
+Session Wrangler is the "meta-Claude" that sees all your Claude sessions, diagnoses issues, revives stuck sessions, and helps you navigate the complexity of running 4-5+ parallel sessions.
+
+## Problem It Solves
+
+When running multiple Claude Code sessions:
+- Sessions hang with no explanation
+- Processes consume memory but do nothing
+- Hard to remember which session was doing what
+- Jumping between sessions requires context switching
+- No unified view of all work in progress
+
+## Features
+
+### 🔍 Discovery
+- List all Claude sessions (running, stuck, zombie, resumable)
+- Cross-reference with worktrees, branches, and processes
+- Check session health (file size, corruption, heartbeats)
+- Query PostgreSQL database for stale entries
+
+### 🔬 Inspection
+- Deep dive into any session's state
+- Understand what it was doing (last prompt/response)
+- Diagnose why it's stuck or corrupted
+- Get specific recommendations for recovery
+
+### 🚀 Revival
+- Spawn Alacritty terminal in correct worktree
+- Provide clear resume instructions
+- Handle corrupted sessions gracefully
+- Protect uncommitted work
+
+### 🧹 Cleanup
+- Kill zombie processes safely
+- Archive corrupted session files
+- Close orphaned terminal windows
+- Clean stale database entries
+
+### 🔀 Navigation
+- Focus existing session terminals
+- Jump between active sessions
+- Smart window finding (by title, PID, cwd)
+- Cross-platform support (macOS, Linux)
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/sessions` | List all Claude sessions with status |
+| `/sessions.inspect <session>` | Deep dive into a specific session |
+| `/sessions.revive <session>` | Spawn terminal and revive session |
+| `/sessions.cleanup` | Clean up zombies and corrupted files |
+| `/sessions.switch <session>` | Navigate to another session's terminal |
+
+## Usage Examples
+
+### Check All Sessions
+
+```bash
+/sessions
+```
+
+Output:
+```
+Active Sessions (3)
+  ✅ s009  Resume Stuck Sessions  │ 045-milestone-coordinator  │ 2min ago
+  ⚠️ s003  i18n Implementation    │ i18n-complete-system      │ 45min stale
+  ❌ s012  QA Testing             │ 040-issue-520-tests       │ ZOMBIE (PID 47759)
+
+Resumable Sessions (2)
+  💤 eb6a2d8b  session-manager plugin  │ 2 messages │ Jan 24 05:49
+```
+
+### Inspect a Stuck Session
+
+```bash
+/sessions.inspect s003
+```
+
+Shows:
+- Last prompt and response
+- File size and health
+- Process status (PID, CPU, memory)
+- Worktree and uncommitted changes
+- Diagnosis and recommended action
+
+### Revive a Session
+
+```bash
+/sessions.revive s003
+```
+
+Actions:
+1. Spawns Alacritty terminal in correct worktree
+2. Displays resume command: `claude --resume <session-id>`
+3. Focuses the new terminal window
+
+### Clean Up Zombies
+
+```bash
+/sessions.cleanup
+```
+
+Finds and offers to:
+- Kill unresponsive processes
+- Archive corrupted session files (>50MB)
+- Close orphaned terminal windows
+- Delete stale database entries
+
+### Switch to Another Session
+
+```bash
+/sessions.switch work-feature
+```
+
+Focuses the terminal window for the specified session.
+
+## Architecture
+
+### Data Sources
+
+```
+[Session Wrangler Plugin]
+       │
+       ├── ps aux                           # Running processes
+       ├── ~/.claude/history.jsonl          # Last prompts
+       ├── ~/.claude/projects/*/            # Session transcripts
+       ├── PostgreSQL sessions table        # Heartbeats
+       └── git worktree list                # Worktree mappings
+```
+
+### Session States
+
+| State | Icon | Meaning |
+|-------|------|---------|
+| Active | ✅ | Running and responding |
+| Stale | ⚠️ | Running but idle 5-30min |
+| Zombie | ❌ | Stuck or corrupted |
+| Resumable | 💤 | Can be resumed with `--resume` |
+| Corrupted | 🔥 | File damaged, cannot resume |
+
+### Health Checks
+
+- **File size**: < 10MB = healthy, > 50MB = corrupted
+- **Content**: No null entries = healthy
+- **Process**: CPU > 0% = active, CPU = 0% = idle
+- **Heartbeat**: < 5min = active, > 30min = stale
+
+## Installation
+
+The plugin is located at:
+```
+.claude/plugins/session-wrangler/
+```
+
+Add to Claude Code's installed plugins:
+```json
+{
+  "plugins": [
+    "session-wrangler"
+  ]
+}
+```
+
+## Requirements
+
+- **Claude Code**: Latest version
+- **Alacritty**: For spawning terminals (or modify for your terminal)
+- **jq**: For JSON parsing (optional, fallback available)
+- **PostgreSQL**: Optional, for enhanced session tracking
+
+### Platform Support
+
+- ✅ **macOS**: Full support (osascript for window management)
+- ✅ **Linux (X11)**: Full support (wmctrl for window management)
+- ⚠️ **Linux (Wayland)**: Limited (compositor-dependent)
+- ❌ **Windows**: Not yet supported
+
+## Configuration
+
+### Terminal Emulator
+
+Default: Alacritty
+
+To use a different terminal, modify `/sessions.revive`:
+```bash
+# Replace:
+alacritty --title "$TITLE" --working-directory "$PATH" &
+
+# With your terminal:
+kitty --title "$TITLE" --directory "$PATH" &
+# or
+wezterm start --cwd "$PATH" &
+```
+
+### Archive Location
+
+Default: `~/.claude/archive/YYYYMMDD/`
+
+Change in `/sessions.cleanup`:
+```bash
+ARCHIVE_DIR=~/.claude/archive/$(date +%Y%m%d)
+```
+
+### Session File Path
+
+Default: `~/.claude/projects/-Users-kobik-private-workspace-caro/`
+
+Update in all commands if your project path differs.
+
+## Safety Features
+
+- **Never delete permanently**: Always archives files
+- **Confirm destructive actions**: Kill, cleanup require confirmation
+- **Protect uncommitted work**: Warns before archiving
+- **Graceful degradation**: Works without PostgreSQL, jq, etc.
+
+## Troubleshooting
+
+### "Session not found"
+
+Check available sessions:
+```bash
+/sessions
+```
+
+Verify session file exists:
+```bash
+ls ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl
+```
+
+### "Cannot focus terminal"
+
+Manual steps:
+1. Use Cmd+Tab (macOS) or Alt+Tab (Linux)
+2. Look for window title containing session slug
+3. Check Mission Control (macOS) for other desktops
+
+### "Failed to spawn terminal"
+
+Check if Alacritty is installed:
+```bash
+which alacritty
+```
+
+Install if needed:
+```bash
+brew install --cask alacritty  # macOS
+```
+
+### "Permission denied"
+
+Fix session file permissions:
+```bash
+chmod 644 ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl
+```
+
+## Development
+
+### File Structure
+
+```
+session-wrangler/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest
+├── commands/
+│   ├── sessions.md          # List command
+│   ├── inspect.md           # Inspect command
+│   ├── revive.md            # Revive command
+│   ├── cleanup.md           # Cleanup command
+│   └── switch.md            # Switch command
+├── skills/
+│   └── session-discovery/
+│       └── SKILL.md         # Discovery skill
+└── README.md                # This file
+```
+
+### Adding New Commands
+
+1. Create command markdown in `commands/`
+2. Add to `plugin.json` manifest
+3. Use session-discovery skill for consistency
+4. Follow safety principles (confirm, archive, protect)
+
+### Testing
+
+1. Create multiple Claude sessions in different worktrees
+2. Test `/sessions` shows all correctly
+3. Test `/sessions.inspect` with each session
+4. Test `/sessions.revive` with stopped session
+5. Test `/sessions.cleanup` with corrupted file
+6. Test `/sessions.switch` with active session
+
+## Contributing
+
+See main project contributing guidelines. This plugin follows:
+- Clear user communication
+- Safety-first design
+- Platform compatibility
+- Graceful error handling
+
+## Version History
+
+### v1.0.0 (2026-01-24)
+- Initial implementation
+- 5 core commands
+- Session discovery skill
+- macOS and Linux X11 support
+
+## License
+
+AGPL-3.0 (same as parent project)
+
+## Authors
+
+- Caro Project Team
+- Session Wrangler designed for managing parallel Claude workflows
+
+## Related
+
+- [Claude Code CLI](https://claude.ai/claude-code)
+- [Milestone Coordinator Plugin](..milestone-coordinator/) (companion plugin)
+- [Caro Project](https://github.com/caro-project/caro)

--- a/.claude/plugins/session-wrangler/commands/cleanup.md
+++ b/.claude/plugins/session-wrangler/commands/cleanup.md
@@ -1,0 +1,542 @@
+# /sessions.cleanup - Clean Up Zombies
+
+Safely identify and remove zombie Claude processes, corrupted session files, and orphaned resources.
+
+## Purpose
+
+Help users clean up:
+- Zombie processes (running but unresponsive)
+- Corrupted session files (>50MB or null content)
+- Orphaned Alacritty windows
+- Stale database entries
+
+**Safety First:** Always confirm before deleting anything. Archive rather than delete when possible.
+
+## Usage
+
+```bash
+/sessions.cleanup [--dry-run] [--force-all] [--type=<process|file|terminal|db>]
+```
+
+Options:
+- `--dry-run`: Show what would be cleaned up without doing it
+- `--force-all`: Skip confirmations (dangerous!)
+- `--type=X`: Clean only specific resource type
+
+## Discovery Phase
+
+### 1. Find Zombie Processes
+
+```bash
+# Get all Claude processes
+ps aux | grep "[c]laude" | while read -r line; do
+  PID=$(echo "$line" | awk '{print $2}')
+  CPU=$(echo "$line" | awk '{print $3}')
+  START=$(echo "$line" | awk '{print $9}')
+
+  # Check if process is a zombie candidate
+  # Criteria: CPU = 0% AND running for > 30 min
+
+  # Get process start time in epoch
+  START_EPOCH=$(ps -p $PID -o lstart= | xargs -I {} date -j -f "%a %b %d %T %Y" "{}" "+%s" 2>/dev/null)
+  NOW=$(date +%s)
+  RUNTIME=$((NOW - START_EPOCH))
+
+  if [[ "$CPU" == "0.0" ]] && [ "$RUNTIME" -gt 1800 ]; then
+    # Extract session ID from command line
+    SESSION_ID=$(ps -p $PID -o command= | grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}')
+
+    # Check if session file is corrupted or if there's no heartbeat
+    if [ -n "$SESSION_ID" ]; then
+      SESSION_FILE=~/.claude/projects/-Users-kobik-private-workspace-caro/${SESSION_ID}.jsonl
+
+      if [ -f "$SESSION_FILE" ]; then
+        FILE_SIZE=$(stat -f%z "$SESSION_FILE" 2>/dev/null || stat -c%s "$SESSION_FILE")
+        NULL_COUNT=$(grep -c '"content":null' "$SESSION_FILE" 2>/dev/null || echo 0)
+
+        if [ "$FILE_SIZE" -gt 52428800 ] || [ "$NULL_COUNT" -gt 10 ]; then
+          echo "$PID|$SESSION_ID|CORRUPTED_FILE"
+        else
+          echo "$PID|$SESSION_ID|ZOMBIE_IDLE"
+        fi
+      else
+        echo "$PID|UNKNOWN|NO_SESSION_FILE"
+      fi
+    else
+      echo "$PID|UNKNOWN|NO_SESSION_ID"
+    fi
+  fi
+done
+```
+
+### 2. Find Corrupted Session Files
+
+```bash
+# Scan all session files
+for file in ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl; do
+  FILE_SIZE=$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file")
+  SESSION_ID=$(basename "$file" .jsonl)
+
+  # Check if process is running for this session
+  PID=$(ps aux | grep "[c]laude.*$SESSION_ID" | awk '{print $2}')
+
+  # Size check
+  if [ "$FILE_SIZE" -gt 52428800 ]; then
+    echo "$file|SIZE|$FILE_SIZE|$PID"
+    continue
+  fi
+
+  # Null content check
+  NULL_COUNT=$(grep -c '"content":null' "$file" 2>/dev/null || echo 0)
+  if [ "$NULL_COUNT" -gt 10 ]; then
+    echo "$file|NULL_CONTENT|$NULL_COUNT|$PID"
+    continue
+  fi
+
+  # JSON validity check
+  if ! head -1 "$file" | jq empty 2>/dev/null; then
+    echo "$file|INVALID_JSON|0|$PID"
+    continue
+  fi
+done
+```
+
+### 3. Find Orphaned Alacritty Windows
+
+```bash
+# On macOS, query Alacritty windows
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  osascript <<'EOF' 2>/dev/null | while read -r window_title; do
+    # Check if this is a Claude session window
+    if [[ "$window_title" == *"Claude:"* ]]; then
+      # Extract slug from title
+      SLUG=$(echo "$window_title" | sed 's/.*Claude: \(.*\)/\1/')
+
+      # Check if session file exists
+      SESSION_FILE=$(find ~/.claude/projects/-Users-kobik-private-workspace-caro/ -name "*.jsonl" -exec sh -c '
+        FOUND_SLUG=$(head -20 "{}" | jq -r "select(.slug) | .slug" 2>/dev/null | head -1)
+        if [ "$FOUND_SLUG" == "'$SLUG'" ]; then
+          echo "{}"
+        fi
+      ' \; | head -1)
+
+      if [ -z "$SESSION_FILE" ]; then
+        echo "$window_title|ORPHANED|NO_SESSION"
+      else
+        SESSION_ID=$(basename "$SESSION_FILE" .jsonl)
+        PID=$(ps aux | grep "[c]laude.*$SESSION_ID" | awk '{print $2}')
+        if [ -z "$PID" ]; then
+          echo "$window_title|ORPHANED|SESSION_DEAD"
+        fi
+      fi
+    fi
+  done
+tell application "Alacritty"
+  set windowTitles to name of every window
+  repeat with aTitle in windowTitles
+    return aTitle
+  end repeat
+end tell
+EOF
+fi
+```
+
+### 4. Find Stale Database Entries
+
+```bash
+# Check if PostgreSQL is available
+if docker ps | grep -q continuous-claude-postgres; then
+  # Find sessions with very stale heartbeats and no corresponding file
+  docker exec continuous-claude-postgres psql -U claude -d continuous_claude -t -c "
+    SELECT id, working_on,
+           EXTRACT(EPOCH FROM (NOW() - last_heartbeat)) as staleness
+    FROM sessions
+    WHERE last_heartbeat < NOW() - INTERVAL '24 hours'
+    ORDER BY staleness DESC;
+  " 2>/dev/null | while IFS='|' read -r session_id working_on staleness; do
+    session_id=$(echo "$session_id" | xargs)
+    staleness=$(echo "$staleness" | xargs | cut -d. -f1)
+
+    # Check if session file exists
+    SESSION_FILE=~/.claude/projects/-Users-kobik-private-workspace-caro/${session_id}.jsonl
+    if [ ! -f "$SESSION_FILE" ]; then
+      echo "$session_id|DB_ORPHAN|${staleness}s"
+    fi
+  done
+fi
+```
+
+## Analysis Phase
+
+Collect all findings and categorize:
+
+```
+═══════════════════════════════════════════════════════════════════
+Cleanup Analysis
+═══════════════════════════════════════════════════════════════════
+
+Zombie Processes (<count>)
+───────────────────────────────────────────────────────────────────
+  PID <pid>
+    Session: <slug> (<short-id>)
+    Running: <runtime>
+    CPU: 0.0%
+    Reason: <reason>
+    Action: Kill process
+
+Corrupted Session Files (<count>)
+───────────────────────────────────────────────────────────────────
+  <filename>
+    Size: <size>MB (limit: 50MB)
+    Null Content: <count> entries
+    Process: <PID or "Not running">
+    Worktree: <path>
+    Action: Archive to ~/.claude/archive/
+
+Orphaned Windows (<count>)
+───────────────────────────────────────────────────────────────────
+  Alacritty: "<window-title>"
+    Session: <slug or "UNKNOWN">
+    Reason: <reason>
+    Action: Close window
+
+Stale Database Entries (<count>)
+───────────────────────────────────────────────────────────────────
+  Session: <short-id>
+    Last Heartbeat: <time-ago>
+    File Exists: No
+    Action: Delete from database
+
+═══════════════════════════════════════════════════════════════════
+Total Issues: <count>
+  Zombie Processes: <n>
+  Corrupted Files: <n>
+  Orphaned Windows: <n>
+  Stale DB Entries: <n>
+
+Estimated Disk Space to Recover: <total-mb>MB
+═══════════════════════════════════════════════════════════════════
+```
+
+## Confirmation Phase
+
+If not `--dry-run` or `--force-all`, ask for confirmation:
+
+```bash
+# Show summary
+echo "This will:"
+echo "  • Kill $ZOMBIE_COUNT zombie processes"
+echo "  • Archive $CORRUPTED_COUNT corrupted session files"
+echo "  • Close $ORPHANED_COUNT orphaned terminal windows"
+echo "  • Delete $STALE_DB_COUNT database entries"
+echo ""
+echo "Archived files will be moved to: ~/.claude/archive/"
+echo "No data will be permanently deleted without your confirmation."
+echo ""
+read -p "Proceed with cleanup? (y/n): " CONFIRM
+
+if [ "$CONFIRM" != "y" ]; then
+  echo "Cleanup cancelled."
+  exit 0
+fi
+```
+
+For each category, offer granular control:
+
+```bash
+# Process-by-process confirmation
+echo ""
+echo "Zombie Processes:"
+while read -r zombie_info; do
+  PID=$(echo "$zombie_info" | cut -d'|' -f1)
+  SESSION_ID=$(echo "$zombie_info" | cut -d'|' -f2)
+  REASON=$(echo "$zombie_info" | cut -d'|' -f3)
+
+  echo ""
+  echo "  PID $PID - Session: $SESSION_ID"
+  echo "  Reason: $REASON"
+  read -p "  Kill this process? (y/n/skip-all): " CONFIRM
+
+  if [ "$CONFIRM" == "skip-all" ]; then
+    break
+  elif [ "$CONFIRM" == "y" ]; then
+    # Record for execution
+    echo "$PID" >> /tmp/claude-cleanup-pids.txt
+  fi
+done
+```
+
+## Execution Phase
+
+### 1. Kill Zombie Processes
+
+```bash
+# Read PIDs to kill
+while read -r PID; do
+  echo "Killing process $PID..."
+
+  # Try graceful termination first
+  kill -TERM "$PID" 2>/dev/null
+
+  # Wait up to 10 seconds
+  for i in {1..10}; do
+    if ! ps -p "$PID" > /dev/null 2>&1; then
+      echo "  ✅ Process terminated gracefully"
+      break
+    fi
+    sleep 1
+  done
+
+  # Force kill if still running
+  if ps -p "$PID" > /dev/null 2>&1; then
+    echo "  ⚠️  Forcing kill..."
+    kill -9 "$PID" 2>/dev/null
+    sleep 1
+
+    if ps -p "$PID" > /dev/null 2>&1; then
+      echo "  ❌ Failed to kill process $PID"
+    else
+      echo "  ✅ Process force-killed"
+    fi
+  fi
+done < /tmp/claude-cleanup-pids.txt
+```
+
+### 2. Archive Corrupted Files
+
+```bash
+# Create archive directory
+ARCHIVE_DIR=~/.claude/archive/$(date +%Y%m%d)
+mkdir -p "$ARCHIVE_DIR"
+
+# Move files
+while read -r file_info; do
+  FILE_PATH=$(echo "$file_info" | cut -d'|' -f1)
+  REASON=$(echo "$file_info" | cut -d'|' -f2)
+
+  FILENAME=$(basename "$FILE_PATH")
+  ARCHIVE_PATH="$ARCHIVE_DIR/$FILENAME"
+
+  echo "Archiving $FILENAME..."
+  echo "  Reason: $REASON"
+
+  # Move file
+  mv "$FILE_PATH" "$ARCHIVE_PATH"
+
+  if [ $? -eq 0 ]; then
+    echo "  ✅ Archived to: $ARCHIVE_PATH"
+  else
+    echo "  ❌ Failed to archive"
+  fi
+done < /tmp/claude-cleanup-files.txt
+
+echo ""
+echo "Archived files location: $ARCHIVE_DIR"
+```
+
+### 3. Close Orphaned Windows
+
+```bash
+# macOS only
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  while read -r window_title; do
+    echo "Closing Alacritty window: $window_title..."
+
+    osascript <<EOF 2>/dev/null
+      tell application "Alacritty"
+        set windowList to every window whose name contains "$window_title"
+        repeat with aWindow in windowList
+          close aWindow
+        end repeat
+      end tell
+EOF
+
+    if [ $? -eq 0 ]; then
+      echo "  ✅ Window closed"
+    else
+      echo "  ⚠️  Failed to close window (may need manual closure)"
+    fi
+  done < /tmp/claude-cleanup-windows.txt
+fi
+```
+
+### 4. Clean Database Entries
+
+```bash
+# PostgreSQL cleanup
+if docker ps | grep -q continuous-claude-postgres; then
+  while read -r session_id; do
+    echo "Deleting database entry for: $session_id..."
+
+    docker exec continuous-claude-postgres psql -U claude -d continuous_claude -c \
+      "DELETE FROM sessions WHERE id = '$session_id';" 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+      echo "  ✅ Database entry deleted"
+    else
+      echo "  ❌ Failed to delete database entry"
+    fi
+  done < /tmp/claude-cleanup-db.txt
+fi
+```
+
+## Summary Report
+
+```
+═══════════════════════════════════════════════════════════════════
+Cleanup Complete
+═══════════════════════════════════════════════════════════════════
+
+Results:
+  ✅ Killed <n> zombie processes
+  ✅ Archived <n> corrupted session files
+  ✅ Closed <n> orphaned windows
+  ✅ Deleted <n> stale database entries
+
+Archived Files:
+  Location: <archive-dir>
+  Total Size: <size>MB
+
+Failed Operations:
+  <list any failures>
+
+Disk Space Recovered: <total-mb>MB
+
+═══════════════════════════════════════════════════════════════════
+
+💡 Next Steps:
+  • Run /sessions to see current healthy sessions
+  • Review archived files in: <archive-dir>
+  • If needed, manually inspect failed operations
+
+Archived files are kept for 30 days by default.
+To permanently delete: rm -rf <archive-dir>
+```
+
+## Safety Features
+
+### Pre-Cleanup Validation
+
+```bash
+# Never clean up if user explicitly says no
+# Always show what will be affected before acting
+# Provide rollback information
+
+# Check for uncommitted work in worktrees
+for file_info in $CORRUPTED_FILES; do
+  SESSION_FILE=$(echo "$file_info" | cut -d'|' -f1)
+  SESSION_ID=$(basename "$SESSION_FILE" .jsonl)
+
+  # Find worktree
+  CWD=$(head -20 "$SESSION_FILE" | jq -r 'select(.cwd) | .cwd' | head -1)
+
+  if [ -n "$CWD" ] && [ -d "$CWD" ]; then
+    cd "$CWD"
+    if [ -n "$(git status --porcelain)" ]; then
+      echo "⚠️  WARNING: Uncommitted changes in worktree: $CWD"
+      echo "   Files:"
+      git status --short | head -5
+      echo ""
+      echo "   Consider committing before cleanup!"
+      echo ""
+      read -p "   Skip this session? (y/n): " SKIP
+      if [ "$SKIP" == "y" ]; then
+        # Remove from cleanup list
+        continue
+      fi
+    fi
+  fi
+done
+```
+
+### Archive Instead of Delete
+
+- NEVER permanently delete session files
+- Always move to `~/.claude/archive/YYYYMMDD/`
+- Keep archive structure organized by date
+- Provide easy recovery path
+
+### Confirmation Levels
+
+| Operation | Confirmation Level |
+|-----------|-------------------|
+| Kill idle process (no corruption) | Per-process or batch |
+| Kill zombie (corrupted session) | Per-process |
+| Archive corrupted file (no uncommitted work) | Batch OK |
+| Archive corrupted file (uncommitted work) | Per-file required |
+| Close orphaned window | Batch OK |
+| Delete DB entry (file also deleted) | Batch OK |
+
+## Error Handling
+
+| Error | Recovery |
+|-------|----------|
+| Process won't die | Report PID, suggest manual `kill -9` |
+| File move fails | Check permissions, disk space |
+| Window close fails | Provide manual close instructions |
+| DB delete fails | Log error, continue with others |
+| Permission denied | Suggest `sudo` or permission fix |
+
+## Special Cases
+
+### All Sessions Healthy
+
+```
+✅ All Sessions Healthy
+
+No cleanup needed! Your Claude sessions are in good shape:
+  • <n> active sessions running normally
+  • <n> resumable sessions available
+  • No zombie processes found
+  • No corrupted files detected
+
+Run /sessions to see all sessions.
+```
+
+### Dry Run Mode
+
+```
+═══════════════════════════════════════════════════════════════════
+Dry Run - No Changes Made
+═══════════════════════════════════════════════════════════════════
+
+<show full analysis>
+
+This was a dry run. No processes were killed or files moved.
+
+To actually perform cleanup, run:
+  /sessions.cleanup
+
+To clean only specific types:
+  /sessions.cleanup --type=process   (kill zombies only)
+  /sessions.cleanup --type=file      (archive corrupted files only)
+  /sessions.cleanup --type=terminal  (close orphaned windows only)
+  /sessions.cleanup --type=db        (clean database only)
+```
+
+### Cleanup After Revive
+
+If user ran `/sessions.revive` and then `/sessions.cleanup`, detect and handle:
+
+```
+ℹ️  Detected Recent Revival
+
+Session <slug> was just revived. Excluding from cleanup to avoid
+interrupting the newly started process.
+
+Waiting 60 seconds before considering it for cleanup.
+```
+
+## Performance Notes
+
+- Process zombie detection: O(n) where n = running processes
+- File corruption scan: O(m) where m = session files
+- Limit scan depth to improve speed on large session histories
+- Cache results during confirmation phase to avoid re-scanning
+
+## Integration
+
+After cleanup completes:
+- Update `/sessions` cache if any exists
+- Clear any stale database connections
+- Suggest running `/sessions` to verify cleanup

--- a/.claude/plugins/session-wrangler/commands/inspect.md
+++ b/.claude/plugins/session-wrangler/commands/inspect.md
@@ -1,0 +1,427 @@
+# /sessions.inspect - Deep Dive into a Session
+
+Perform comprehensive analysis of a specific Claude session to understand its state, health, and context.
+
+## Purpose
+
+Help users understand:
+- What the session was working on
+- Why it might be stuck or corrupted
+- Whether it can be recovered
+- What the recommended action is
+
+## Usage
+
+```bash
+/sessions.inspect <session-identifier>
+```
+
+Where `<session-identifier>` can be:
+- Full session ID: `2893aa9b-69d3-4167-9ad1-4c5a06697d93`
+- Short ID (first 8 chars): `2893aa9b`
+- Session slug: `warm-floating-pancake`
+- Worktree name: `045-milestone-coordinator-plugin`
+- Branch name: `feature/i18n-complete-system`
+
+## Execution Steps
+
+### 1. Resolve Session Identifier
+
+```bash
+# If full UUID provided
+if [[ "$IDENTIFIER" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+  SESSION_ID="$IDENTIFIER"
+  SESSION_FILE=~/.claude/projects/-Users-kobik-private-workspace-caro/${SESSION_ID}.jsonl
+fi
+
+# If short ID provided
+if [[ "$IDENTIFIER" =~ ^[a-f0-9]{8}$ ]]; then
+  SESSION_FILE=$(ls ~/.claude/projects/-Users-kobik-private-workspace-caro/${IDENTIFIER}*.jsonl 2>/dev/null | head -1)
+  SESSION_ID=$(basename "$SESSION_FILE" .jsonl)
+fi
+
+# If slug provided
+if [[ ! "$IDENTIFIER" =~ ^[a-f0-9] ]]; then
+  # Search for slug in session files
+  for file in ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl; do
+    SLUG=$(head -20 "$file" | jq -r 'select(.slug) | .slug' | head -1)
+    if [[ "$SLUG" == "$IDENTIFIER" ]]; then
+      SESSION_FILE="$file"
+      SESSION_ID=$(basename "$file" .jsonl)
+      break
+    fi
+  done
+fi
+
+# If worktree/branch provided
+if [[ -z "$SESSION_FILE" ]]; then
+  # Search by cwd or gitBranch
+  for file in ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl; do
+    CWD=$(head -20 "$file" | jq -r 'select(.cwd) | .cwd' | head -1)
+    BRANCH=$(head -20 "$file" | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+    if [[ "$CWD" == *"$IDENTIFIER"* ]] || [[ "$BRANCH" == *"$IDENTIFIER"* ]]; then
+      SESSION_FILE="$file"
+      SESSION_ID=$(basename "$file" .jsonl)
+      break
+    fi
+  done
+fi
+```
+
+### 2. Extract Session Metadata
+
+```bash
+# Basic info
+SLUG=$(head -20 "$SESSION_FILE" | jq -r 'select(.slug) | .slug' | head -1)
+BRANCH=$(head -20 "$SESSION_FILE" | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+CWD=$(head -20 "$SESSION_FILE" | jq -r 'select(.cwd) | .cwd' | head -1)
+
+# Creation time
+CREATED=$(stat -f%B "$SESSION_FILE" 2>/dev/null || stat -c%W "$SESSION_FILE")
+CREATED_DATE=$(date -r "$CREATED" "+%Y-%m-%d %H:%M" 2>/dev/null || date -d "@$CREATED" "+%Y-%m-%d %H:%M")
+
+# Last modified
+LAST_MOD=$(stat -f%m "$SESSION_FILE" 2>/dev/null || stat -c%Y "$SESSION_FILE")
+LAST_MOD_DATE=$(date -r "$LAST_MOD" "+%Y-%m-%d %H:%M" 2>/dev/null || date -d "@$LAST_MOD" "+%Y-%m-%d %H:%M")
+
+# File size
+FILE_SIZE=$(stat -f%z "$SESSION_FILE" 2>/dev/null || stat -c%s "$SESSION_FILE")
+FILE_SIZE_MB=$(echo "scale=2; $FILE_SIZE / 1048576" | bc)
+
+# Message count
+USER_MSG_COUNT=$(grep -c '"role":"user"' "$SESSION_FILE")
+ASST_MSG_COUNT=$(grep -c '"role":"assistant"' "$SESSION_FILE")
+TOTAL_MSG_COUNT=$((USER_MSG_COUNT + ASST_MSG_COUNT))
+```
+
+### 3. Get Last Prompt and Response
+
+```bash
+# Last user prompt (with proper escaping and truncation)
+LAST_PROMPT=$(grep '"role":"user"' "$SESSION_FILE" | tail -1 | jq -r '.content[0].text' 2>/dev/null | head -c 300)
+if [ -z "$LAST_PROMPT" ]; then
+  LAST_PROMPT="[Unable to extract - possible corruption]"
+fi
+
+# Last assistant response
+LAST_RESPONSE=$(grep '"role":"assistant"' "$SESSION_FILE" | tail -1 | jq -r '.content[0].text' 2>/dev/null | head -c 300)
+if [ -z "$LAST_RESPONSE" ]; then
+  LAST_RESPONSE="[No response recorded]"
+fi
+```
+
+### 4. Check Process State
+
+```bash
+# Find process by session ID
+PID=$(ps aux | grep "[c]laude.*--resume $SESSION_ID" | awk '{print $2}' | head -1)
+
+if [ -n "$PID" ]; then
+  # Get process details
+  CPU=$(ps aux | grep "^[^ ]* *$PID " | awk '{print $3}')
+  MEM=$(ps aux | grep "^[^ ]* *$PID " | awk '{print $4}')
+  START=$(ps aux | grep "^[^ ]* *$PID " | awk '{print $9}')
+
+  # Check if process is responsive
+  if [ "$CPU" == "0.0" ]; then
+    PROCESS_STATUS="🟡 Running but idle (CPU 0%)"
+  else
+    PROCESS_STATUS="🟢 Running and active"
+  fi
+else
+  PROCESS_STATUS="🔴 Not running"
+fi
+```
+
+### 5. Check File Health
+
+```bash
+# File size check
+if [ "$FILE_SIZE" -gt 52428800 ]; then  # 50MB
+  SIZE_STATUS="❌ File too large (${FILE_SIZE_MB}MB) - likely corrupted"
+elif [ "$FILE_SIZE" -gt 10485760 ]; then  # 10MB
+  SIZE_STATUS="⚠️  Large file (${FILE_SIZE_MB}MB) - may be slow to resume"
+else
+  SIZE_STATUS="✅ Healthy size (${FILE_SIZE_MB}MB)"
+fi
+
+# Content null check
+NULL_COUNT=$(grep -c '"content":null' "$SESSION_FILE" 2>/dev/null || echo 0)
+if [ "$NULL_COUNT" -gt 10 ]; then
+  CONTENT_STATUS="❌ High null content count ($NULL_COUNT) - corrupted"
+else
+  CONTENT_STATUS="✅ Content appears valid"
+fi
+
+# JSON structure check
+if head -1 "$SESSION_FILE" | jq empty 2>/dev/null; then
+  JSON_STATUS="✅ Valid JSON structure"
+else
+  JSON_STATUS="❌ Invalid JSON - file corrupted"
+fi
+```
+
+### 6. Check Worktree State
+
+```bash
+# Find matching worktree
+WORKTREE_PATH=$(git -C /Users/kobik-private/workspace/caro worktree list | grep "$CWD" | awk '{print $1}')
+
+if [ -n "$WORKTREE_PATH" ] && [ -d "$WORKTREE_PATH" ]; then
+  WORKTREE_STATUS="✅ Exists: $WORKTREE_PATH"
+
+  # Check for uncommitted work
+  cd "$WORKTREE_PATH"
+  if [ -n "$(git status --porcelain)" ]; then
+    UNCOMMITTED=$(git status --porcelain | wc -l | tr -d ' ')
+    WORKTREE_STATUS="$WORKTREE_STATUS\n     ⚠️  $UNCOMMITTED uncommitted changes"
+  fi
+else
+  WORKTREE_STATUS="❌ Worktree deleted or moved"
+fi
+```
+
+### 7. Query PostgreSQL (Optional)
+
+```bash
+if docker ps | grep -q continuous-claude-postgres; then
+  DB_DATA=$(docker exec continuous-claude-postgres psql -U claude -d continuous_claude -t -c \
+    "SELECT working_on, last_heartbeat,
+     EXTRACT(EPOCH FROM (NOW() - last_heartbeat)) as staleness
+     FROM sessions WHERE id = '$SESSION_ID';" 2>/dev/null)
+
+  if [ -n "$DB_DATA" ]; then
+    WORKING_ON=$(echo "$DB_DATA" | awk -F'|' '{print $1}' | xargs)
+    HEARTBEAT=$(echo "$DB_DATA" | awk -F'|' '{print $2}' | xargs)
+    STALENESS=$(echo "$DB_DATA" | awk -F'|' '{print $3}' | xargs | cut -d. -f1)
+
+    if [ "$STALENESS" -lt 300 ]; then
+      HEARTBEAT_STATUS="✅ Recent heartbeat (${STALENESS}s ago)"
+    elif [ "$STALENESS" -lt 1800 ]; then
+      HEARTBEAT_STATUS="⚠️  Stale heartbeat (${STALENESS}s ago)"
+    else
+      HEARTBEAT_STATUS="❌ Very stale heartbeat (${STALENESS}s ago)"
+    fi
+  fi
+fi
+```
+
+### 8. Determine Overall State
+
+```bash
+# Calculate overall health
+if [[ "$SIZE_STATUS" == *"❌"* ]] || [[ "$CONTENT_STATUS" == *"❌"* ]] || [[ "$JSON_STATUS" == *"❌"* ]]; then
+  OVERALL_STATE="🔥 CORRUPTED"
+  CAN_RESUME="No"
+elif [[ "$PROCESS_STATUS" == *"🔴"* ]] && [[ "$SIZE_STATUS" == *"✅"* ]]; then
+  OVERALL_STATE="💤 RESUMABLE"
+  CAN_RESUME="Yes"
+elif [[ "$PROCESS_STATUS" == *"🟢"* ]]; then
+  OVERALL_STATE="✅ ACTIVE"
+  CAN_RESUME="Already running"
+elif [[ "$PROCESS_STATUS" == *"🟡"* ]]; then
+  OVERALL_STATE="⚠️  STALE"
+  CAN_RESUME="Running but idle"
+else
+  OVERALL_STATE="❓ UNKNOWN"
+  CAN_RESUME="Uncertain"
+fi
+```
+
+### 9. Generate Diagnosis
+
+```bash
+# Create human-readable diagnosis based on health checks
+DIAGNOSIS=""
+
+if [[ "$FILE_SIZE" -gt 52428800 ]]; then
+  DIAGNOSIS+="• Session file exceeds 50MB - indicates runaway context growth or corruption\n"
+fi
+
+if [ "$NULL_COUNT" -gt 10 ]; then
+  DIAGNOSIS+="• High number of null content entries - data loss occurred\n"
+fi
+
+if [[ "$PROCESS_STATUS" == *"idle"* ]]; then
+  DIAGNOSIS+="• Process running but using 0% CPU - may be hung or waiting for input\n"
+fi
+
+if [[ "$WORKTREE_STATUS" == *"deleted"* ]]; then
+  DIAGNOSIS+="• Associated worktree no longer exists - branch may have been merged/deleted\n"
+fi
+
+if [[ "$WORKTREE_STATUS" == *"uncommitted"* ]]; then
+  DIAGNOSIS+="• Uncommitted work exists in worktree - important not to lose this\n"
+fi
+
+if [ -n "$STALENESS" ] && [ "$STALENESS" -gt 1800 ]; then
+  DIAGNOSIS+="• No heartbeat for over 30 minutes - session likely abandoned or stuck\n"
+fi
+
+if [ -z "$DIAGNOSIS" ]; then
+  DIAGNOSIS="• No obvious issues detected"
+fi
+```
+
+### 10. Recommend Action
+
+```bash
+# Generate specific recommendation
+RECOMMENDATION=""
+
+if [[ "$OVERALL_STATE" == "🔥 CORRUPTED" ]]; then
+  RECOMMENDATION="Session cannot be resumed due to corruption. Options:
+  1. Start fresh session in the same worktree
+  2. Archive this session file for reference
+  3. If uncommitted work exists, commit it first
+
+  Command: cd $WORKTREE_PATH && claude"
+
+elif [[ "$OVERALL_STATE" == "💤 RESUMABLE" ]]; then
+  RECOMMENDATION="Session can be resumed. Use:
+
+  /sessions.revive $SLUG
+
+  This will spawn a terminal in the correct worktree and provide resume instructions."
+
+elif [[ "$OVERALL_STATE" == "⚠️  STALE" ]]; then
+  RECOMMENDATION="Session is running but idle. Options:
+  1. Check terminal - may be waiting for user input
+  2. If terminal not found, kill process and resume cleanly
+
+  To kill: kill -TERM $PID
+  Then: /sessions.revive $SLUG"
+
+elif [[ "$OVERALL_STATE" == "✅ ACTIVE" ]]; then
+  RECOMMENDATION="Session is healthy and running. Use /sessions.switch to navigate to its terminal."
+
+else
+  RECOMMENDATION="State unclear. Manual investigation needed. Check session file and process manually."
+fi
+```
+
+### 11. Format Output
+
+```
+═══════════════════════════════════════════════════════════════════════
+Session Inspection Report
+═══════════════════════════════════════════════════════════════════════
+
+Session ID: <full-session-id>
+State: <OVERALL_STATE>
+Slug: <slug>
+Can Resume: <can-resume>
+
+Last Activity
+─────────────────────────────────────────────────────────────────────
+Created: <created-date>
+Last Modified: <last-mod-date>
+Time Since Activity: <time-ago>
+
+Last User Prompt:
+"<last-prompt-truncated>..."
+
+Last Assistant Response:
+"<last-response-truncated>..."
+
+Working Context
+─────────────────────────────────────────────────────────────────────
+Directory: <cwd>
+Git Branch: <branch>
+Worktree: <worktree-status>
+<if uncommitted work, list files>
+
+File Statistics
+─────────────────────────────────────────────────────────────────────
+Size: <size-mb>MB (<size-bytes> bytes)
+Messages: <total-count> (<user-count> user, <asst-count> assistant)
+File Health: <size-status>
+Content Health: <content-status>
+JSON Structure: <json-status>
+
+Process Status
+─────────────────────────────────────────────────────────────────────
+<process-status>
+<if running:>
+  PID: <pid>
+  CPU: <cpu>%
+  Memory: <mem>%
+  Started: <start-time>
+
+<if PostgreSQL available:>
+Database Info
+─────────────────────────────────────────────────────────────────────
+Working On: <working-on>
+Last Heartbeat: <heartbeat>
+Heartbeat Status: <heartbeat-status>
+
+Health Checks
+─────────────────────────────────────────────────────────────────────
+<size-status>
+<content-status>
+<json-status>
+<worktree-status>
+<if process running: process-status>
+<if db available: heartbeat-status>
+
+Diagnosis
+─────────────────────────────────────────────────────────────────────
+<diagnosis-points>
+
+Recommended Action
+─────────────────────────────────────────────────────────────────────
+<recommendation-text>
+
+═══════════════════════════════════════════════════════════════════════
+
+💡 Next Steps:
+  /sessions.revive <slug>   - Revive this session
+  /sessions.cleanup         - Clean up if zombie
+  /sessions                 - Back to session list
+```
+
+## Special Cases
+
+### Session Not Found
+```
+❌ Session not found: "<identifier>"
+
+Searched for:
+  • Full session ID
+  • Short ID (first 8 characters)
+  • Session slug
+  • Worktree name
+  • Branch name
+
+Available sessions:
+<list sessions from /sessions command>
+
+Use: /sessions to see all available sessions
+```
+
+### Multiple Matches
+```
+⚠️  Multiple sessions match "<identifier>":
+
+1. <slug1> (<short-id1>) - <worktree1>
+2. <slug2> (<short-id2>) - <worktree2>
+
+Please specify which session using:
+  • Full session ID
+  • Unique slug
+  • /sessions.inspect <number> (e.g., /sessions.inspect 1)
+```
+
+## Performance Notes
+
+- Read only first 20 and last 5 lines of session file for metadata
+- Skip deep content analysis if file > 50MB
+- Cache worktree list across multiple inspections
+- Timeout PostgreSQL query after 2s
+
+## Error Handling
+
+- **File unreadable**: Report permission issue and suggest `chmod 644`
+- **jq missing**: Fall back to grep/awk parsing with note
+- **Git not available**: Skip worktree checks
+- **Process info unavailable**: Use file-based data only

--- a/.claude/plugins/session-wrangler/commands/revive.md
+++ b/.claude/plugins/session-wrangler/commands/revive.md
@@ -1,0 +1,439 @@
+# /sessions.revive - Revive a Stuck Session
+
+Spawn a new Alacritty terminal in the correct worktree and provide instructions to resume or restart a Claude session.
+
+## Purpose
+
+Help users recover from:
+- Sessions that stopped responding
+- Sessions with corrupted files
+- Sessions that need to be resumed after system restart
+- Sessions in resumable state
+
+**Key principle:** The plugin does NOT resume the session itself - it spawns the terminal and tells the user how to resume.
+
+## Usage
+
+```bash
+/sessions.revive <session-identifier>
+```
+
+Where `<session-identifier>` can be:
+- Slug: `warm-floating-pancake`
+- Short ID: `2893aa9b`
+- Full ID: `2893aa9b-69d3-4167-9ad1-4c5a06697d93`
+- Worktree: `045-milestone-coordinator-plugin`
+
+## Pre-Flight Checks
+
+Before attempting to revive:
+
+1. **Resolve session identifier** (same logic as `/sessions.inspect`)
+2. **Check session health** (run subset of inspect checks)
+3. **Determine if revivable** (see decision matrix below)
+4. **Find or create worktree** (if deleted, offer to recreate)
+
+### Decision Matrix
+
+| Current State | File Health | Worktree Exists | Action |
+|---------------|-------------|-----------------|--------|
+| Not running | Healthy (<10MB) | Yes | Resume in existing worktree |
+| Not running | Healthy | No | Offer to recreate worktree |
+| Not running | Corrupted | Yes | Start fresh, preserve context |
+| Not running | Corrupted | No | Start fresh on branch |
+| Running | Any | Any | Switch to existing terminal |
+| Zombie | Any | Yes | Kill process, then resume |
+
+## Execution Steps
+
+### 1. Resolve and Inspect Session
+
+```bash
+# Use same resolution logic as /sessions.inspect
+SESSION_FILE=<resolved-path>
+SESSION_ID=$(basename "$SESSION_FILE" .jsonl)
+
+# Get metadata
+SLUG=$(head -20 "$SESSION_FILE" | jq -r 'select(.slug) | .slug' | head -1)
+CWD=$(head -20 "$SESSION_FILE" | jq -r 'select(.cwd) | .cwd' | head -1)
+BRANCH=$(head -20 "$SESSION_FILE" | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+
+# Check file health
+FILE_SIZE=$(stat -f%z "$SESSION_FILE" 2>/dev/null || stat -c%s "$SESSION_FILE")
+IS_CORRUPTED=false
+if [ "$FILE_SIZE" -gt 52428800 ] || [ $(grep -c '"content":null' "$SESSION_FILE") -gt 10 ]; then
+  IS_CORRUPTED=true
+fi
+
+# Check if process running
+PID=$(ps aux | grep "[c]laude.*$SESSION_ID" | awk '{print $2}' | head -1)
+```
+
+### 2. Handle Running Session
+
+If process already running:
+
+```bash
+if [ -n "$PID" ]; then
+  echo "⚠️  Session is already running (PID $PID)"
+  echo ""
+  echo "This session is active. Options:"
+  echo ""
+  echo "1. Use /sessions.switch to navigate to its terminal"
+  echo "2. If terminal is lost, this may be a zombie. Use /sessions.cleanup"
+  echo ""
+  echo "Would you like me to:"
+  echo "  a) Switch to the session's terminal"
+  echo "  b) Kill the process and restart clean"
+  exit 0
+fi
+```
+
+### 3. Check Worktree
+
+```bash
+# Check if worktree exists
+WORKTREE_PATH=""
+if [ -d "$CWD" ]; then
+  WORKTREE_PATH="$CWD"
+else
+  # Try to find by branch name
+  WORKTREE_PATH=$(git -C /Users/kobik-private/workspace/caro worktree list | grep "$BRANCH" | awk '{print $1}')
+fi
+
+if [ -z "$WORKTREE_PATH" ] || [ ! -d "$WORKTREE_PATH" ]; then
+  echo "⚠️  Worktree not found: $CWD"
+  echo ""
+  echo "The session was working in a worktree that no longer exists."
+  echo ""
+  echo "Options:"
+  echo "1. Recreate the worktree for branch: $BRANCH"
+  echo "2. Start fresh session in main workspace"
+  echo ""
+  echo "Would you like me to recreate the worktree?"
+  # Wait for user input
+  read -p "Recreate worktree? (y/n): " RECREATE
+
+  if [ "$RECREATE" == "y" ]; then
+    # Generate worktree name
+    WORKTREE_NUM=$(git -C /Users/kobik-private/workspace/caro worktree list | wc -l | tr -d ' ')
+    WORKTREE_NAME="${WORKTREE_NUM}-${BRANCH//\//-}"
+    WORKTREE_PATH="/Users/kobik-private/workspace/caro/.worktrees/$WORKTREE_NAME"
+
+    # Create worktree
+    git -C /Users/kobik-private/workspace/caro worktree add "$WORKTREE_PATH" "$BRANCH"
+
+    if [ $? -ne 0 ]; then
+      echo "❌ Failed to create worktree"
+      exit 1
+    fi
+
+    echo "✅ Worktree created: $WORKTREE_PATH"
+  else
+    echo "Aborting revival."
+    exit 0
+  fi
+fi
+```
+
+### 4. Handle Corrupted Session
+
+If session is corrupted:
+
+```bash
+if [ "$IS_CORRUPTED" == "true" ]; then
+  echo "═══════════════════════════════════════════════════════════════════"
+  echo "⚠️  Session File Corrupted"
+  echo "═══════════════════════════════════════════════════════════════════"
+  echo ""
+  echo "Session: $SLUG"
+  echo "File size: $(echo "scale=2; $FILE_SIZE / 1048576" | bc)MB"
+  echo ""
+  echo "This session cannot be resumed due to file corruption."
+  echo "The session file is either too large or contains null content."
+  echo ""
+  echo "I can start a fresh session in the same worktree, but the"
+  echo "conversation history will be lost."
+  echo ""
+  echo "Worktree: $WORKTREE_PATH"
+  echo "Branch: $BRANCH"
+  echo ""
+  echo "📋 Before starting fresh, check for uncommitted work:"
+
+  cd "$WORKTREE_PATH"
+  if [ -n "$(git status --porcelain)" ]; then
+    echo ""
+    echo "⚠️  UNCOMMITTED CHANGES FOUND:"
+    git status --short
+    echo ""
+    echo "You may want to commit these before starting a new session."
+    echo ""
+  fi
+
+  echo "I'll now spawn a terminal in the worktree."
+  echo "You can start fresh with: claude"
+  echo ""
+  echo "Press Enter to continue..."
+  read
+fi
+```
+
+### 5. Spawn Terminal
+
+```bash
+# Determine terminal title
+TERM_TITLE="Claude: $SLUG"
+
+# Spawn Alacritty in the worktree directory
+alacritty \
+  --title "$TERM_TITLE" \
+  --working-directory "$WORKTREE_PATH" \
+  &
+
+ALACRITTY_PID=$!
+
+# Give terminal time to spawn
+sleep 0.5
+
+# Check if it succeeded
+if ps -p $ALACRITTY_PID > /dev/null 2>&1; then
+  echo "✅ Terminal spawned successfully (PID $ALACRITTY_PID)"
+else
+  echo "❌ Failed to spawn terminal"
+  echo ""
+  echo "You can manually navigate to:"
+  echo "  cd $WORKTREE_PATH"
+  exit 1
+fi
+```
+
+### 6. Provide Instructions
+
+```bash
+# Different instructions based on corruption state
+if [ "$IS_CORRUPTED" == "true" ]; then
+  cat <<EOF
+
+═══════════════════════════════════════════════════════════════════
+✅ Terminal Spawned
+═══════════════════════════════════════════════════════════════════
+
+I've opened a new Alacritty terminal in:
+  $WORKTREE_PATH
+
+Since the session file is corrupted, start a fresh session with:
+
+  claude
+
+The previous conversation history is lost, but you can:
+  • Continue work in the same worktree
+  • Reference uncommitted files
+  • Review session file manually: $SESSION_FILE
+
+To archive the old session file:
+  mkdir -p ~/.claude/archive/
+  mv $SESSION_FILE ~/.claude/archive/
+
+═══════════════════════════════════════════════════════════════════
+EOF
+
+else
+  cat <<EOF
+
+═══════════════════════════════════════════════════════════════════
+✅ Terminal Spawned
+═══════════════════════════════════════════════════════════════════
+
+I've opened a new Alacritty terminal in:
+  $WORKTREE_PATH
+
+To resume your previous session, type this in the new terminal:
+
+  claude --resume $SESSION_ID
+
+This will restore your full conversation history ($(grep -c '"role":"user"' "$SESSION_FILE") messages).
+
+Your last prompt was:
+  "$(grep '"role":"user"' "$SESSION_FILE" | tail -1 | jq -r '.content[0].text' 2>/dev/null | head -c 100)..."
+
+═══════════════════════════════════════════════════════════════════
+EOF
+fi
+```
+
+### 7. Focus Terminal (macOS only)
+
+```bash
+# On macOS, try to focus the new terminal
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  osascript <<EOF 2>/dev/null
+    tell application "Alacritty"
+      activate
+    end tell
+EOF
+
+  if [ $? -eq 0 ]; then
+    echo "🎯 Terminal window focused"
+  fi
+fi
+```
+
+## Special Cases
+
+### Session Already Active
+
+```
+⚠️  Session Already Running
+
+Session: <slug>
+PID: <pid>
+Started: <start-time>
+
+This session is currently active. Options:
+
+1. /sessions.switch <slug>
+   Navigate to the existing terminal
+
+2. Kill and restart:
+   kill -TERM <pid>
+   /sessions.revive <slug>
+
+3. Check if zombie:
+   /sessions.inspect <slug>
+
+What would you like to do?
+```
+
+### Worktree Deleted
+
+```
+⚠️  Worktree No Longer Exists
+
+Session was in: <cwd>
+Branch: <branch>
+
+The worktree directory has been deleted. I can:
+
+1. Recreate the worktree:
+   git worktree add .worktrees/NNN-<branch> <branch>
+
+2. Start fresh on branch in main workspace:
+   cd /Users/kobik-private/workspace/caro
+   git checkout <branch>
+   claude
+
+3. Abandon this session (mark as archived)
+
+Which option would you prefer?
+```
+
+### Branch Deleted
+
+```
+⚠️  Branch No Longer Exists
+
+Session was on branch: <branch>
+
+The branch has been deleted (possibly merged to main).
+
+Options:
+
+1. Start fresh session on main branch
+2. Recreate the branch from a commit
+3. Archive this session
+
+The session file is preserved at:
+  <session-file>
+
+What would you like to do?
+```
+
+### Alacritty Not Installed
+
+```
+❌ Alacritty Not Found
+
+I need Alacritty terminal to spawn a new session window.
+
+Options:
+
+1. Install Alacritty:
+   brew install --cask alacritty
+
+2. Manually navigate:
+   cd <worktree-path>
+   claude --resume <session-id>
+
+3. Use different terminal (manual setup required)
+
+After installing Alacritty, run this command again.
+```
+
+## User Confirmation Flow
+
+For potentially destructive operations, always confirm:
+
+```bash
+# Before killing a process
+echo "⚠️  This will kill PID $PID. Continue? (y/n): "
+read CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "Aborting."
+  exit 0
+fi
+
+# Before recreating worktree
+echo "This will create a new worktree at: $WORKTREE_PATH"
+echo "Continue? (y/n): "
+read CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "Aborting."
+  exit 0
+fi
+
+# Before starting fresh (corrupted session)
+echo "⚠️  Starting fresh will lose conversation history. Continue? (y/n): "
+read CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "Aborting. You can manually inspect: $SESSION_FILE"
+  exit 0
+fi
+```
+
+## Integration with Other Commands
+
+After successful revival:
+
+```
+💡 Next Steps:
+
+• In the new terminal, follow the instructions above
+• Use /sessions to verify the session is active
+• Use /sessions.inspect to check health after resuming
+• If issues persist, use /sessions.cleanup
+```
+
+## Error Handling
+
+| Error | Recovery |
+|-------|----------|
+| Terminal spawn fails | Provide manual `cd` command |
+| Session not found | Suggest `/sessions` to list available |
+| Permission denied | Suggest `chmod` fix |
+| Git worktree error | Suggest `git worktree prune` |
+| Branch not found | Offer to recreate or abandon |
+
+## Performance Notes
+
+- Terminal spawn is async (backgrounded with `&`)
+- Don't wait for terminal to fully load
+- Provide instructions immediately
+- Let user execute resume command in their own time
+
+## Success Criteria
+
+- ✅ Terminal spawned in correct directory
+- ✅ Instructions displayed clearly
+- ✅ User knows exactly what to type
+- ✅ Corrupted sessions handled gracefully
+- ✅ No data loss from uncommitted work

--- a/.claude/plugins/session-wrangler/commands/sessions.md
+++ b/.claude/plugins/session-wrangler/commands/sessions.md
@@ -1,0 +1,230 @@
+# /sessions - List All Claude Sessions
+
+List all Claude Code sessions across all states: running, stale, zombie, and resumable.
+
+## Purpose
+
+Provide a unified view of all Claude sessions to help users understand:
+- What sessions are currently active
+- Which sessions are stuck or zombie
+- Which sessions can be resumed
+- Where each session is working (worktree/branch)
+
+## Execution Steps
+
+### 1. Discover Running Processes
+
+```bash
+ps aux | grep "[c]laude" | awk '{print $2, $3, $9, $11}'
+```
+
+Parse output to get:
+- PID (column 1)
+- CPU % (column 2)
+- Start time (column 3)
+- Command (column 4+)
+
+### 2. List Session Files
+
+```bash
+ls -lh ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl 2>/dev/null
+```
+
+For each session file, extract:
+- Filename (session ID)
+- File size (indicator of health)
+
+### 3. Get Session Metadata
+
+For each session file:
+
+```bash
+SESSION_FILE="<path-to-session>.jsonl"
+
+# Extract slug
+SLUG=$(head -20 "$SESSION_FILE" | jq -r 'select(.slug) | .slug' | head -1)
+
+# Extract branch
+BRANCH=$(head -20 "$SESSION_FILE" | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+
+# Extract cwd
+CWD=$(head -20 "$SESSION_FILE" | jq -r 'select(.cwd) | .cwd' | head -1)
+
+# Get last user prompt (truncated)
+LAST_PROMPT=$(grep '"role":"user"' "$SESSION_FILE" | tail -1 | jq -r '.content[0].text' 2>/dev/null | head -c 50)
+
+# Count messages
+MSG_COUNT=$(grep -c '"role":"user"' "$SESSION_FILE")
+```
+
+### 4. Get Last Activity Time
+
+```bash
+# From history file
+LAST_ACTIVITY=$(grep '"sessionId":"<session-id>"' ~/.claude/history.jsonl 2>/dev/null | tail -1 | jq -r '.timestamp')
+
+# Or from session file modification time
+LAST_MODIFIED=$(stat -f%m "$SESSION_FILE" 2>/dev/null || stat -c%Y "$SESSION_FILE")
+```
+
+Calculate time ago:
+```bash
+NOW=$(date +%s)
+DIFF=$((NOW - LAST_MODIFIED))
+if [ $DIFF -lt 300 ]; then
+  TIME_AGO="$((DIFF / 60))min ago"
+elif [ $DIFF -lt 3600 ]; then
+  TIME_AGO="$((DIFF / 60))min ago"
+elif [ $DIFF -lt 86400 ]; then
+  TIME_AGO="$((DIFF / 3600))h ago"
+else
+  TIME_AGO="$((DIFF / 86400))d ago"
+fi
+```
+
+### 5. Map to Worktrees
+
+```bash
+# List worktrees
+git -C /Users/kobik-private/workspace/caro worktree list
+
+# Match session CWD to worktree path
+WORKTREE=$(git -C /Users/kobik-private/workspace/caro worktree list | grep "$CWD" | awk '{print $1}' | xargs basename)
+```
+
+### 6. Determine Session State
+
+For each session, determine state based on:
+
+| Condition | State |
+|-----------|-------|
+| Process running + CPU > 0% + Activity < 5min | ✅ Active |
+| Process running + CPU = 0% + Activity 5-30min | ⚠️ Stale |
+| Process running + (File > 50MB OR Activity > 30min) | ❌ Zombie |
+| No process + File < 10MB + No corruption | 💤 Resumable |
+| File > 50MB OR null content | 🔥 Corrupted |
+
+### 7. Query PostgreSQL (Optional)
+
+If available, cross-reference with database:
+
+```bash
+docker exec continuous-claude-postgres psql -U claude -d continuous_claude -c \
+  "SELECT id, working_on, last_heartbeat,
+   EXTRACT(EPOCH FROM (NOW() - last_heartbeat)) as staleness
+   FROM sessions
+   WHERE last_heartbeat > NOW() - INTERVAL '2 hours'
+   ORDER BY last_heartbeat DESC;" 2>/dev/null
+```
+
+### 8. Format Output
+
+Group sessions by state and format as:
+
+```
+Session Wrangler - Claude Sessions Overview
+═══════════════════════════════════════════════════════════════════════
+
+Active Sessions (N)
+───────────────────────────────────────────────────────────────────────
+  ✅ <slug>
+     "<last-prompt-preview...>"
+     📂 <worktree> │ 🔀 <branch> │ ⏱️  <time-ago>
+     PID: <pid> │ CPU: <cpu>% │ Size: <size>
+
+Stale Sessions (N)
+───────────────────────────────────────────────────────────────────────
+  ⚠️  <slug>
+     "<last-prompt-preview...>"
+     📂 <worktree> │ 🔀 <branch> │ ⏱️  <time-ago> (idle)
+     PID: <pid> │ Size: <size>
+
+Zombie Sessions (N)
+───────────────────────────────────────────────────────────────────────
+  ❌ <slug>
+     "<last-prompt-preview...>"
+     📂 <worktree> │ 🔀 <branch>
+     PID: <pid> │ ⚠️  STUCK - needs cleanup
+
+Resumable Sessions (N)
+───────────────────────────────────────────────────────────────────────
+  💤 <slug> (<short-id>)
+     "<last-prompt-preview...>"
+     📂 <worktree> │ 🔀 <branch> │ 📅 <date>
+     💬 <count> messages │ 📏 <size>
+     ▶️  claude --resume <session-id>
+
+Corrupted Sessions (N)
+───────────────────────────────────────────────────────────────────────
+  🔥 <slug>
+     ⚠️  CORRUPTED - cannot resume (Size: <size>)
+     📂 <worktree> │ 🔀 <branch>
+     💡 Suggest: Archive and start fresh
+
+═══════════════════════════════════════════════════════════════════════
+Total: <count> sessions | Active: <n> | Stuck: <n> | Resumable: <n>
+
+💡 Quick Actions:
+  /sessions.inspect <slug>    - Deep dive into a session
+  /sessions.revive <slug>     - Revive a stuck/resumable session
+  /sessions.cleanup           - Clean up zombies and corrupted files
+  /sessions.switch <slug>     - Jump to another session's terminal
+```
+
+## Special Cases
+
+### No Sessions Found
+```
+No Claude sessions found.
+
+This could mean:
+  • No sessions have been started yet
+  • Session directory doesn't exist
+  • You're in a different project
+
+Expected location: ~/.claude/projects/-Users-kobik-private-workspace-caro/
+```
+
+### PostgreSQL Unavailable
+Continue with file-based discovery only. Add note:
+```
+ℹ️  PostgreSQL unavailable - showing file-based data only
+   For more accurate heartbeat data, ensure continuous-claude-postgres container is running
+```
+
+### jq Not Available
+Fall back to grep/awk parsing. Add note:
+```
+⚠️  jq not installed - using basic parsing (may be less accurate)
+   Install with: brew install jq
+```
+
+## Performance Considerations
+
+- Limit file reads to first/last 20 lines for metadata extraction
+- Cache worktree list (read once, use for all sessions)
+- Skip PostgreSQL query if container check fails quickly
+- Truncate long prompts to 50 chars for display
+- Process sessions in parallel if > 10 sessions found
+
+## Error Handling
+
+- **Permission denied on session file**: Skip and note in output
+- **Corrupted JSON**: Try line-by-line parsing as fallback
+- **Missing git repository**: Skip worktree mapping
+- **Stat command varies by OS**: Try both `stat -f%m` (macOS) and `stat -c%Y` (Linux)
+
+## User Interaction
+
+After displaying results:
+- If zombies found: Suggest `/sessions.cleanup`
+- If many stale sessions: Suggest reviewing which to keep
+- If resumable sessions: Highlight how to resume
+- If all sessions active: Show "All systems operational ✅"
+
+## Next Steps
+
+Based on output, suggest:
+- "Run `/sessions.inspect <slug>` to understand what a session was doing"
+- "Run `/sessions.cleanup` to remove N zombie processes"
+- "Run `/sessions.revive <slug>` to restart work in a resumable session"

--- a/.claude/plugins/session-wrangler/commands/switch.md
+++ b/.claude/plugins/session-wrangler/commands/switch.md
@@ -1,0 +1,475 @@
+# /sessions.switch - Navigate to Another Session
+
+Focus and navigate to an existing Claude session's terminal window.
+
+## Purpose
+
+Help users quickly jump between active Claude sessions without manually searching for terminals.
+
+**Key principle:** This command finds and focuses the terminal - it does NOT start a new terminal or resume a session.
+
+## Usage
+
+```bash
+/sessions.switch <session-identifier>
+```
+
+Where `<session-identifier>` can be:
+- Slug: `warm-floating-pancake`
+- Short ID: `2893aa9b`
+- Worktree: `045-milestone-coordinator-plugin`
+- Branch: `feature/i18n-complete-system`
+
+## Pre-Flight Checks
+
+1. **Session must be running** - If not running, suggest `/sessions.revive`
+2. **Terminal must exist** - If process exists but no terminal found, report issue
+3. **Platform support** - macOS (osascript) vs Linux (wmctrl)
+
+## Execution Steps
+
+### 1. Resolve Session Identifier
+
+```bash
+# Use same resolution logic as /sessions.inspect
+SESSION_FILE=<resolved-path>
+SESSION_ID=$(basename "$SESSION_FILE" .jsonl)
+
+# Get metadata
+SLUG=$(head -20 "$SESSION_FILE" | jq -r 'select(.slug) | .slug' | head -1)
+CWD=$(head -20 "$SESSION_FILE" | jq -r 'select(.cwd) | .cwd' | head -1)
+```
+
+### 2. Check If Session Is Running
+
+```bash
+# Find process
+PID=$(ps aux | grep "[c]laude.*$SESSION_ID" | awk '{print $2}' | head -1)
+
+if [ -z "$PID" ]; then
+  echo "❌ Session Not Running"
+  echo ""
+  echo "Session: $SLUG"
+  echo "This session is not currently active."
+  echo ""
+  echo "Options:"
+  echo "  1. Resume it: /sessions.revive $SLUG"
+  echo "  2. Check status: /sessions.inspect $SLUG"
+  echo "  3. List all: /sessions"
+  exit 1
+fi
+
+# Process is running - continue
+echo "✅ Session found (PID $PID)"
+```
+
+### 3. Find Terminal Window (macOS)
+
+```bash
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Method 1: Find by window title
+  WINDOW_TITLE=$(osascript <<EOF 2>/dev/null
+    tell application "Alacritty"
+      set windowList to every window
+      repeat with aWindow in windowList
+        set windowTitle to name of aWindow
+        if windowTitle contains "$SLUG" then
+          return windowTitle
+        end if
+      end repeat
+    end tell
+EOF
+  )
+
+  # Method 2: Find by working directory
+  if [ -z "$WINDOW_TITLE" ]; then
+    WINDOW_TITLE=$(osascript <<EOF 2>/dev/null
+      tell application "System Events"
+        set processList to every process whose name is "Alacritty"
+        repeat with aProcess in processList
+          set windowList to windows of aProcess
+          repeat with aWindow in windowList
+            -- Check window properties for CWD match
+            -- This is approximate and may not work reliably
+          end repeat
+        end repeat
+      end tell
+EOF
+    )
+  fi
+
+  # Method 3: Find by PID correlation
+  if [ -z "$WINDOW_TITLE" ]; then
+    # Get terminal sessions associated with Claude PID
+    TERMINAL_PID=$(ps -o ppid= -p $PID | xargs)
+
+    if [ -n "$TERMINAL_PID" ]; then
+      WINDOW_TITLE=$(osascript <<EOF 2>/dev/null
+        tell application "System Events"
+          set processList to every process whose unix id is $TERMINAL_PID
+          if (count of processList) > 0 then
+            set aProcess to item 1 of processList
+            if (count of windows of aProcess) > 0 then
+              return name of window 1 of aProcess
+            end if
+          end if
+        end tell
+EOF
+      )
+    fi
+  fi
+fi
+```
+
+### 4. Find Terminal Window (Linux)
+
+```bash
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  # Use wmctrl if available
+  if command -v wmctrl &> /dev/null; then
+    # Find window by title or PID
+    WINDOW_ID=$(wmctrl -lp | while read -r line; do
+      WIN_ID=$(echo "$line" | awk '{print $1}')
+      WIN_PID=$(echo "$line" | awk '{print $3}')
+      WIN_TITLE=$(echo "$line" | cut -d' ' -f5-)
+
+      # Match by title
+      if [[ "$WIN_TITLE" == *"$SLUG"* ]]; then
+        echo "$WIN_ID"
+        break
+      fi
+
+      # Match by PID correlation
+      if [ "$WIN_PID" == "$PID" ] || ps --ppid $WIN_PID | grep -q $PID; then
+        echo "$WIN_ID"
+        break
+      fi
+    done)
+  fi
+fi
+```
+
+### 5. Focus Terminal Window
+
+#### macOS Implementation
+
+```bash
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [ -n "$WINDOW_TITLE" ]; then
+    osascript <<EOF 2>/dev/null
+      tell application "Alacritty"
+        activate
+        set windowList to every window
+        repeat with aWindow in windowList
+          if name of aWindow contains "$SLUG" then
+            set index of aWindow to 1
+            return
+          end if
+        end repeat
+      end tell
+EOF
+
+    if [ $? -eq 0 ]; then
+      echo "✅ Switched to session: $SLUG"
+      echo ""
+      echo "The terminal window has been brought to front."
+      exit 0
+    else
+      echo "⚠️  Found terminal but failed to focus it"
+    fi
+  fi
+fi
+```
+
+#### Linux Implementation
+
+```bash
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  if [ -n "$WINDOW_ID" ]; then
+    # Activate window
+    wmctrl -ia "$WINDOW_ID"
+
+    if [ $? -eq 0 ]; then
+      echo "✅ Switched to session: $SLUG"
+      echo ""
+      echo "The terminal window has been brought to front."
+      exit 0
+    else
+      echo "⚠️  Found terminal but failed to focus it"
+    fi
+  fi
+fi
+```
+
+### 6. Fallback: Manual Instructions
+
+If automatic focusing fails:
+
+```bash
+echo "═══════════════════════════════════════════════════════════════════"
+echo "Cannot Automatically Switch"
+echo "═══════════════════════════════════════════════════════════════════"
+echo ""
+echo "Session: $SLUG (PID $PID)"
+echo "Working Directory: $CWD"
+echo ""
+echo "The session is running, but I couldn't automatically focus its terminal."
+echo ""
+echo "Manual steps:"
+echo "  1. Look for a terminal window with title: \"Claude: $SLUG\""
+echo "  2. Or search your terminal windows for working directory: $CWD"
+echo "  3. Use Cmd+Tab (macOS) or Alt+Tab (Linux) to find the window"
+echo ""
+echo "Process Info:"
+ps aux | grep "^[^ ]* *$PID " | awk '{print "  "$11, $12, $13, $14, $15}'
+echo ""
+echo "If you can't find the terminal:"
+echo "  • The process may be running headless (rare)"
+echo "  • The terminal may have been closed"
+echo "  • Try /sessions.inspect $SLUG for more details"
+echo ""
+echo "═══════════════════════════════════════════════════════════════════"
+```
+
+## Smart Search Strategies
+
+### Strategy 1: Title Matching
+
+Most reliable when sessions use consistent window titles.
+
+```bash
+# Expected title format: "Claude: <slug>"
+# Also check: "<slug>", "claude <slug>", "<worktree-name>"
+```
+
+### Strategy 2: Working Directory
+
+Match terminal's current working directory to session's CWD.
+
+```bash
+# On macOS, this requires accessibility permissions
+# On Linux, use /proc/$PID/cwd if available
+```
+
+### Strategy 3: Process Tree
+
+Trace from Claude PID to parent shell to terminal emulator.
+
+```bash
+# Example process tree:
+# Alacritty (pid 1000)
+#   └─ zsh (pid 1001)
+#       └─ claude (pid 1002)  ← Target PID
+
+# Find by walking up the tree
+SHELL_PID=$(ps -o ppid= -p $PID | xargs)
+TERMINAL_PID=$(ps -o ppid= -p $SHELL_PID | xargs)
+```
+
+### Strategy 4: Terminal History
+
+Some terminals maintain session history accessible via API.
+
+```bash
+# Alacritty: Check config for socket/API endpoint
+# iTerm2: Use AppleScript API
+# Kitty: Use remote control socket
+```
+
+## Platform-Specific Implementations
+
+### macOS (Alacritty)
+
+```bash
+# Primary: AppleScript via osascript
+# Pros: Native, reliable, works with most terminals
+# Cons: Requires Accessibility permissions for some features
+
+# Fallback: Use Mission Control/Exposé
+osascript -e 'tell application "System Events" to key code 160'  # F9 for Exposé
+```
+
+### macOS (iTerm2)
+
+```bash
+# iTerm2 has rich AppleScript API
+osascript <<EOF
+  tell application "iTerm2"
+    activate
+    set sessionList to sessions of current window
+    repeat with aSession in sessionList
+      if name of aSession contains "$SLUG" then
+        select aSession
+        return
+      end if
+    end repeat
+  end tell
+EOF
+```
+
+### Linux (X11)
+
+```bash
+# Use wmctrl for window management
+wmctrl -ia <window-id>  # Activate window
+
+# Alternative: xdotool
+xdotool search --name "$SLUG" windowactivate
+```
+
+### Linux (Wayland)
+
+```bash
+# Wayland has limited window management
+# May need compositor-specific tools
+
+# Sway (i3-like)
+swaymsg '[title=".*'$SLUG'.*"] focus'
+
+# GNOME
+gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell \
+  --method org.gnome.Shell.Eval "global.get_window_actors().forEach(a => { if (a.get_meta_window().get_title().includes('$SLUG')) a.get_meta_window().activate(0); });"
+```
+
+## Interactive Mode
+
+If multiple terminals match, let user choose:
+
+```bash
+echo "Found multiple terminals for session $SLUG:"
+echo ""
+echo "1. Alacritty - Window 1 (Claude: $SLUG)"
+echo "2. Alacritty - Window 2 (Claude: $SLUG - backup)"
+echo "3. iTerm2 - Tab (working on $SLUG)"
+echo ""
+read -p "Which terminal? (1-3): " CHOICE
+
+case $CHOICE in
+  1) WINDOW_ID=<id1> ;;
+  2) WINDOW_ID=<id2> ;;
+  3) WINDOW_ID=<id3> ;;
+  *) echo "Invalid choice"; exit 1 ;;
+esac
+
+# Focus chosen window
+```
+
+## Status Display
+
+After successful switch:
+
+```
+✅ Switched to Session
+
+Session: <slug>
+Worktree: <worktree-name>
+Branch: <branch>
+PID: <pid>
+
+Last Activity: <time-ago>
+Context: "<last-prompt-preview...>"
+
+You are now focused on this session's terminal.
+```
+
+## Special Cases
+
+### Session Running But No Terminal
+
+```
+⚠️  Process Found But No Terminal
+
+Session: <slug>
+PID: <pid>
+State: Running
+
+The Claude process is active, but I couldn't find its terminal window.
+
+This can happen if:
+  • The terminal was closed while Claude kept running
+  • Claude was started in background/tmux/screen
+  • The terminal is on a different workspace/desktop
+
+Options:
+  1. Kill the process and revive: /sessions.cleanup then /sessions.revive
+  2. Manually find the terminal using Activity Monitor / top
+  3. Check if running in tmux: tmux list-sessions
+
+Process details:
+<ps aux output>
+```
+
+### Multiple Sessions, Same Worktree
+
+```
+⚠️  Ambiguity Detected
+
+Multiple sessions found in worktree: <worktree>
+
+1. <slug-1> (PID <pid1>) - Active 2min ago
+2. <slug-2> (PID <pid2>) - Active 45min ago
+
+Which session would you like to switch to? (1-2):
+```
+
+### Session on Different Desktop/Space
+
+```
+ℹ️  Session May Be On Different Desktop
+
+The session's terminal was found but may be on a different macOS Space/Desktop.
+
+Session: <slug>
+Terminal: <window-title>
+
+I've attempted to focus it. If you don't see it:
+  • Swipe between Spaces
+  • Use Mission Control (F3 or Ctrl+Up)
+  • Check "Windows" in dock
+
+The terminal should now be visible on one of your spaces.
+```
+
+## Error Handling
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| Session not found | Invalid identifier | Suggest `/sessions` |
+| Process not running | Session stopped | Suggest `/sessions.revive` |
+| No terminal found | Terminal closed or bg | Provide manual search steps |
+| Focus failed | Permission/API issue | Provide manual instructions |
+| Platform unsupported | Not macOS/Linux X11 | Explain limitation |
+
+## Performance Notes
+
+- Window search is O(n) where n = open windows
+- Cache window list during single command execution
+- Timeout window enumeration after 5 seconds
+- Use native APIs when available (faster than process parsing)
+
+## Integration
+
+Works well with other commands:
+
+```bash
+# Typical workflow
+/sessions                    # List all sessions
+/sessions.inspect work-123   # Check details
+/sessions.switch work-123    # Jump to that session
+```
+
+## Success Criteria
+
+- ✅ Terminal window focused and brought to front
+- ✅ User can immediately interact with session
+- ✅ Works across different terminal emulators
+- ✅ Graceful degradation with manual instructions
+- ✅ Fast (< 1 second to switch)
+
+## Future Enhancements
+
+- Support for tmux/screen sessions
+- Support for more terminal emulators (Kitty, WezTerm, Terminator)
+- Support for Windows (Windows Terminal)
+- Session history preview before switching
+- Keyboard shortcut integration

--- a/.claude/plugins/session-wrangler/skills/session-discovery/SKILL.md
+++ b/.claude/plugins/session-wrangler/skills/session-discovery/SKILL.md
@@ -1,0 +1,317 @@
+# Session Discovery Skill
+
+This skill teaches Claude how to discover, analyze, and understand Claude Code sessions across multiple terminals and worktrees.
+
+## Core Capabilities
+
+### 1. Finding Running Sessions
+
+**Get all Claude processes:**
+```bash
+ps aux | grep "claude" | grep -v grep | awk '{print $2, $9, $10, $11}'
+```
+
+**Parse output:**
+- Column 1: PID
+- Column 2: Start time
+- Column 3: CPU %
+- Column 4+: Command
+
+**Interpreting process state:**
+- Process running with recent CPU activity = Active
+- Process running with 0% CPU for 5+ min = Potentially stuck
+- No process found = Either not running or zombie
+
+### 2. Finding Session Files
+
+**List all session files with sizes:**
+```bash
+ls -lh ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl 2>/dev/null | awk '{print $5, $9}'
+```
+
+**Health indicators:**
+- File size < 10MB = Healthy
+- File size 10-50MB = Large but recoverable
+- File size > 50MB = Likely corrupted, may not resume
+
+**Check for corruption:**
+```bash
+# Sample first and last messages to check for null content
+head -1 <session-file>.jsonl | jq '.content'
+tail -1 <session-file>.jsonl | jq '.content'
+```
+
+If content fields are `null`, the session is corrupted.
+
+### 3. Getting Last Activity
+
+**From history file:**
+```bash
+grep '"sessionId"' ~/.claude/history.jsonl | grep '<session-id>' | tail -1 | jq -r '.timestamp, .display'
+```
+
+**From session file metadata:**
+```bash
+head -5 <session>.jsonl | jq -r 'select(.type == "session_metadata") | .slug, .gitBranch, .cwd'
+```
+
+**Calculate staleness:**
+- Compare last timestamp to current time
+- 0-5 min = Active
+- 5-30 min = Recently active
+- 30+ min = Stale
+- No recent activity = Abandoned
+
+### 4. Mapping to Worktrees
+
+**List all worktrees:**
+```bash
+git worktree list --porcelain
+```
+
+**Parse worktree data:**
+- `worktree` line = directory path
+- `branch` line = branch name
+- Match session's `cwd` field to worktree path
+- Match session's `gitBranch` to worktree branch
+
+**Cross-reference logic:**
+```bash
+# Get session's cwd and branch
+SESSION_CWD=$(head -10 <session>.jsonl | jq -r 'select(.cwd) | .cwd' | head -1)
+SESSION_BRANCH=$(head -10 <session>.jsonl | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+
+# Find matching worktree
+git worktree list | grep "$SESSION_CWD"
+```
+
+### 5. Checking Session Health
+
+**Run all health checks:**
+```bash
+# 1. File size check
+FILE_SIZE=$(stat -f%z <session>.jsonl 2>/dev/null || stat -c%s <session>.jsonl)
+if [ $FILE_SIZE -gt 52428800 ]; then
+  echo "❌ CORRUPTED: File too large ($FILE_SIZE bytes)"
+fi
+
+# 2. Content check
+CONTENT_NULL=$(grep -c '"content":null' <session>.jsonl || echo 0)
+if [ $CONTENT_NULL -gt 10 ]; then
+  echo "❌ CORRUPTED: Null content entries found ($CONTENT_NULL)"
+fi
+
+# 3. Process check
+PID=$(ps aux | grep "claude.*$SESSION_ID" | grep -v grep | awk '{print $2}')
+if [ -n "$PID" ]; then
+  echo "✅ RUNNING: PID $PID"
+else
+  echo "💤 STOPPED: No process found"
+fi
+
+# 4. Heartbeat check (from PostgreSQL if available)
+docker exec continuous-claude-postgres psql -U claude -d continuous_claude -c \
+  "SELECT last_heartbeat FROM sessions WHERE id = '$SESSION_ID';" 2>/dev/null
+```
+
+### 6. Extracting Session Context
+
+**Get last user prompt:**
+```bash
+grep '"role":"user"' <session>.jsonl | tail -1 | jq -r '.content[0].text' | head -c 200
+```
+
+**Get last assistant response:**
+```bash
+grep '"role":"assistant"' <session>.jsonl | tail -1 | jq -r '.content[0].text' | head -c 200
+```
+
+**Count message exchanges:**
+```bash
+grep -c '"role":"user"' <session>.jsonl
+```
+
+**Get session working directory:**
+```bash
+head -20 <session>.jsonl | jq -r 'select(.cwd) | .cwd' | head -1
+```
+
+## Session States
+
+| State | Indicator | Description |
+|-------|-----------|-------------|
+| ✅ **Active** | Process running, CPU > 0%, heartbeat < 2min | Session is actively working |
+| ⚠️ **Stale** | Process running, CPU = 0%, no activity 5-30min | Session idle but recoverable |
+| ❌ **Zombie** | Process running, file corrupted OR no heartbeat 30+min | Process stuck, needs cleanup |
+| 💤 **Resumable** | No process, file healthy, size < 10MB | Can be resumed with `claude --resume` |
+| 🔥 **Corrupted** | File > 50MB OR null content entries | Cannot be resumed, data lost |
+| 📦 **Archived** | File moved to archive, no process | Historical session, read-only |
+
+## Common Issues and Diagnosis
+
+### Issue: Session Won't Resume
+**Symptoms:** `claude --resume <id>` fails or hangs
+**Diagnosis:**
+1. Check file size: `ls -lh <session>.jsonl`
+2. Check for null content: `grep '"content":null' <session>.jsonl | head`
+3. Check file permissions: `ls -l <session>.jsonl`
+
+**Solutions:**
+- If > 50MB: File corrupted, cannot resume
+- If null content: Corruption, cannot resume
+- If permissions: `chmod 644 <session>.jsonl`
+
+### Issue: Zombie Process
+**Symptoms:** Process exists but doesn't respond
+**Diagnosis:**
+1. Check CPU usage: `ps aux | grep <PID>`
+2. Check for hung syscalls: `lsof -p <PID>`
+3. Check memory: `ps -o rss,vsz,pid,comm | grep <PID>`
+
+**Solutions:**
+- Try graceful stop: `kill -TERM <PID>`, wait 10s
+- Force kill if needed: `kill -9 <PID>`
+- Clean up session file if corrupted
+
+### Issue: Lost Worktree Context
+**Symptoms:** Can't find which worktree a session was in
+**Diagnosis:**
+1. Check session metadata: `head -20 <session>.jsonl | jq '.cwd, .gitBranch'`
+2. List worktrees: `git worktree list`
+3. Check for deleted worktrees: Compare paths
+
+**Solutions:**
+- If worktree exists: Resume session in that directory
+- If worktree deleted: Create new worktree for the branch
+- If branch deleted: Start fresh session
+
+## Advanced Queries
+
+### Find sessions by worktree:
+```bash
+for session in ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl; do
+  CWD=$(head -20 "$session" | jq -r 'select(.cwd) | .cwd' | head -1)
+  if [[ "$CWD" == *"$WORKTREE_NAME"* ]]; then
+    echo "$(basename $session): $CWD"
+  fi
+done
+```
+
+### Find sessions by branch:
+```bash
+for session in ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl; do
+  BRANCH=$(head -20 "$session" | jq -r 'select(.gitBranch) | .gitBranch' | head -1)
+  if [[ "$BRANCH" == "$TARGET_BRANCH" ]]; then
+    echo "$(basename $session): $BRANCH"
+  fi
+done
+```
+
+### Find sessions by last prompt keyword:
+```bash
+grep -l "keyword" ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl
+```
+
+### Get session size statistics:
+```bash
+ls -lh ~/.claude/projects/-Users-kobik-private-workspace-caro/*.jsonl | \
+  awk '{print $5}' | \
+  sort -h | \
+  awk 'BEGIN {print "Min\tMedian\tMax"}
+       {a[NR]=$1}
+       END {print a[1]"\t"a[int(NR/2)]"\t"a[NR]}'
+```
+
+## Integration with PostgreSQL
+
+If the continuous-claude-postgres container is running, you can query the sessions table:
+
+```bash
+# Check if container is running
+docker ps | grep continuous-claude-postgres
+
+# Query active sessions
+docker exec continuous-claude-postgres psql -U claude -d continuous_claude -c \
+  "SELECT id, project, working_on, last_heartbeat,
+   EXTRACT(EPOCH FROM (NOW() - last_heartbeat)) as seconds_since_heartbeat
+   FROM sessions
+   WHERE last_heartbeat > NOW() - INTERVAL '1 hour'
+   ORDER BY last_heartbeat DESC;"
+
+# Find stale sessions
+docker exec continuous-claude-postgres psql -U claude -d continuous_claude -c \
+  "SELECT id, working_on, last_heartbeat
+   FROM sessions
+   WHERE last_heartbeat < NOW() - INTERVAL '30 minutes'
+   AND last_heartbeat > NOW() - INTERVAL '24 hours';"
+```
+
+## Best Practices
+
+1. **Always check file health before attempting resume** - Corrupted files waste time
+2. **Cross-reference multiple data sources** - Process + file + DB gives complete picture
+3. **Handle missing data gracefully** - Sessions may be partially corrupted
+4. **Assume sessions can be in any state** - Don't assume healthy state
+5. **Provide actionable diagnosis** - Don't just report status, explain what to do
+6. **Protect user data** - Never suggest deleting sessions without explicit confirmation
+7. **Use relative session IDs** - Users can refer to sessions by slug or short ID
+8. **Format output for readability** - Tables, colors, emojis help parsing
+
+## Output Format Standards
+
+### For /sessions command:
+```
+# Active Sessions (N)
+  ✅ <slug>  <last-prompt-preview>  │ <worktree>  │ <time-ago>
+  ⚠️ <slug>  <last-prompt-preview>  │ <worktree>  │ <time-ago> (stale)
+  ❌ <slug>  <last-prompt-preview>  │ <worktree>  │ ZOMBIE (PID <pid>)
+
+# Resumable Sessions (N)
+  💤 <short-id>  <last-prompt-preview>  │ <messages> msgs │ <date>
+```
+
+### For /sessions.inspect command:
+```
+Session: <full-id>
+Status: <icon> <state>
+Slug: <slug>
+Last Activity: <timestamp>
+
+Last Prompt: "<truncated-preview>"
+Last Response: "<truncated-preview>"
+
+Working Directory: <cwd>
+Git Branch: <branch>
+Worktree: <worktree-path>
+
+File Stats:
+  Size: <size>
+  Messages: <count>
+  Created: <timestamp>
+
+Process:
+  PID: <pid> (or "Not running")
+  CPU: <usage>
+  Memory: <usage>
+
+Health Checks:
+  ✅/❌ File size < 10MB
+  ✅/❌ Content not null
+  ✅/❌ Process responding
+  ✅/❌ Worktree exists
+
+Diagnosis:
+  <human-readable assessment>
+
+Recommended Action:
+  <specific next step>
+```
+
+## Error Handling
+
+- **Missing jq**: Fallback to grep/awk parsing
+- **Missing session file**: Report as deleted/archived
+- **Permission denied**: Report and suggest fixing permissions
+- **PostgreSQL unavailable**: Skip DB queries, use file-based discovery only
+- **Corrupted JSON**: Use line-by-line parsing instead of jq
+- **Git worktree errors**: Suggest running `git worktree prune`


### PR DESCRIPTION
## Overview

Adds the **Session Wrangler** plugin - a meta-manager for handling multiple parallel Claude Code sessions across worktrees.

## Problem Solved

When running 4-5+ parallel Claude sessions:
- Sessions hang with no clear explanation
- Hard to track which session is doing what
- Zombie processes consume resources
- No unified view of all work in progress
- Difficult to navigate between sessions

## Features

### 5 Core Commands

1. **`/sessions`** - List all sessions with health status
   - Shows active, stale, zombie, and resumable sessions
   - Cross-references with worktrees and processes
   - Displays last activity and resource usage

2. **`/sessions.inspect <session>`** - Deep dive analysis
   - Session health diagnostics
   - Last prompt and response preview
   - Worktree and uncommitted work detection
   - Specific recovery recommendations

3. **`/sessions.revive <session>`** - Revive stuck sessions
   - Spawns Alacritty terminal in correct worktree
   - Provides clear `--resume` instructions
   - Handles corrupted sessions gracefully
   - Protects uncommitted work

4. **`/sessions.cleanup`** - Clean up resources
   - Kill zombie processes (with confirmation)
   - Archive corrupted session files (>50MB)
   - Close orphaned terminal windows
   - Clean stale PostgreSQL entries

5. **`/sessions.switch <session>`** - Navigate sessions
   - Focus existing terminal windows
   - Smart search (by slug, PID, worktree, branch)
   - Cross-platform (macOS osascript, Linux wmctrl)

### Session States

- ✅ **Active**: Running and responding
- ⚠️ **Stale**: Idle 5-30min but recoverable
- ❌ **Zombie**: Stuck or corrupted process
- 💤 **Resumable**: Stopped, can use `--resume`
- 🔥 **Corrupted**: File damaged, cannot resume

## Architecture

```
Session Wrangler Plugin
├── session-discovery skill (foundational knowledge)
├── /sessions (list command)
├── /sessions.inspect (deep analysis)
├── /sessions.revive (terminal spawning)
├── /sessions.cleanup (resource cleanup)
└── /sessions.switch (navigation)

Data Sources:
- ps aux (running processes)
- ~/.claude/history.jsonl (last prompts)
- ~/.claude/projects/*/ (session transcripts)
- PostgreSQL sessions table (heartbeats - optional)
- git worktree list (worktree mappings)
```

## Health Checks

- **File size**: <10MB healthy, >50MB corrupted
- **Content**: Null content entries indicate corruption
- **Process**: CPU usage and responsiveness
- **Heartbeat**: PostgreSQL last_heartbeat timestamps
- **Worktree**: Uncommitted work detection

## Safety Features

- Never permanently deletes - always archives
- Confirms before destructive actions
- Protects uncommitted work
- Graceful degradation (works without PostgreSQL, jq)
- Clear error messages and recovery instructions

## Platform Support

- ✅ macOS (osascript for window management)
- ✅ Linux X11 (wmctrl for window management)
- ⚠️ Linux Wayland (compositor-dependent, limited)
- ❌ Windows (not yet supported)

## Usage Example

```bash
# List all sessions
/sessions

# Inspect a specific session
/sessions.inspect warm-floating-pancake

# Revive a stopped session
/sessions.revive warm-floating-pancake
# → Spawns terminal, shows: claude --resume <session-id>

# Clean up zombies
/sessions.cleanup
# → Interactive cleanup with confirmation

# Switch to another active session
/sessions.switch s009
# → Focuses terminal window
```

## Testing Checklist

- [x] Plugin manifest validates
- [x] All 5 commands documented
- [x] Session discovery skill complete
- [x] README with examples
- [ ] Test `/sessions` with multiple sessions
- [ ] Test `/sessions.inspect` with corrupted session
- [ ] Test `/sessions.revive` spawning terminal
- [ ] Test `/sessions.cleanup` archiving files
- [ ] Test `/sessions.switch` focusing windows

## Dependencies

- **Required**: Alacritty terminal emulator (or modify for your terminal)
- **Optional**: jq (for JSON parsing, has fallback)
- **Optional**: PostgreSQL (for enhanced tracking)
- **Platform**: macOS or Linux with X11

## Files Changed

- `.claude/plugins/session-wrangler/` - New plugin directory
  - `plugin.json` - Manifest
  - `README.md` - Documentation
  - `commands/*.md` - 5 command implementations
  - `skills/session-discovery/SKILL.md` - Discovery skill

## Related

This plugin complements the parallel workflow model where users run multiple Claude sessions across different worktrees for concurrent development.

## Next Steps

After merge:
1. Test with real multi-session workflow
2. Add support for more terminals (Kitty, WezTerm)
3. Add Windows support (Windows Terminal)
4. Consider session recovery automation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Session Wrangler plugin to manage multiple parallel Claude Code sessions across worktrees. Provides a unified view, health checks, and commands to inspect, revive, clean up, and switch sessions to reduce hangs, zombies, and lost context.

- **New Features**
  - /sessions: List all sessions with status (active, stale, zombie, resumable).
  - /sessions.inspect <session>: Deep analysis with diagnostics and recovery tips.
  - /sessions.revive <session>: Spawn terminal in the right worktree with resume instructions.
  - /sessions.cleanup: Kill zombies, archive corrupted files, close orphaned windows.
  - /sessions.switch <session>: Focus the existing terminal for quick navigation.

- **Dependencies**
  - Requires Alacritty for terminal spawning.
  - Optional: jq (JSON parsing), PostgreSQL (heartbeats/metadata).
  - Platform support: macOS and Linux X11; limited Wayland; Windows not supported.

<sup>Written for commit 3c89ca37f930f9151e9a2f66c2a970db1b1c4282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

