### PR TITLE
Research Codex Guardian and translate learnings into Caro roadmap artifacts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -230,6 +230,46 @@ gantt
 
 ---
 
+### ⚡ v1.3.0 - Core Features & Agent Integration
+**Due Date**: May 31, 2026
+**Status**: 0% Complete
+**Focus**: Universal agent integration, sandbox execution, and core UX improvements
+
+#### Key Deliverables
+
+- **Agent Integration Protocol** (ADR-015) — *Informed by Codex Guardian research*
+  - `caro validate --json` machine-readable subcommand
+  - Structured `AssessmentPayload` output: `decision`, `risk_score`, `rationale`, `suggested_alternative`
+  - Exit code contract: `0=allow`, `1=block`, `2=warn`, `3=error`
+  - Pre-built hooks: Claude Code (`~/.claude/hooks/pre-tool-use/`), shell preexec (bash/zsh)
+  - Drop-in alternative to Codex Guardian for non-Codex agents
+
+- **Sandbox Execution Phase 1** (ADR-010) — *Accelerated from v2.0.0*
+  - Linux bubblewrap integration (opt-in via `--sandbox` flag)
+  - Three sandbox profiles: strict, moderate, permissive
+  - `<500ms` overhead target
+  - Fail-safe: unavailable sandbox blocks execution (no silent bypass)
+
+- **Safety Module Refactor** — *Tech debt from Codex Guardian comparison*
+  - Decouple `SafetyPolicy` (rules) from `SafetyReviewer` (decision engine)
+  - `AssessmentPayload` type live in codebase (already added)
+  - Enables pluggable reviewers (pattern, LLM guardian, human) without god-object growth
+
+- **Core UX Features**
+  - Enhanced context with Starship integration (#670)
+  - OS/Distro preferences system (#669)
+  - Request memory tracking (#671)
+  - User feedback system MVP (#673)
+  - Proactive suggested queries (#674)
+
+**Success Criteria**:
+- `caro validate --json "rm -rf /"` returns well-formed JSON + exit code 1
+- Claude Code hook integration documented and tested end-to-end
+- Sandbox overhead measured <500ms p99 on Linux CI
+- Safety module refactor maintains 93.1%+ test pass rate
+
+---
+
 ### 🚀 v2.0.0 - Advanced Features
 **Due Date**: June 30, 2026 (184 days)
 **Status**: 38% Complete (13 open, 8 closed)
@@ -243,6 +283,8 @@ gantt
 - **Safety & Rules**
   - Research Dogma rule engine architecture (#126)
   - Add security hardening features (#6)
+  - Guardian Mode: LLM-assisted review for borderline commands (ADR-016) — *inspired by Codex Guardian*
+  - Community safety rule profiles: `caro rules install org/profile`
 
 - **AI Enhancements**
   - Research voice synthesis for Caro character (#160, #187)

--- a/docs/adr/ADR-015-universal-agent-integration-protocol.md
+++ b/docs/adr/ADR-015-universal-agent-integration-protocol.md
@@ -1,0 +1,351 @@
+# ADR-015: Universal Agent Integration Protocol
+
+**Status**: Proposed
+
+**Date**: 2026-03-25
+
+**Authors**: @wildcard
+
+**Target**: Community + Enterprise
+
+**Related**:
+- [ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) — Sandbox execution
+- [ADR-003](./ADR-003-monitoring-audit-trail.md) — Monitoring and audit trail
+- [ADR-016](./ADR-016-guardian-mode-llm-review.md) — Guardian Mode (LLM-assisted review)
+
+## Context
+
+### Inspiration: Codex Guardian
+
+OpenAI's Codex CLI (open source, Rust) ships an experimental feature called "Guardian"
+([PR #13860](https://github.com/openai/codex/pull/13860)) that automates approval decisions
+for agent actions using a risk-based AI subagent reviewer. It cleanly separates:
+
+- **approval_policy** — *when* a command requires review (untrusted, on-request, never)
+- **approvals_reviewer** — *who* reviews it (user or `guardian_subagent`)
+
+Guardian returns a structured **assessment payload**: `risk_score`, `rationale`, `action_summary`,
+`decision`. This payload is what drives both automated decisions and audit trails.
+
+Guardian is still **experimental** because:
+1. Assessment payload generation can fail silently (Issue #15341)
+2. The protocol is intentionally temporary while the design finalizes
+3. Risk scoring is not yet well-tuned (over-protective in some cases, permissive in others)
+4. It only works inside Codex CLI — not usable by other coder agents
+
+### The Problem Caro Must Solve
+
+Caro currently has no machine-readable output mode. Its safety validation returns human-readable
+text to the terminal. This means:
+
+- Coder agents (Claude Code, Cursor, GitHub Copilot, Aider) cannot call Caro as a safety
+  middleware layer without parsing terminal output
+- No structured exit-code contract for automation
+- No drop-in alternative to Codex Guardian for agents not using Codex
+- No path to integration with shell hooks, CI/CD pipelines, or approval workflows
+
+Today's agents implement safety in isolation (or not at all). Caro should be the reusable
+safety layer that any agent, script, or workflow can call.
+
+### Stakeholders
+
+- **Agent developers**: Need a simple, reliable subprocess API to invoke safety validation
+- **End users**: Want coder agents to automatically invoke Caro without manual configuration
+- **Enterprise users**: Need structured output for SIEM/audit log ingestion
+- **Shell scripters**: Need exit codes and JSON for composable pipelines
+
+## Decision
+
+We will add a **machine-readable validation protocol** to Caro, making it a universal
+safety middleware that any coder agent or script can call via subprocess.
+
+### Core Addition: `caro validate` Subcommand
+
+```bash
+# New subcommand (non-interactive, no execution)
+caro validate --json "rm -rf ./dist"
+```
+
+Exit codes (POSIX-compatible):
+- `0` — Safe, allowed
+- `1` — Blocked (dangerous pattern detected)
+- `2` — Warning (moderate risk, human review recommended)
+- `3` — Error (validator internal error)
+
+JSON output on stdout:
+```json
+{
+  "decision": "block",
+  "risk_score": 95,
+  "risk_level": "critical",
+  "rationale": "Recursive deletion of a relative path — could wipe project files if CWD is wrong",
+  "pattern_matched": "recursive_filesystem_deletion",
+  "suggested_alternative": "rm -rf ./dist/* (keeps directory, slightly safer) or trash ./dist",
+  "confidence_score": 1.0,
+  "execution_time_ms": 8,
+  "caro_version": "1.3.0"
+}
+```
+
+For allowed commands:
+```json
+{
+  "decision": "allow",
+  "risk_score": 2,
+  "risk_level": "safe",
+
+  "rationale": "No dangerous patterns detected",
+  "pattern_matched": null,
+  "suggested_alternative": null,
+  "confidence_score": 0.95,
+  "execution_time_ms": 4,
+  "caro_version": "1.3.0"
+}
+```
+
+For warnings:
+```json
+{
+  "decision": "warn",
+  "risk_score": 45,
+  "risk_level": "moderate",
+  "rationale": "Command modifies file permissions — verify target path is intentional",
+  "pattern_matched": "permission_modification",
+  "suggested_alternative": null,
+  "confidence_score": 0.9,
+  "execution_time_ms": 5,
+  "caro_version": "1.3.0"
+}
+```
+
+### Pre-built Agent Integration Hooks
+
+#### Claude Code (via hooks)
+
+`~/.claude/hooks/pre-tool-use/caro-validate.sh`:
+```bash
+#!/bin/bash
+# Caro safety validation hook for Claude Code
+# Blocks dangerous Bash commands before Claude executes them
+
+COMMAND="$CLAUDE_TOOL_INPUT_COMMAND"
+if [ -z "$COMMAND" ]; then exit 0; fi
+
+RESULT=$(caro validate --json "$COMMAND" 2>/dev/null)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 1 ]; then
+  RATIONALE=$(echo "$RESULT" | jq -r '.rationale')
+  echo "BLOCKED by Caro: $RATIONALE" >&2
+  exit 1
+fi
+
+exit 0
+```
+
+#### Shell preexec Hook (bash/zsh)
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+caro_preexec() {
+    local cmd="$1"
+    local result exit_code
+    result=$(caro validate --json "$cmd" 2>/dev/null)
+    exit_code=$?
+    if [ $exit_code -eq 1 ]; then
+        echo "⚠️  Caro blocked: $(echo "$result" | jq -r '.rationale')" >&2
+        return 1
+    fi
+}
+[[ -n "$ZSH_VERSION" ]] && preexec_functions+=(caro_preexec)
+[[ -n "$BASH_VERSION" ]] && trap 'caro_preexec "$BASH_COMMAND"' DEBUG
+```
+
+### Architecture
+
+The `validate` subcommand maps directly onto the existing `SafetyValidator` but adds:
+
+1. **`AssessmentPayload`** — Structured output type (see ADR implementation notes)
+2. **JSON serialization** — `serde_json` output to stdout
+3. **Exit code contract** — Deterministic process exit codes
+4. **No-execution guarantee** — `caro validate` NEVER executes the command
+
+```
+caro validate --json "rm -rf /"
+       │
+       ▼
+SafetyValidator::validate_command()
+       │
+       ▼
+ValidationResult → AssessmentPayload::from(result)
+       │
+       ▼
+serde_json::to_string_pretty(&payload) → stdout
+       │
+       ▼
+process::exit(exit_code)
+```
+
+### Difference from Default `caro` Behavior
+
+| Mode | Generates command | Validates | Executes | Output format |
+|------|------------------|-----------|----------|---------------|
+| `caro "query"` | Yes | Yes | Yes (with confirm) | Human-readable |
+| `caro validate "cmd"` | No | Yes | **Never** | JSON (--json flag) or human |
+| `caro validate --dry-run "query"` | Yes | Yes | **Never** | JSON |
+
+## Rationale
+
+### Why a Separate Subcommand?
+
+The `validate` subcommand keeps the separation clean:
+- No ambiguity about whether a command will execute
+- Simple subprocess interface — no state, no sessions, pure function
+- Works identically in interactive and CI/CD contexts
+- Easy to test: known input → deterministic JSON output
+
+### Why Match Codex Guardian's Assessment Payload Format?
+
+Teams already building with Codex Guardian should be able to drop in Caro with minimal
+changes to their tooling. Matching the conceptual payload fields (`risk_score`, `rationale`,
+`decision`) creates a de-facto community standard for safety assessment output.
+
+### Why Not a Daemon/Server?
+
+Caro's philosophy is stateless, single-binary operation. A daemon would:
+- Add installation complexity
+- Introduce state management bugs
+- Prevent use in sandboxed/containerized CI environments
+- Conflict with the "batteries included" single-binary design
+
+Subprocess calls are fast enough (<50ms) for agent use cases.
+
+### Why These Three Exit Codes?
+
+- `0/1` are universal (success/failure) — works in every shell and CI system
+- `2` for warnings distinguishes "probably fine, human should check" from "definitely blocked"
+- `3` for errors (not the command's fault) prevents silently allowing commands when the
+  validator itself fails
+
+## Consequences
+
+### Benefits
+
+1. **Universal adoption**: Any coder agent, script, or CI pipeline can call Caro
+2. **Drop-in Guardian replacement**: Projects using Codex Guardian can adopt Caro
+3. **Auditable output**: Structured JSON feeds directly into ADR-003 monitoring systems
+4. **Composable**: Unix-philosophy tool — validate | log | decide
+5. **Community standard**: Establishes assessment payload format others can build on
+
+### Trade-offs
+
+1. **Two surfaces to maintain**: Both the interactive CLI and the validate API
+2. **Version coupling**: Callers depend on JSON field names → breaking changes are painful
+3. **No streaming**: Batch commands must call the subprocess multiple times
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| JSON schema changes breaking callers | High | Semantic versioning + `caro_version` in payload |
+| Silent exit code misinterpretation | Medium | Document exit codes clearly, add `--exit-code-info` flag |
+| Performance impact on hot loops | Low | Benchmark; subprocess fork <20ms on modern hardware |
+
+## Alternatives Considered
+
+### Alternative 1: Library Crate
+
+Expose `caro-safety` as a separate crate that agents link against.
+
+- **Pros**: Zero subprocess overhead, native Rust integration
+- **Cons**: Version coupling, Rust-only, binary size impact for callers, complex distribution
+- **Why not chosen**: Subprocess is simpler, language-agnostic, and works for all agent types
+
+### Alternative 2: MCP Tool
+
+Expose Caro as an MCP server with a `validate_command` tool.
+
+- **Pros**: Native Claude Code integration, structured I/O
+- **Cons**: Requires running MCP server daemon, more complex than a simple CLI call, MCP-specific
+- **Why not chosen**: Subprocess approach works universally; MCP can be a future addition layered on top
+
+### Alternative 3: Extend Existing Flags
+
+Add `--validate-only --json` to the main `caro` command.
+
+- **Pros**: Fewer subcommands
+- **Cons**: Ambiguous — user might think it could still execute, flag combinations are harder to document
+- **Why not chosen**: Explicit `validate` subcommand is unambiguous and easier to hook safely
+
+## Implementation Notes
+
+### New Module: `src/cli/validate.rs`
+
+```rust
+pub struct ValidateArgs {
+    pub command: String,
+    pub json: bool,
+    pub shell: Option<ShellType>,
+}
+
+pub async fn run(args: ValidateArgs, config: &Config) -> Result<()> {
+    let validator = SafetyValidator::new(SafetyConfig::from_level(config.safety_level))?;
+    let result = validator.validate_command(&args.command, shell).await?;
+    let payload = AssessmentPayload::from(result);
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        // Human-readable output
+        println!("{}: {} (risk: {})", payload.decision, payload.rationale, payload.risk_level);
+    }
+
+    std::process::exit(payload.exit_code());
+}
+```
+
+### New Type: `AssessmentPayload` in `src/safety/mod.rs`
+
+See companion ADR implementation. The `AssessmentPayload` type wraps `ValidationResult`
+with agent-friendly field names and exit code semantics.
+
+### CLI Integration (`src/main.rs` / `src/cli/mod.rs`)
+
+```rust
+// Add to Args enum
+#[derive(Subcommand)]
+enum Commands {
+    // ... existing commands
+    Validate(ValidateArgs),
+}
+```
+
+### Testing Strategy
+
+1. **Unit**: `AssessmentPayload::from(ValidationResult)` field mapping
+2. **Integration**: `caro validate --json "rm -rf /"` → assert JSON fields + exit code 1
+3. **Contract**: JSON schema snapshot test (prevents silent breaking changes)
+4. **Hook**: Shell script test calling `caro validate` as a preexec hook
+
+## Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| JSON output latency | <50ms p99 |
+| Exit code reliability | 100% correct for known patterns |
+| Claude Code hook integration | Works out-of-box with documented hook |
+| Zero breaking changes | Additive-only JSON fields in patch versions |
+
+## References
+
+- [Codex Guardian PR #13860](https://github.com/openai/codex/pull/13860) — Smart approvals implementation
+- [Codex Guardian Issue #15341](https://github.com/openai/codex/issues/15341) — Assessment payload bug (what to avoid)
+- [ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) — Sandbox execution (complementary layer)
+- [ADR-016](./ADR-016-guardian-mode-llm-review.md) — Guardian Mode (LLM-assisted review layer)
+- [CLAUDE.md](../../CLAUDE.md) — Project architecture overview
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-03-25 | @wildcard | Initial draft, inspired by Codex Guardian research |

--- a/docs/adr/ADR-016-guardian-mode-llm-review.md
+++ b/docs/adr/ADR-016-guardian-mode-llm-review.md
@@ -1,0 +1,363 @@
+# ADR-016: Guardian Mode — LLM-Assisted Review for Borderline Commands
+
+**Status**: Proposed
+
+**Date**: 2026-03-25
+
+**Authors**: @wildcard
+
+**Target**: Community
+
+**Depends on**:
+- [ADR-015](./ADR-015-universal-agent-integration-protocol.md) — Universal Agent Integration Protocol (AssessmentPayload, validate subcommand)
+- [ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) — Sandbox execution
+
+## Context
+
+### The Limitation of Pure Pattern Matching
+
+Caro's current safety system uses 52 pre-compiled regex patterns to detect dangerous commands.
+This works excellently for clear-cut cases (`rm -rf /`, `mkfs`, fork bombs) but has a fundamental
+gap: **context-blind binary decisions on borderline commands**.
+
+Examples of commands that require semantic reasoning:
+- `find . -delete` — dangerous when CWD is `/`, routine in a build cleanup script
+- `chmod 777 /tmp/my-script` — likely fine; `chmod 777 /etc/passwd` — critical risk
+- `dd if=/dev/urandom of=./testfile bs=1M count=10` — safe; `dd if=/dev/urandom of=/dev/sda` — destroys disk
+- `kubectl delete pod my-pod` — routine; `kubectl delete namespace production` — catastrophic
+
+Pattern matching alone cannot distinguish these. The result: either false positives
+(blocking safe commands → user frustration) or false negatives (allowing dangerous
+commands → security gap).
+
+### The Codex Guardian Approach
+
+OpenAI's Codex Guardian (PR #13860) solves a related problem: replacing human approval decisions
+with an AI subagent reviewer. Guardian uses a "carefully prompted reviewer" that gathers context
+and applies a risk-based decision framework.
+
+Key architectural insights from Guardian:
+1. **Session-scoped LLM instance** — Guardian reuses the same reviewer subagent across
+   multiple approval requests in a session (PR #14668), sharing prompt cache for latency
+2. **Structured assessment payload** — Returns `risk_score`, `rationale`, `decision`
+3. **Complementary to pattern matching** — Guardian is an overlay, not a replacement for
+   policy-based rules
+
+Key reason Guardian is still experimental:
+- Assessment payload generation can fail silently → silent allow bugs
+- Trust calibration not yet tuned → both over-protective and permissive in different scenarios
+- Protocol design was finalized mid-implementation (payload schema was designed late)
+
+### The Opportunity for Caro
+
+Caro already has an embedded LLM backend. Unlike Codex Guardian which calls an external API,
+Caro can run the reviewer locally — no latency from network calls, no API cost, no privacy
+concern about sending commands to a remote service.
+
+The Dogma rule engine (v2.0.0 roadmap) is Caro's long-term answer to advanced safety rules.
+Guardian Mode is a focused, earlier implementation of the LLM-review concept that:
+- Ships sooner (targeted for v2.0.0 alongside Dogma, as a lighter parallel track)
+- Solves the immediate borderline command problem
+- Validates the LLM-as-reviewer architecture before Dogma's broader scope
+
+## Decision
+
+We will add **Guardian Mode** — an optional LLM-assisted review layer that supplements
+pattern matching for borderline commands.
+
+### Activation
+
+Guardian Mode is **opt-in** and explicitly configured:
+```toml
+# ~/.config/caro/config.toml
+[safety]
+guardian_mode = true          # Enable LLM-assisted review
+guardian_threshold = 0.4      # Invoke LLM when pattern confidence < 0.4 (0.0-1.0)
+guardian_backend = "embedded" # "embedded" | "ollama" | "none"
+guardian_timeout_ms = 2000    # Max time to wait for LLM review
+```
+
+Or via flag:
+```bash
+caro --guardian "find . -delete"
+caro validate --json --guardian "chmod 777 /tmp/script.sh"
+```
+
+### Decision Flow
+
+```
+Input command
+     │
+     ▼
+Pattern Matching (52 patterns)
+     │
+     ├─ CRITICAL/HIGH match → Block immediately (no LLM needed, high confidence)
+     │
+     ├─ MODERATE match + guardian_mode=true → LLM Review
+     │         │
+     │         ▼
+     │   Guardian LLM: "Is this safe in context?"
+     │         │
+     │         ├─ LLM says BLOCK → Block + explain
+     │         ├─ LLM says WARN → Warn + rationale
+     │         └─ LLM says ALLOW → Allow + confidence note
+     │
+     ├─ No match + confidence < threshold + guardian_mode=true → LLM Review
+     │         (catches novel patterns not in database)
+     │
+     └─ No match + high confidence → Allow (no LLM needed)
+```
+
+### Session-Scoped LLM Instance (Learning from Guardian PR #14668)
+
+The critical performance optimization from Codex Guardian: **reuse the LLM instance across
+multiple validations in a session**.
+
+```rust
+pub struct GuardianSession {
+    backend: Arc<dyn InferenceBackend>,
+    /// System prompt loaded once, cached for the session
+    system_prompt: String,
+    /// Session ID for audit trail correlation
+    session_id: Uuid,
+}
+
+impl GuardianSession {
+    /// Create once per Caro session (not per command)
+    pub fn new(backend: Arc<dyn InferenceBackend>) -> Self { ... }
+
+    /// Review a command — reuses the loaded model context
+    pub async fn review(&self, command: &str, context: &ExecutionContext)
+        -> Result<GuardianAssessment> { ... }
+}
+```
+
+This avoids re-loading the model for every command. For the embedded backend, model loading
+is the expensive operation (200-500ms); subsequent inferences are fast (50-150ms).
+
+### Guardian Prompt Design
+
+The system prompt is carefully designed to produce well-structured output every time
+(solving the silent payload failure that plagues Codex Guardian):
+
+```
+You are a shell command safety reviewer. Your job is to assess whether a given shell command
+is safe to execute in the described context.
+
+Respond ONLY with a JSON object in exactly this format (no other text):
+{
+  "decision": "allow" | "warn" | "block",
+  "risk_score": <0-100 integer>,
+  "rationale": "<one sentence explaining the decision>",
+  "suggested_alternative": "<safer command, or null>"
+}
+
+Rules:
+- "allow" (risk_score 0-30): command is routine and unlikely to cause harm
+- "warn" (risk_score 31-70): command could cause harm in some contexts; human should verify
+- "block" (risk_score 71-100): command is likely to cause irreversible harm
+
+Context provided: operating system, current directory, shell type.
+If the command is clearly safe (e.g., ls, cat, echo), respond with allow and risk_score < 10.
+If uncertain, prefer "warn" over "block" to avoid false positives.
+```
+
+Key design decisions to prevent Codex Guardian's payload bug:
+1. **JSON-only response** — Prompt explicitly forbids non-JSON text
+2. **Strict schema** — All fields required, no optional fields that could be omitted
+3. **Parse validation** — If response doesn't parse as valid JSON with all fields, it's a
+   validator error (exit code 3) — never a silent allow
+4. **Timeout with fallback** — If LLM doesn't respond within `guardian_timeout_ms`,
+   fall back to pattern-matching-only result (never silent allow)
+
+### AssessmentPayload Integration
+
+Guardian Mode output feeds into the same `AssessmentPayload` type defined in ADR-015:
+
+```rust
+pub struct AssessmentPayload {
+    pub decision: Decision,       // allow | warn | block
+    pub risk_score: u8,           // 0-100
+    pub risk_level: RiskLevel,    // safe | low | moderate | high | critical
+    pub rationale: String,        // Human-readable explanation
+    pub pattern_matched: Option<String>,
+    pub suggested_alternative: Option<String>,
+    pub confidence_score: f32,    // 0.0-1.0
+    pub reviewed_by: ReviewedBy,  // NEW: patterns | guardian | patterns+guardian
+    pub execution_time_ms: u64,
+    pub caro_version: String,
+}
+
+pub enum ReviewedBy {
+    PatternsOnly,
+    GuardianOnly,
+    PatternsAndGuardian,
+}
+```
+
+The `reviewed_by` field tells callers how the decision was made — important for audit trails.
+
+## Rationale
+
+### Why LLM Review Instead of More Patterns?
+
+Patterns are fast and deterministic but cannot capture semantic context. The combinatorial
+explosion of "dangerous in context X, safe in context Y" makes exhaustive patterns
+impractical. An LLM naturally handles this:
+
+- `find . -delete` in `/home/user/project` → low risk
+- `find . -delete` in `/` or `/etc` → critical
+- `dd ... of=/dev/sda` → critical
+- `dd ... of=./disk.img` → safe
+
+A pattern for each combination is unmaintainable. The LLM reasons naturally about context.
+
+### Why Opt-In (Not Default)?
+
+1. **Latency**: LLM adds 50-150ms per review — acceptable for interactive use, not for hot loops
+2. **Privacy**: Even the embedded backend processes the command text — users should consent
+3. **Reliability**: Pattern matching is 100% deterministic; LLM adds nondeterminism
+4. **Gradual rollout**: Opt-in lets us tune the guardian threshold before making it default
+
+### Why Not Default Guardian for Everything?
+
+Pattern matching is fast, deterministic, and highly accurate for known dangerous patterns.
+Guardian Mode is an overlay for borderline cases — it should not replace the pattern
+database for clear-cut dangerous commands. The combination is:
+- Fast + accurate for known patterns
+- Context-aware for borderline cases
+
+### Why Session-Scoped vs Per-Command LLM?
+
+Per-command initialization has O(n×model_load_time) cost. With 5-10 commands in a typical
+session, that's 1-5 seconds of total model loading overhead. Session-scoped initialization
+pays the model load cost once and amortizes it across all commands.
+
+## Consequences
+
+### Benefits
+
+1. **Near-zero false positives**: LLM can reason about context that patterns cannot
+2. **Novel attack detection**: LLM may catch dangerous patterns not in the 52-pattern database
+3. **Better user explanations**: LLM generates human-readable rationale (vs pattern description)
+4. **Suggested alternatives**: LLM can recommend safer commands
+5. **Local privacy**: Embedded backend — no command text sent to external services
+
+### Trade-offs
+
+1. **Latency increase**: +50-150ms for commands reviewed by guardian
+2. **Nondeterism**: LLM may give different answers to identical inputs (mitigated by prompt design)
+3. **Model dependency**: Quality depends on embedded model capability
+4. **Complexity**: Two code paths for safety decisions
+
+### Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| LLM generates non-JSON | Silent allow bug | Parse validation + timeout fallback → error, not allow |
+| LLM is over-protective | User frustration | Tune threshold; default threshold set conservatively |
+| LLM is under-protective | Security compromise | Pattern matching always runs first; LLM only for borderline |
+| Model unavailable | Guardian skipped | Configurable: `guardian_unavailable = "warn"/"skip"/"block"` |
+| Prompt injection via command | Manipulation | Commands sent as data fields, not as instructions |
+
+## Alternatives Considered
+
+### Alternative 1: More Patterns (Extend Pattern Database)
+
+Add context-aware patterns: `find.*-delete` with CWD context, `dd.*of=/dev/` etc.
+
+- **Pros**: Deterministic, fast, no LLM dependency
+- **Cons**: Combinatorial explosion, can't capture all contexts, maintenance burden
+- **Why not chosen**: Context-aware patterns become indistinguishable from a DSL — better to use LLM for this
+
+### Alternative 2: AST-Based Analysis (ADR-007)
+
+Parse shell commands into AST and reason about their effects symbolically.
+
+- **Pros**: Deterministic, fast, no LLM dependency
+- **Cons**: Shell parsing is complex (ADR-007 found this to be hard), incomplete coverage
+- **Decision**: ADR-007 (AST parser) is a complementary track, not a replacement for Guardian Mode
+
+### Alternative 3: Dogma Rule Engine Only (v2.0.0)
+
+Wait for Dogma's full rule engine to handle borderline cases.
+
+- **Pros**: Unified approach, more powerful
+- **Cons**: Dogma is more complex and further out; Guardian Mode can ship earlier with less scope
+- **Why not chosen**: Guardian Mode is a focused MVP; Dogma is the long-term platform
+
+### Alternative 4: External LLM API
+
+Call Claude API or OpenAI API for guardian reviews.
+
+- **Pros**: Highest quality reasoning, no local model required
+- **Cons**: Network latency, API cost, privacy (commands sent externally), offline not supported
+- **Why not chosen**: Conflicts with Caro's offline-first, privacy-first philosophy
+
+## Implementation Notes
+
+### Phase 1: Foundation (Alongside AssessmentPayload in ADR-015)
+
+- Add `AssessmentPayload` type with `reviewed_by` field
+- Add `GuardianSession` struct (disabled by default)
+- Add guardian-related fields to `SafetyConfig`
+
+### Phase 2: Embedded Backend Integration
+
+- Wire `GuardianSession` to embedded backend
+- Implement system prompt + JSON response parsing
+- Add timeout + fallback logic
+- Unit tests: mock LLM responses, test JSON parsing robustness
+
+### Phase 3: Integration + Threshold Tuning
+
+- Connect to `validate` subcommand (ADR-015)
+- Add `--guardian` CLI flag and `guardian_mode` config
+- Benchmark: measure latency overhead vs without guardian
+- Integration tests: known borderline commands → verify correct decisions
+
+### Module Structure
+
+```
+src/safety/
+├── mod.rs           # SafetyValidator, SafetyConfig, ValidationResult, AssessmentPayload (ADR-015)
+├── patterns.rs      # Pattern database (unchanged)
+├── guardian/        # NEW
+│   ├── mod.rs       # GuardianSession, GuardianAssessment
+│   ├── prompt.rs    # System prompt templates
+│   └── parser.rs    # JSON response parsing + validation
+└── validator.rs     # Orchestrator: patterns → optional guardian → AssessmentPayload
+```
+
+### Testing Strategy
+
+1. **Unit**: JSON response parsing — test all valid/invalid response shapes
+2. **Unit**: Timeout fallback — verify guardian timeout returns pattern-only result
+3. **Integration**: End-to-end with embedded backend (requires model)
+4. **Property**: Known borderline commands evaluated by guardian (snapshot/regression tests)
+5. **Security**: Prompt injection attempts via crafted command strings
+
+## Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| False positive rate reduction | >50% reduction on borderline commands vs patterns-only |
+| Guardian review latency | <200ms p95 (after session warm-up) |
+| JSON parse reliability | 100% — no silent allows from parse failures |
+| Timeout reliability | 100% — timeouts always return pattern-only result, never silent allow |
+| User opt-in rate | >20% of users enable guardian mode within 6 months of release |
+
+## References
+
+- [Codex Guardian PR #13860](https://github.com/openai/codex/pull/13860) — Smart approvals
+- [Codex Guardian session caching PR #14668](https://github.com/openai/codex/pull/14668) — Session reuse
+- [Codex Guardian Issue #15341](https://github.com/openai/codex/issues/15341) — Assessment payload failure (what to avoid)
+- [ADR-007](./ADR-007-ast-parser-shell-validation.md) — AST-based validation (complementary)
+- [ADR-015](./ADR-015-universal-agent-integration-protocol.md) — Universal Agent Integration Protocol
+- [ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) — Sandbox execution
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-03-25 | @wildcard | Initial draft, informed by Codex Guardian research |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,8 @@ Example: `ADR-001-enterprise-community-architecture.md`
 | [ADR-012](./ADR-012-honggfuzz-integration.md) | Honggfuzz Integration for Security-Critical Fuzz Testing | Proposed | 2026-01-02 |
 | [ADR-013](./ADR-013-pre-processing-pipeline.md) | Pre-Processing Pipeline Architecture | Proposed | 2026-01-01 |
 | [ADR-014](./ADR-014-serde-env-evaluation.md) | Environment Variable Deserialization with serde-env | Proposed | 2026-01-01 |
+| [ADR-015](./ADR-015-universal-agent-integration-protocol.md) | Universal Agent Integration Protocol | Proposed | 2026-03-25 |
+| [ADR-016](./ADR-016-guardian-mode-llm-review.md) | Guardian Mode — LLM-Assisted Review for Borderline Commands | Proposed | 2026-03-25 |
 
 ## Contributing to ADRs
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,6 +444,27 @@ enum Commands {
         #[arg(short, long, default_value = "5")]
         limit: usize,
     },
+
+    /// Validate a shell command for safety without executing it (ADR-015)
+    ///
+    /// Exits 0=allow, 1=block, 2=warn, 3=error.
+    /// Use --json for machine-readable output (agent/script integration).
+    Validate {
+        /// The shell command to validate
+        command: String,
+
+        /// Output structured JSON assessment payload
+        #[arg(long)]
+        json: bool,
+
+        /// Shell type to validate against: bash, zsh, fish, sh (default: auto-detect)
+        #[arg(short, long)]
+        shell: Option<String>,
+
+        /// Safety level: strict | moderate | permissive (default: moderate)
+        #[arg(long)]
+        safety: Option<String>,
+    },
     // /// Manage telemetry data and settings
     // Telemetry {
     //     #[command(subcommand)]
@@ -1035,6 +1056,65 @@ fn handle_config_command(command: ConfigCommands) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+// =============================================================================
+// Validate Command (ADR-015: Universal Agent Integration Protocol)
+// =============================================================================
+
+/// Validate a shell command for safety and return a structured assessment.
+///
+/// This is the core of `caro validate --json` — a pure safety check with no
+/// command generation or execution. Designed for agent/script integration:
+///
+/// ```bash
+/// caro validate --json "rm -rf /"   # exit 1, JSON decision=block
+/// caro validate --json "ls -la"     # exit 0, JSON decision=allow
+/// ```
+///
+/// Exit codes: 0=allow, 1=block, 2=warn, 3=internal error
+async fn handle_validate_command(
+    command: String,
+    shell_arg: Option<String>,
+    safety_arg: Option<String>,
+) -> Result<caro::safety::AssessmentPayload, String> {
+    use std::str::FromStr;
+    use std::time::Instant;
+
+    // Resolve shell: CLI arg → auto-detect
+    let shell = match shell_arg {
+        Some(ref s) => caro::models::ShellType::from_str(s).unwrap_or_else(|_| {
+            caro::models::ShellType::detect()
+        }),
+        None => caro::models::ShellType::detect(),
+    };
+
+    // Resolve safety level: CLI arg → moderate default
+    let safety_level = match safety_arg {
+        Some(ref s) => s
+            .parse::<caro::models::SafetyLevel>()
+            .unwrap_or(caro::models::SafetyLevel::Moderate),
+        None => caro::models::SafetyLevel::Moderate,
+    };
+
+    let config = caro::safety::SafetyConfig::from_level(safety_level);
+    let validator = caro::safety::SafetyValidator::new(config)
+        .map_err(|e| format!("Failed to initialize safety validator: {e}"))?;
+
+    let start = Instant::now();
+    let result = validator
+        .validate_command(&command, shell)
+        .await
+        .map_err(|e| format!("Validation error: {e}"))?;
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+
+    let mut payload = caro::safety::AssessmentPayload::from_validation(
+        result,
+        caro::safety::ReviewedBy::PatternsOnly,
+    );
+    payload.execution_time_ms = elapsed_ms;
+
+    Ok(payload)
 }
 
 // =============================================================================
@@ -1901,6 +1981,45 @@ async fn main() {
         //         }
         //     }
         // }
+        Some(Commands::Validate {
+            command,
+            json,
+            shell,
+            safety,
+        }) => {
+            match handle_validate_command(command, shell, safety).await {
+                Ok(payload) => {
+                    let exit_code = payload.exit_code();
+                    if json {
+                        match serde_json::to_string_pretty(&payload) {
+                            Ok(s) => println!("{s}"),
+                            Err(e) => {
+                                eprintln!("caro: failed to serialize assessment: {e}");
+                                process::exit(3);
+                            }
+                        }
+                    } else {
+                        let status = match payload.decision {
+                            caro::safety::Decision::Allow => "✓ ALLOW",
+                            caro::safety::Decision::Warn => "⚠ WARN ",
+                            caro::safety::Decision::Block => "✗ BLOCK",
+                        };
+                        println!(
+                            "{status}  risk={}/100  {}",
+                            payload.risk_score, payload.rationale
+                        );
+                        if let Some(alt) = &payload.suggested_alternative {
+                            println!("  Suggested: {alt}");
+                        }
+                    }
+                    process::exit(exit_code);
+                }
+                Err(e) => {
+                    eprintln!("caro validate: {e}");
+                    process::exit(3);
+                }
+            }
+        }
         None => {
             // Continue to regular command generation
         }

--- a/src/safety/mod.rs
+++ b/src/safety/mod.rs
@@ -68,6 +68,135 @@ pub struct ValidationResult {
     pub confidence_score: f32,
 }
 
+/// Machine-readable assessment payload for agent integration (ADR-015)
+///
+/// Structured output for the `caro validate --json` subcommand and Guardian Mode (ADR-016).
+/// Designed to be a community standard format that coder agents (Claude Code, Cursor, etc.)
+/// can parse to make automated safety decisions — equivalent to Codex Guardian's assessment
+/// payload but available as a universal, agent-agnostic interface.
+///
+/// # Exit Code Contract
+///
+/// Use [`AssessmentPayload::exit_code`] to get the POSIX exit code:
+/// - `0` — allow
+/// - `1` — block
+/// - `2` — warn
+/// - `3` — validator error
+///
+/// # Example
+///
+/// ```no_run
+/// use caro::safety::{SafetyValidator, SafetyConfig, AssessmentPayload};
+/// use caro::models::ShellType;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let validator = SafetyValidator::new(SafetyConfig::moderate())?;
+/// let result = validator.validate_command("ls -la", ShellType::Bash).await?;
+/// let payload = AssessmentPayload::from_validation(result, ReviewedBy::PatternsOnly);
+///
+/// assert_eq!(payload.decision, Decision::Allow);
+/// assert_eq!(payload.exit_code(), 0);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssessmentPayload {
+    /// Final decision: allow, warn, or block
+    pub decision: Decision,
+    /// Risk score from 0 (safe) to 100 (critical danger)
+    pub risk_score: u8,
+    /// Risk level derived from score and patterns
+    pub risk_level: RiskLevel,
+    /// Human-readable explanation of the decision
+    pub rationale: String,
+    /// Name of the matched danger pattern, if any
+    pub pattern_matched: Option<String>,
+    /// A safer alternative command, if one can be suggested
+    pub suggested_alternative: Option<String>,
+    /// Confidence in the decision (0.0–1.0)
+    pub confidence_score: f32,
+    /// What performed the review (patterns, guardian LLM, or both)
+    pub reviewed_by: ReviewedBy,
+    /// Time taken to produce this assessment in milliseconds
+    pub execution_time_ms: u64,
+    /// Caro version that produced this payload (for schema versioning)
+    pub caro_version: String,
+}
+
+/// Final safety decision
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Decision {
+    /// Command is safe to execute
+    Allow,
+    /// Command may be risky in some contexts — human review recommended
+    Warn,
+    /// Command is dangerous and should not execute
+    Block,
+}
+
+/// Which validation layer(s) produced this assessment
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewedBy {
+    /// Pattern matching only (fast, deterministic)
+    PatternsOnly,
+    /// LLM-assisted Guardian Mode only
+    GuardianOnly,
+    /// Pattern matching + Guardian Mode LLM review
+    PatternsAndGuardian,
+}
+
+impl AssessmentPayload {
+    /// Convert a `ValidationResult` into a structured `AssessmentPayload`
+    pub fn from_validation(result: ValidationResult, reviewed_by: ReviewedBy) -> Self {
+        let decision = if result.allowed {
+            if result.warnings.is_empty() {
+                Decision::Allow
+            } else {
+                Decision::Warn
+            }
+        } else {
+            Decision::Block
+        };
+
+        let risk_score = match result.risk_level {
+            RiskLevel::Safe => 2,
+            RiskLevel::Moderate => 50,
+            RiskLevel::High => 75,
+            RiskLevel::Critical => 95,
+        };
+
+        let pattern_matched = result.matched_patterns.first().cloned();
+
+        Self {
+            decision,
+            risk_score,
+            risk_level: result.risk_level,
+            rationale: result.explanation,
+            pattern_matched,
+            suggested_alternative: None, // Populated by Guardian Mode (ADR-016)
+            confidence_score: result.confidence_score,
+            reviewed_by,
+            execution_time_ms: 0, // Caller should fill this in
+            caro_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    /// POSIX exit code for use with `caro validate`
+    ///
+    /// - `0` — allow
+    /// - `1` — block
+    /// - `2` — warn
+    pub fn exit_code(&self) -> i32 {
+        match self.decision {
+            Decision::Allow => 0,
+            Decision::Block => 1,
+            Decision::Warn => 2,
+        }
+    }
+}
+
 /// Pattern definition for dangerous command detection
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DangerPattern {

--- a/tests/validate_subcommand.rs
+++ b/tests/validate_subcommand.rs
@@ -1,0 +1,194 @@
+/// Integration tests for `caro validate` subcommand (ADR-015)
+///
+/// Tests the exit code contract and JSON assessment payload against known
+/// dangerous, safe, and borderline commands.
+///
+/// Exit code contract:
+///   0 = allow
+///   1 = block
+///   2 = warn
+///   3 = internal error
+use caro::{
+    models::ShellType,
+    safety::{AssessmentPayload, Decision, ReviewedBy, SafetyConfig, SafetyValidator},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Run the validate handler logic directly (mirrors handle_validate_command in main.rs)
+async fn validate(command: &str) -> AssessmentPayload {
+    let config = SafetyConfig::moderate();
+    let validator = SafetyValidator::new(config).expect("validator init");
+    let result = validator
+        .validate_command(command, ShellType::Bash)
+        .await
+        .expect("validation should not error");
+    AssessmentPayload::from_validation(result, ReviewedBy::PatternsOnly)
+}
+
+// ---------------------------------------------------------------------------
+// Exit code contract
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_validate_dangerous_exits_block() {
+    let payload = validate("rm -rf /").await;
+    assert_eq!(
+        payload.decision,
+        Decision::Block,
+        "rm -rf / must be blocked"
+    );
+    assert_eq!(payload.exit_code(), 1, "block → exit 1");
+}
+
+#[tokio::test]
+async fn test_validate_safe_command_exits_allow() {
+    let payload = validate("ls -la").await;
+    assert_eq!(payload.decision, Decision::Allow, "ls -la must be allowed");
+    assert_eq!(payload.exit_code(), 0, "allow → exit 0");
+}
+
+#[tokio::test]
+async fn test_validate_fork_bomb_exits_block() {
+    let payload = validate(":(){ :|:& };:").await;
+    assert_eq!(payload.decision, Decision::Block, "fork bomb must be blocked");
+    assert_eq!(payload.exit_code(), 1);
+}
+
+#[tokio::test]
+async fn test_validate_disk_wipe_exits_block() {
+    let payload = validate("dd if=/dev/random of=/dev/sda").await;
+    assert_eq!(payload.decision, Decision::Block, "disk wipe must be blocked");
+    assert_eq!(payload.exit_code(), 1);
+}
+
+#[tokio::test]
+async fn test_validate_safe_commands_all_allow() {
+    let safe = ["pwd", "echo hello", "cat README.md", "git status", "cargo build"];
+    for cmd in safe {
+        let payload = validate(cmd).await;
+        assert_eq!(
+            payload.decision,
+            Decision::Allow,
+            "safe command '{cmd}' should be allowed"
+        );
+        assert_eq!(payload.exit_code(), 0, "safe command '{cmd}' → exit 0");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AssessmentPayload field contract
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_payload_has_required_fields() {
+    let payload = validate("rm -rf /").await;
+
+    // All fields must be populated
+    assert!(!payload.rationale.is_empty(), "rationale must not be empty");
+    assert!(payload.risk_score > 0, "dangerous command must have risk_score > 0");
+    assert!(!payload.caro_version.is_empty(), "caro_version must be set");
+
+    // reviewed_by must indicate patterns-only (no LLM in basic validate)
+    assert!(
+        matches!(payload.reviewed_by, ReviewedBy::PatternsOnly),
+        "basic validate must use PatternsOnly"
+    );
+}
+
+#[tokio::test]
+async fn test_payload_safe_command_risk_score() {
+    let payload = validate("ls -la").await;
+    // Safe commands should have low risk scores
+    assert!(
+        payload.risk_score < 50,
+        "safe command risk_score should be < 50, got {}",
+        payload.risk_score
+    );
+}
+
+#[tokio::test]
+async fn test_payload_dangerous_command_risk_score() {
+    let payload = validate("rm -rf /").await;
+    // Critical dangerous commands should have high risk scores
+    assert!(
+        payload.risk_score >= 70,
+        "rm -rf / risk_score should be >= 70, got {}",
+        payload.risk_score
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialisation contract
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_payload_serialises_to_valid_json() {
+    let payload = validate("rm -rf /").await;
+    let json = serde_json::to_string_pretty(&payload).expect("must serialize to JSON");
+
+    // All required top-level fields present
+    assert!(json.contains("\"decision\""), "JSON must contain decision");
+    assert!(json.contains("\"risk_score\""), "JSON must contain risk_score");
+    assert!(json.contains("\"risk_level\""), "JSON must contain risk_level");
+    assert!(json.contains("\"rationale\""), "JSON must contain rationale");
+    assert!(json.contains("\"confidence_score\""), "JSON must contain confidence_score");
+    assert!(json.contains("\"reviewed_by\""), "JSON must contain reviewed_by");
+    assert!(json.contains("\"caro_version\""), "JSON must contain caro_version");
+}
+
+#[tokio::test]
+async fn test_payload_decision_field_is_lowercase() {
+    // Agents depend on lowercase decision values: "allow", "block", "warn"
+    let block = validate("rm -rf /").await;
+    let json = serde_json::to_string(&block).expect("serialize");
+    assert!(
+        json.contains("\"block\""),
+        "decision must be lowercase 'block' in JSON, got: {json}"
+    );
+
+    let allow = validate("ls -la").await;
+    let json = serde_json::to_string(&allow).expect("serialize");
+    assert!(
+        json.contains("\"allow\""),
+        "decision must be lowercase 'allow' in JSON, got: {json}"
+    );
+}
+
+#[tokio::test]
+async fn test_payload_deserialises_roundtrip() {
+    // JSON roundtrip: serialize then deserialize and compare key fields
+    let payload = validate("rm -rf /").await;
+    let json = serde_json::to_string(&payload).expect("serialize");
+    let recovered: AssessmentPayload = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(payload.decision, recovered.decision);
+    assert_eq!(payload.risk_score, recovered.risk_score);
+    assert_eq!(payload.rationale, recovered.rationale);
+    assert_eq!(payload.caro_version, recovered.caro_version);
+}
+
+// ---------------------------------------------------------------------------
+// Shell-specific validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_validate_respects_shell_type() {
+    // Both Bash and Zsh should catch rm -rf /
+    for shell in [ShellType::Bash, ShellType::Zsh, ShellType::Sh] {
+        let config = SafetyConfig::moderate();
+        let validator = SafetyValidator::new(config).expect("validator init");
+        let result = validator
+            .validate_command("rm -rf /", shell)
+            .await
+            .expect("validation should not error");
+        let payload = AssessmentPayload::from_validation(result, ReviewedBy::PatternsOnly);
+        assert_eq!(
+            payload.decision,
+            Decision::Block,
+            "rm -rf / must be blocked for shell {shell:?}"
+        );
+    }
+}


### PR DESCRIPTION
- Add ADR-015: Universal Agent Integration Protocol — defines `caro validate --json`
  machine-readable subcommand and pre-built hooks for Claude Code, Cursor, and shell
  preexec. Structured AssessmentPayload format inspired by Codex Guardian's assessment
  payload, designed as a universal drop-in for any coder agent.

- Add ADR-016: Guardian Mode — LLM-assisted review for borderline commands. Session-scoped
  LLM reviewer (learning from Codex PR #14668 session caching), strict JSON-only prompt
  to prevent Codex's silent payload failure bug (Issue #15341), timeout fallback to
  pattern-only (never silent allow).

- Add AssessmentPayload, Decision, ReviewedBy types to src/safety/mod.rs — the structured
  output foundation required by both ADRs and the eventual `caro validate --json` subcommand.

- Update ROADMAP.md: add full v1.3.0 milestone section (agent integration protocol +
  sandbox Phase 1 accelerated from v2.0.0 + safety module refactor). Add Guardian Mode
  and community rule profiles to v2.0.0 deliverables.

- Update docs/adr/README.md with ADR-015 and ADR-016 index entries.

https://claude.ai/code/session_013E2o4mEmDQvfA6WAjzMjCY