### PR TITLE
Fix Apple Silicon source setup and add a CPU-only development path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,7 +200,6 @@ tests/evaluation/results/*.md
 # Other AI agents (fully excluded unless you use them)
 .opencode/
 .windsurf/
-.gemini/
 .cursor/
 .qwen/
 .kilocode/
@@ -220,3 +219,10 @@ tests/evaluation/results/*.md
 # thoughts/ledgers/CONTINUITY_CLAUDE-*.md
 .continuous-claude-tmp/
 tests/evaluation/target/
+
+# gemini-cli settings
+.gemini/
+gemini/
+
+# GitHub App credentials
+gha-creds-*.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: help build test clean fmt lint audit check bench install
+.PHONY: help build release build-cpu build-mlx test test-cpu clean fmt lint audit check bench install install-cpu run-cpu run-mlx
+
+CPU_FEATURES := --no-default-features --features embedded-cpu
+MLX_FEATURES := --features embedded-mlx,embedded-cpu
+DEV_MODEL ?= smollm-135m-q4
+MLX_MODEL ?= qwen-0.5b-q4
+ARGS ?=
 
 # Default target
 help:
@@ -6,8 +12,11 @@ help:
 	@echo "Build Commands:"
 	@echo "  build          - Build the project in debug mode"
 	@echo "  release        - Build optimized release binary"
+	@echo "  build-cpu      - Build release binary for CPU-only local development"
+	@echo "  build-mlx      - Build release binary with Apple Silicon MLX support"
 	@echo "Test Commands (Clean Output):"
 	@echo "  test           - Run all tests quietly (default)"
+	@echo "  test-cpu       - Run library and integration tests for CPU-only builds"
 	@echo "  test-verbose   - Run all tests with verbose output"
 	@echo "  test-quiet     - Run tests with minimal output"
 	@echo "  test-show-output - Run tests showing stdout/stderr"
@@ -25,7 +34,10 @@ help:
 	@echo "Other:"
 	@echo "  bench     - Run benchmarks"
 	@echo "  clean     - Clean build artifacts"
-	@echo "  install   - Install cmdai locally"
+	@echo "  install   - Install caro locally"
+	@echo "  install-cpu - Install caro locally using the CPU-only feature set"
+	@echo "  run-cpu   - Run caro from source with the CPU-only feature set"
+	@echo "  run-mlx   - Run caro from source with MLX enabled"
 
 # Build commands
 build:
@@ -34,9 +46,18 @@ build:
 release:
 	cargo build --release
 
+build-cpu:
+	cargo build --release $(CPU_FEATURES)
+
+build-mlx:
+	cargo build --release $(MLX_FEATURES)
+
 # Test commands with cleaner output
 test:
 	RUST_LOG=warn cargo test -q --all-features
+
+test-cpu:
+	RUST_LOG=warn cargo test $(CPU_FEATURES)
 
 test-verbose:
 	RUST_LOG=debug cargo test --verbose --all-features
@@ -126,6 +147,9 @@ clean:
 install:
 	cargo install --path .
 
+install-cpu:
+	cargo install --path . $(CPU_FEATURES)
+
 # Development setup
 setup:
 	rustup component add rustfmt clippy
@@ -138,6 +162,12 @@ doc:
 # Run with debug logging
 run-debug:
 	RUST_LOG=debug cargo run --
+
+run-cpu:
+	CARO_MODEL=$(DEV_MODEL) cargo run $(CPU_FEATURES) -- $(ARGS)
+
+run-mlx:
+	CARO_MODEL=$(MLX_MODEL) cargo run $(MLX_FEATURES) -- $(ARGS)
 
 # Profile release build
 profile: release

--- a/README.md
+++ b/README.md
@@ -182,9 +182,10 @@ cargo install caro --features embedded-mlx
 
 #### Prerequisites
 - **Rust 1.83+** with Cargo (or latest stable recommended)
-- **CMake** (for model inference backends)
 - **macOS with Apple Silicon** (optional, for GPU acceleration)
-- **Xcode** (optional, for full MLX GPU support on Apple Silicon)
+- **CMake** (optional, only needed for the MLX GPU build on Apple Silicon)
+- **Protobuf** (optional, only needed for `knowledge` / `chromadb` feature work)
+- **Xcode** (optional, only needed for full MLX GPU support on Apple Silicon)
 
 ### Platform-Specific Setup
 
@@ -198,24 +199,25 @@ For complete macOS setup instructions including GPU acceleration, see [macOS Set
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 
-# Install CMake via Homebrew
-brew install cmake
-
 # Clone and build
 git clone https://github.com/wildcard/caro.git
 cd caro
-cargo build --release
+
+# Fast local development path (no full Xcode required)
+cargo build --release --no-default-features --features embedded-cpu
 
 # Run
-./target/release/caro "list all files"
+CARO_MODEL=smollm-135m-q4 ./target/release/caro "list all files"
 ```
 
 **For GPU Acceleration (Apple Silicon only):**
+- Install CMake via Homebrew: `brew install cmake`
 - Install Xcode from App Store (required for Metal compiler)
-- Build with: `cargo build --release --features embedded-mlx`
+- Build with: `cargo build --release --features embedded-mlx,embedded-cpu`
 - See [macOS Setup Guide](docs/MACOS_SETUP.md) for details
 
-**Note:** The default build uses a stub implementation that works immediately without Xcode. For production GPU acceleration, Xcode is required.
+**Note:** For Apple Silicon development without full Xcode, use the CPU-only build:
+`cargo build --release --no-default-features --features embedded-cpu`.
 
 #### Linux
 
@@ -265,16 +267,25 @@ cargo build --release
 git clone https://github.com/wildcard/caro.git
 cd caro
 
-# Build the project (uses CPU backend by default)
-cargo build --release
+# Fast local build that works on Apple Silicon without full Xcode
+cargo build --release --no-default-features --features embedded-cpu
 
 # Run the CLI
-./target/release/caro --version
+CARO_MODEL=smollm-135m-q4 ./target/release/caro --version
 ```
 
 ### Development Commands
 
 ```bash
+# CPU-only bring-up for Apple Silicon or general local development
+make build-cpu
+make test-cpu
+make run-cpu ARGS="list files"
+
+# Full Apple Silicon MLX build (requires CMake + full Xcode)
+make build-mlx
+make run-mlx ARGS="list files"
+
 # Run tests
 make test
 
@@ -285,10 +296,10 @@ make fmt
 make lint
 
 # Build optimized binary
-make build-release
+make release
 
 # Run with debug logging
-RUST_LOG=debug cargo run -- "your command"
+RUST_LOG=debug cargo run --no-default-features --features embedded-cpu -- "your command"
 ```
 
 ## 📖 Usage
@@ -629,6 +640,8 @@ For current usage, ChromaDB works well for basic command storage and retrieval, 
 - Cargo
 - Make (optional, for convenience commands)
 - Docker (optional, for development container)
+- Protobuf (optional, for `knowledge` / `chromadb` feature work)
+- CMake + full Xcode (optional, only for Apple Silicon MLX builds)
 
 ### Setup Development Environment
 
@@ -637,17 +650,23 @@ For current usage, ChromaDB works well for basic command storage and retrieval, 
 git clone https://github.com/wildcard/caro.git
 cd caro
 
-# Install dependencies and build
-cargo build
+# Install Rust components used by the repo
+rustup component add rustfmt clippy
 
-# Run tests
-cargo test
+# Fast local development build
+cargo build --no-default-features --features embedded-cpu
+
+# Run tests for the CPU-only path
+cargo test --no-default-features --features embedded-cpu
 
 # Check formatting
 cargo fmt -- --check
 
 # Run clippy linter
-cargo clippy -- -D warnings
+cargo clippy --no-default-features --features embedded-cpu -- -D warnings
+
+# First source run with a small development model
+CARO_MODEL=smollm-135m-q4 cargo run --no-default-features --features embedded-cpu -- "list files"
 ```
 
 ### Backend Configuration

--- a/docs/MACOS_SETUP.md
+++ b/docs/MACOS_SETUP.md
@@ -6,10 +6,11 @@ This guide covers setup for caro on macOS, with special attention to Apple Silic
 
 ### Required
 - **macOS**: 10.15 (Catalina) or later
-- **Rust**: 1.75 or later
+- **Rust**: 1.83 or later
 - **Homebrew**: Package manager for macOS
 
 ### Optional (for GPU acceleration)
+- **CMake**: Required for MLX builds on Apple Silicon
 - **Xcode**: Full Xcode installation for Metal compiler (Apple Silicon only)
 
 ## Quick Start (All Macs)
@@ -34,12 +35,17 @@ cargo --version
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-### 3. Install CMake
+### 3. Install Optional Native Dependencies
 
 ```bash
+# Only needed for MLX or knowledge-related feature work
+brew install protobuf
+
+# Only needed for MLX GPU builds
 brew install cmake
 
-# Verify installation
+# Verify optional tools
+protoc --version
 cmake --version
 ```
 
@@ -49,21 +55,21 @@ cmake --version
 git clone https://github.com/wildcard/caro.git
 cd caro
 
-# Build the project (uses CPU backend by default)
-cargo build --release
+# Fast local build that works without full Xcode
+cargo build --release --no-default-features --features embedded-cpu
 
 # Install locally
-cargo install --path .
+cargo install --path . --no-default-features --features embedded-cpu
 ```
 
 ### 5. Test Installation
 
 ```bash
 # Run a test command
-caro "list all files"
+CARO_MODEL=smollm-135m-q4 caro "list all files"
 
 # Or using cargo
-cargo run --release -- "find text files"
+CARO_MODEL=smollm-135m-q4 cargo run --release --no-default-features --features embedded-cpu -- "find text files"
 ```
 
 ## Apple Silicon GPU Acceleration
@@ -72,36 +78,36 @@ Apple Silicon (M1/M2/M3/M4) chips support GPU-accelerated inference via the MLX 
 
 ### Current Status
 
-The project includes a **fully functional stub implementation** that:
-- ✅ Correctly detects Apple Silicon hardware
-- ✅ Downloads and loads the 1.1GB Qwen model
-- ✅ Provides instant responses for testing and development
-- ✅ Works without any additional dependencies
+The recommended development path on Apple Silicon is now an explicit **CPU-only build** that:
+- ✅ Works with Rust alone and does not require full Xcode
+- ✅ Builds and runs from source on `macos/arm64`
+- ✅ Lets you use a small model for fast first-run setup
+- ✅ Keeps MLX as an upgrade path when you need GPU inference
 
-**For real GPU acceleration**, you need the Metal compiler from Xcode.
+**For real GPU acceleration**, you need both CMake and the Metal compiler from full Xcode.
 
-### Option 1: Stub Implementation (Recommended for Development)
+### Option 1: CPU-Only Development Build (Recommended for Bring-Up)
 
-**No additional setup required!** The default build works immediately:
+**No full Xcode required.** Build and run with the CPU feature set:
 
 ```bash
-# Build (automatically uses MLX stub on Apple Silicon)
-cargo build --release
+# Build for CPU-only local development
+cargo build --release --no-default-features --features embedded-cpu
 
-# Run - will use stub implementation
-cargo run --release -- "list files"
+# Run with a smaller first-download model
+CARO_MODEL=smollm-135m-q4 cargo run --release --no-default-features --features embedded-cpu -- "list files"
 ```
 
 **When to use:**
 - Quick testing and development
-- You don't want to install multi-GB Xcode
+- You want to avoid installing full Xcode
 - You're developing non-inference features
-- You want instant responses for integration testing
+- You want a smaller initial model download during bring-up
 
 **Performance:**
-- Model load: ~500ms (from disk)
-- Response time: ~100ms (simulated inference)
-- Memory: ~1.1GB (model file)
+- Model load: depends on the selected model
+- Response time: slower than MLX GPU mode
+- Memory: depends on the selected model
 
 ### Option 2: Full GPU Acceleration with Xcode
 
@@ -156,7 +162,7 @@ cd caro
 cargo clean
 
 # Build with MLX GPU acceleration
-cargo build --release --features embedded-mlx
+cargo build --release --features embedded-mlx,embedded-cpu
 
 # This will:
 # - Compile mlx-rs (may take 5-10 minutes first time)
@@ -168,7 +174,7 @@ cargo build --release --features embedded-mlx
 
 ```bash
 # Run with logging to see MLX initialization
-RUST_LOG=info cargo run --release -- "list all files"
+RUST_LOG=info cargo run --release --features embedded-mlx,embedded-cpu -- "list all files"
 
 # You should see:
 # INFO caro::backends::embedded::mlx: MLX GPU initialized
@@ -222,10 +228,10 @@ xcrun --find metal       # Should show Metal compiler path
 
 # Clean and rebuild
 cargo clean
-cargo build --release --features embedded-mlx
+cargo build --release --features embedded-mlx,embedded-cpu
 
-# If still failing, use stub implementation:
-cargo build --release  # Without embedded-mlx feature
+# If you only need local development, use the CPU-only path:
+cargo build --release --no-default-features --features embedded-cpu
 ```
 
 ### Model Download Issues
@@ -241,12 +247,12 @@ curl -I https://huggingface.co
 mkdir -p ~/.cache/caro/models
 cd ~/.cache/caro/models
 
-# Download from Hugging Face (1.1GB)
-curl -L -o qwen2.5-coder-1.5b-instruct-q4_k_m.gguf \
-  "https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/resolve/main/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf"
+# Download from Hugging Face (small dev model, ~82MB)
+curl -L -o smollm-135m-instruct-q4_k_m.gguf \
+  "https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct-GGUF/resolve/main/smollm-135m-instruct-q4_k_m.gguf"
 
 # Verify file
-ls -lh qwen2.5-coder-1.5b-instruct-q4_k_m.gguf
+ls -lh smollm-135m-instruct-q4_k_m.gguf
 ```
 
 ### "Failed to load model"
@@ -264,7 +270,7 @@ ls -lh ~/.cache/caro/models/
 rm ~/Library/Caches/caro/models/*.gguf
 
 # Rerun caro to trigger re-download
-cargo run --release -- "test"
+CARO_MODEL=smollm-135m-q4 cargo run --release --no-default-features --features embedded-cpu -- "test"
 ```
 
 ## Platform Detection
@@ -275,10 +281,10 @@ The project automatically detects your platform:
 # Check what backend will be used
 cargo test model_variant_detect --lib -- --nocapture
 
-# On Apple Silicon (M1/M2/M3/M4):
+# On Apple Silicon with `embedded-mlx` enabled:
 # ✅ ModelVariant::MLX
 
-# On Intel Mac or other platforms:
+# On Apple Silicon without `embedded-mlx`, or on other platforms:
 # ✅ ModelVariant::CPU
 ```
 
@@ -295,11 +301,11 @@ cargo build
 
 ### Release Build (Optimized)
 ```bash
-cargo build --release
+cargo build --release --no-default-features --features embedded-cpu
 # - Full optimizations
 # - Stripped debug symbols
 # - Binary size optimized
-# - Fast runtime
+# - Best default for Apple Silicon bring-up without Xcode
 ```
 
 ### Release with Debug Info (Profiling)
@@ -322,8 +328,8 @@ export RUST_LOG=info
 # Disable network access (test offline operation)
 export NO_NETWORK=1
 
-# Custom model cache directory
-export CARO_CACHE_DIR=~/custom/cache/path
+# Select a smaller dev model for first run
+export CARO_MODEL=smollm-135m-q4
 ```
 
 ## Uninstallation
@@ -388,8 +394,8 @@ For issues specific to macOS:
 
 ## Summary
 
-**For quick start**: Just install Rust, CMake, and build. Works immediately with stub implementation.
+**For quick start**: Install Rust, then use the CPU-only build path. It works immediately without full Xcode.
 
-**For production GPU acceleration**: Install Xcode, verify Metal compiler, and build with `--features embedded-mlx`.
+**For production GPU acceleration**: Install CMake and full Xcode, verify the Metal compiler, and build with `--features embedded-mlx,embedded-cpu`.
 
-Both modes are fully functional - the stub provides instant responses for development, while MLX provides real GPU-accelerated inference for production use.
+Both modes are supported: CPU-only is the easiest development bring-up, while MLX provides real GPU-accelerated inference for Apple Silicon.

--- a/docs/XCODE_SETUP.md
+++ b/docs/XCODE_SETUP.md
@@ -6,44 +6,42 @@ The `mlx-rs` crate requires Apple's **Metal compiler** to build GPU-accelerated 
 
 ## Current Status
 
-Your system has:
+Typical Apple Silicon development machines have:
 - ✅ Command Line Tools installed
-- ✅ CMake installed  
-- ✅ Rust toolchain configured
+- ✅ Enough tooling for CPU-only source builds
 - ❌ Metal compiler (requires full Xcode)
 
 ## Installation Options
 
-### Option 1: Use Stub Implementation (Current - No Xcode Needed)
+### Option 1: Use the CPU-Only Development Path (No Xcode Needed)
 
 **Status:** ✅ **WORKING NOW**
 
-The project includes a fully functional stub implementation that:
-- Detects Apple Silicon correctly
-- Loads the 1.1GB Qwen model
-- Provides instant responses
-- Perfect for development and testing
+The recommended bring-up path on Apple Silicon is a CPU-only build that:
+- Avoids full Xcode during initial setup
+- Builds and runs from source cleanly
+- Lets you start with a small model download
+- Keeps MLX as a separate upgrade step
 
 ```bash
 # This works RIGHT NOW without Xcode:
-cd /Users/kobi/personal/caro
-cargo run --release -- "list files"
+cd caro
+CARO_MODEL=smollm-135m-q4 cargo run --release --no-default-features --features embedded-cpu -- "list files"
 
-# Output:
-# INFO caro::cli: Using embedded backend only
-# INFO caro::backends::embedded::mlx: MLX model loaded from ...
-# Command: echo 'Please clarify your request'
+# Or build/install first:
+cargo build --release --no-default-features --features embedded-cpu
+cargo install --path . --no-default-features --features embedded-cpu
 ```
 
 **Pros:**
 - ✅ Works immediately
-- ✅ No multi-GB downloads
-- ✅ Fast responses (~100ms)
-- ✅ Full architecture validated
+- ✅ No multi-GB Xcode download
+- ✅ Clear, reproducible feature set
+- ✅ Good default for local development
 
 **Cons:**
-- ⚠️ Uses pattern matching, not real inference
-- ⚠️ Limited to pre-defined responses
+- ⚠️ Slower than MLX GPU mode
+- ⚠️ Not the highest-quality Apple Silicon path
 
 ### Option 2: Install Xcode for GPU Acceleration
 
@@ -85,13 +83,13 @@ metal --version
 #### Step 3: Build with MLX
 
 ```bash
-cd /Users/kobi/personal/caro
+cd caro
 
 # Clean previous build
 cargo clean
 
 # Build with MLX feature (this will take 5-10 minutes first time)
-cargo build --release --features embedded-mlx
+cargo build --release --features embedded-mlx,embedded-cpu
 
 # If successful, you'll see:
 # Compiling mlx-sys...
@@ -104,7 +102,7 @@ cargo build --release --features embedded-mlx
 
 ```bash
 # Run with info logging
-RUST_LOG=info cargo run --release -- "list all files recursively"
+RUST_LOG=info cargo run --release --features embedded-mlx,embedded-cpu -- "list all files recursively"
 
 # You should see different output indicating real inference:
 # INFO caro::backends::embedded::mlx: MLX GPU initialized
@@ -119,12 +117,12 @@ RUST_LOG=info cargo run --release -- "list all files recursively"
 ```bash
 # Check if Xcode is installed
 xcode-select -p
-# /Library/Developer/CommandLineTools = CLI tools only (stub mode)
+# /Library/Developer/CommandLineTools = CLI tools only (CPU-only mode)
 # /Applications/Xcode.app/... = Full Xcode (GPU mode available)
 
 # Check if Metal is available
 xcrun --find metal
-# Error = No full Xcode (stub mode)
+# Error = No full Xcode (CPU-only mode)
 # /Applications/... = Full Xcode (GPU mode available)
 
 # Check Xcode version (if installed)
@@ -143,21 +141,21 @@ echo 'kernel void test() {}' | metal -o /dev/null -
 # See what features are active
 cargo build --release --verbose 2>&1 | grep features
 
-# Default build (stub):
-# --features embedded-cpu
+# CPU-only build:
+# --no-default-features --features embedded-cpu
 
 # GPU build:
-# --features embedded-mlx
+# --features embedded-mlx,embedded-cpu
 ```
 
 ## Performance Comparison
 
-### Stub Implementation (Current)
+### CPU-Only Bring-Up
 ```
-First run:        ~500ms (model load from disk)
-Response time:    ~100ms (pattern matching)
-Memory:           ~1.1GB (model file in memory)
-Accuracy:         Limited to pre-defined patterns
+First run:        Depends on selected model download
+Response time:    Slower than MLX GPU mode
+Memory:           Depends on selected model
+Accuracy:         Suitable for development bring-up
 ```
 
 ### With Xcode + MLX GPU
@@ -171,11 +169,11 @@ Accuracy:         Full LLM capabilities
 
 ## Decision Guide
 
-### Use Stub Implementation If:
+### Use the CPU-Only Path If:
 - ✅ You want to start developing immediately
 - ✅ You're testing non-inference features
 - ✅ You don't want to install 15GB Xcode
-- ✅ You need fast, predictable responses
+- ✅ You want the smallest first-run setup
 - ✅ You're developing integration tests
 
 ### Install Xcode If:
@@ -188,32 +186,29 @@ Accuracy:         Full LLM capabilities
 ## Current Project Status
 
 ```
-Platform:         ✅ M4 Pro (Apple Silicon) detected
-Rust:             ✅ Installed and working
-CMake:            ✅ Installed and working
-Model:            ✅ 1.1GB Qwen model downloaded
-Stub Backend:     ✅ Fully functional
-MLX GPU:          ⏳ Awaiting Xcode installation
+Platform:         ✅ Apple Silicon detected
+CPU bring-up:     ✅ Available without full Xcode
+MLX GPU:          ⏳ Requires CMake + full Xcode
 ```
 
 ## Quick Commands Reference
 
 ```bash
-# Build with stub (works now)
-cargo build --release
+# Build with the CPU-only path (works now)
+cargo build --release --no-default-features --features embedded-cpu
 
 # Try to build with GPU (will fail without Xcode)
-cargo build --release --features embedded-mlx
+cargo build --release --features embedded-mlx,embedded-cpu
 
-# Run with stub
-cargo run --release -- "list files"
+# Run with CPU-only features
+CARO_MODEL=smollm-135m-q4 cargo run --release --no-default-features --features embedded-cpu -- "list files"
 
 # Check what's blocking GPU mode
 xcrun --find metal  # If error, need Xcode
 
 # After installing Xcode, rebuild
 cargo clean
-cargo build --release --features embedded-mlx
+cargo build --release --features embedded-mlx,embedded-cpu
 ```
 
 ## Support
@@ -222,13 +217,13 @@ If you encounter issues:
 
 1. **"metal: not found"** → Install full Xcode from App Store
 2. **"mlx-sys build failed"** → Run `xcode-select --switch /Applications/Xcode.app/...`
-3. **Stub responses only** → Either Xcode not installed, or not built with `--features embedded-mlx`
+3. **CPU backend selected** → Build with `--features embedded-mlx,embedded-cpu` after installing Xcode
 4. **CMake errors** → Update CMake: `brew upgrade cmake`
 
 ## Summary
 
-**Current state:** Everything works with stub implementation! The model is loaded, inference pipeline is operational, and you can use caro immediately.
+**Current state:** CPU-only source builds work without full Xcode, so you can start local development immediately.
 
-**To unlock GPU:** Install Xcode (15GB, ~30 min download), configure it, and rebuild with `--features embedded-mlx`.
+**To unlock GPU:** Install Xcode, ensure `xcrun --find metal` works, and rebuild with `--features embedded-mlx,embedded-cpu`.
 
-**Recommendation:** Keep using the stub for development, install Xcode when you need real inference for production use.
+**Recommendation:** Use the CPU-only path for bring-up and day-one development, then add Xcode when you need MLX performance.

--- a/src/backends/embedded/common.rs
+++ b/src/backends/embedded/common.rs
@@ -18,11 +18,18 @@ pub enum ModelVariant {
 impl ModelVariant {
     /// Auto-detect the best available model variant for the current platform
     pub fn detect() -> Self {
-        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "embedded-mlx"))]
         {
             Self::MLX
         }
-        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(any(
+            not(all(target_os = "macos", target_arch = "aarch64")),
+            all(
+                target_os = "macos",
+                target_arch = "aarch64",
+                not(feature = "embedded-mlx")
+            )
+        ))]
         {
             Self::CPU
         }
@@ -110,9 +117,16 @@ mod tests {
     #[test]
     fn test_model_variant_detect() {
         let variant = ModelVariant::detect();
-        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "embedded-mlx"))]
         assert_eq!(variant, ModelVariant::MLX);
-        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(any(
+            not(all(target_os = "macos", target_arch = "aarch64")),
+            all(
+                target_os = "macos",
+                target_arch = "aarch64",
+                not(feature = "embedded-mlx")
+            )
+        ))]
         assert_eq!(variant, ModelVariant::CPU);
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -535,7 +535,12 @@ impl CacheManager {
 
         // Get file metadata (size) using HEAD request
         let response = client.head_request(&url).await.map_err(|e| {
-            CacheError::DownloadFailed(format!("Failed to get file metadata: {}", e))
+            match CacheError::from(e) {
+                // Preserve the DownloadFailed contract used by cache get_model tests
+                // while keeping the underlying connection-related message intact.
+                CacheError::NetworkError(msg) => CacheError::DownloadFailed(msg),
+                other => other,
+            }
         })?;
 
         let file_size = response

--- a/src/model_loader.rs
+++ b/src/model_loader.rs
@@ -328,9 +328,16 @@ mod tests {
     #[test]
     fn test_detect_platform() {
         let variant = ModelLoader::detect_platform();
-        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "embedded-mlx"))]
         assert_eq!(variant, ModelVariant::MLX);
-        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(any(
+            not(all(target_os = "macos", target_arch = "aarch64")),
+            all(
+                target_os = "macos",
+                target_arch = "aarch64",
+                not(feature = "embedded-mlx")
+            )
+        ))]
         assert_eq!(variant, ModelVariant::CPU);
     }
 

--- a/tests/cli_interface_contract.rs
+++ b/tests/cli_interface_contract.rs
@@ -77,6 +77,10 @@ impl IntoCliArgs for TestArgs {
     fn force_llm(&self) -> bool {
         self.force_llm
     }
+
+    fn explain(&self) -> bool {
+        false
+    }
 }
 
 #[tokio::test]

--- a/tests/embedded_backend_contract.rs
+++ b/tests/embedded_backend_contract.rs
@@ -124,18 +124,25 @@ async fn test_performance_targets_mlx_vs_cpu() {
 fn test_platform_detection_automatic() {
     let variant = ModelVariant::detect();
 
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "embedded-mlx"))]
     assert_eq!(
         variant,
         ModelVariant::MLX,
-        "Must detect MLX on Apple Silicon"
+        "Must detect MLX on Apple Silicon when embedded-mlx is enabled"
     );
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(any(
+        not(all(target_os = "macos", target_arch = "aarch64")),
+        all(
+            target_os = "macos",
+            target_arch = "aarch64",
+            not(feature = "embedded-mlx")
+        )
+    ))]
     assert_eq!(
         variant,
         ModelVariant::CPU,
-        "Must detect CPU on other platforms"
+        "Must detect CPU when MLX is unavailable"
     );
 }
 

--- a/tests/execution_prompt_behavior.rs
+++ b/tests/execution_prompt_behavior.rs
@@ -77,6 +77,10 @@ impl IntoCliArgs for TestArgs {
     fn force_llm(&self) -> bool {
         self.force_llm
     }
+
+    fn explain(&self) -> bool {
+        false
+    }
 }
 
 #[tokio::test]

--- a/tests/mlx_integration_test.rs
+++ b/tests/mlx_integration_test.rs
@@ -9,17 +9,32 @@ use caro::models::{CommandRequest, ShellType};
 use caro::EmbeddedModelBackend;
 use std::path::PathBuf;
 
+fn expected_embedded_variant() -> ModelVariant {
+    #[cfg(feature = "embedded-mlx")]
+    {
+        ModelVariant::MLX
+    }
+
+    #[cfg(not(feature = "embedded-mlx"))]
+    {
+        ModelVariant::CPU
+    }
+}
+
 /// Test that verifies MLX is correctly detected on Apple Silicon
 #[test]
 fn test_mlx_platform_detection() {
     let variant = ModelVariant::detect();
+    let expected_variant = expected_embedded_variant();
     assert_eq!(
-        variant,
-        ModelVariant::MLX,
-        "M4 Pro should detect MLX backend"
+        variant, expected_variant,
+        "Unexpected embedded variant selected"
     );
 
-    println!("✅ Platform Detection: MLX correctly detected on Apple Silicon");
+    println!(
+        "✅ Platform Detection: {:?} selected on Apple Silicon",
+        expected_variant
+    );
 }
 
 /// Test that MLX backend can be instantiated
@@ -73,10 +88,13 @@ async fn test_embedded_backend_with_mlx() {
     assert!(backend.is_ok(), "EmbeddedModelBackend should create");
 
     let backend = backend.unwrap();
-    assert_eq!(backend.variant(), ModelVariant::MLX);
+    assert_eq!(backend.variant(), expected_embedded_variant());
     assert!(backend.is_available().await, "Backend should be available");
 
-    println!("✅ Embedded Backend: MLX variant working");
+    println!(
+        "✅ Embedded Backend: {:?} variant working",
+        expected_embedded_variant()
+    );
 
     let info = backend.backend_info();
     println!("   Backend Info:");
@@ -199,9 +217,12 @@ async fn test_mlx_full_integration() {
     assert!(backend.is_ok(), "Should create backend with real model");
 
     let backend = backend.unwrap();
-    assert_eq!(backend.variant(), ModelVariant::MLX);
+    assert_eq!(backend.variant(), expected_embedded_variant());
 
-    println!("✅ Backend created with MLX variant");
+    println!(
+        "✅ Backend created with {:?} variant",
+        expected_embedded_variant()
+    );
 
     // Test model download and inference
     let request = CommandRequest::new("list all files recursively", ShellType::Bash);
@@ -260,7 +281,6 @@ fn test_mlx_implementation_status() {
     println!("\n📊 MLX Implementation Status Report");
     println!("{}", "=".repeat(50));
 
-    // Platform
     let variant = ModelVariant::detect();
     println!("✅ Platform: {} (Apple Silicon)", variant);
 
@@ -277,10 +297,10 @@ fn test_mlx_implementation_status() {
 
     #[cfg(not(feature = "embedded-mlx"))]
     {
-        println!("⚠️  MLX Feature: Using stub implementation");
-        println!("   → Install CMAKE for full GPU acceleration");
-        println!("   → Run: brew install cmake");
-        println!("   → Build: cargo build --features embedded-mlx");
+        println!("⚠️  MLX Feature: Disabled in this build");
+        println!("   → CPU backend will be selected on Apple Silicon");
+        println!("   → Install CMake + full Xcode for GPU acceleration");
+        println!("   → Build: cargo build --features embedded-mlx,embedded-cpu");
     }
 
     // Model cache

--- a/tests/quickstart_scenarios.rs
+++ b/tests/quickstart_scenarios.rs
@@ -71,6 +71,10 @@ impl IntoCliArgs for TestArgs {
     fn force_llm(&self) -> bool {
         self.force_llm
     }
+
+    fn explain(&self) -> bool {
+        false
+    }
 }
 
 // =============================================================================

--- a/tests/regression_issue_161.rs
+++ b/tests/regression_issue_161.rs
@@ -78,6 +78,10 @@ impl IntoCliArgs for TestArgs {
     fn force_llm(&self) -> bool {
         self.force_llm
     }
+
+    fn explain(&self) -> bool {
+        false
+    }
 }
 
 // ==============================================================================


### PR DESCRIPTION
## Summary
- make Apple Silicon backend detection fall back to CPU when `embedded-mlx` is not compiled
- add CPU/MLX development targets to simplify local build, run, and install workflows
- update README and macOS/Xcode setup docs to document the CPU-first bring-up path and MLX upgrade path
- align tests and related setup helpers with the updated backend selection behavior
- tighten cache error handling for offline download failures

## Testing
- `cargo build --release --no-default-features --features embedded-cpu`
- `cargo test --no-default-features --features embedded-cpu`
- `./target/release/caro doctor`
- `./target/release/caro --force-llm --output json "list files"`
- `cargo install --path . --no-default-features --features embedded-cpu`