### PR TITLE
fix(ci): install protoc and cmake in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,9 @@ jobs:
           path: target
           key: ${{ runner.os }}-${{ env.RUST_VERSION }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install system dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y protobuf-compiler cmake
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
## Problem

The `v1.2.0` publish to crates.io failed because `protoc` (protobuf compiler) is not installed in the Ubuntu CI runner, but `lance-encoding` (knowledge feature) requires it at build time.

**Error:** `Could not find 'protoc'. If 'protoc' is installed, try setting the PROTOC environment variable`

## Fix

Add `protobuf-compiler cmake` to the apt-get install step in `.github/workflows/publish.yml` before any cargo steps.

## Verification

After merge, we can re-trigger the publish workflow manually for `v1.2.0`:
```bash
gh workflow run publish.yml --ref v1.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix publish workflow by installing `protobuf-compiler` (`protoc`) and `cmake` on the Ubuntu runner before any Cargo steps. This unblocks crates.io publishing by allowing `lance-encoding` to compile its protobufs during build.

<sup>Written for commit f55b035966cfa2a374d561a67344d37220367a43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

