### PR TITLE
fix(knowledge): avoid usize::MAX overflow in LanceDB limit cast

### DIFF
--- a/src/knowledge/migration.rs
+++ b/src/knowledge/migration.rs
@@ -72,7 +72,8 @@ pub async fn export_entries<P: AsRef<Path>>(
 ) -> Result<usize> {
     // Get all entries by querying with empty string (returns all)
     // Note: This is a workaround - ideally we'd have a get_all() method
-    let entries = backend.find_similar("", usize::MAX).await?;
+    // Use i64::MAX as usize to avoid overflow when LanceDB casts the limit to i64
+    let entries = backend.find_similar("", i64::MAX as usize).await?;
     let total = entries.len();
 
     let file = std::fs::File::create(output_path)?;


### PR DESCRIPTION
## Problem

`test_export_import_roundtrip` fails in the publish CI with:
```
panicked at src/knowledge/migration.rs:286:14:
called `Result::unwrap()` on an `Err` value: Database("lance error: Invalid user input: Limit must be non-negative")
```

`export_entries` calls `find_similar("", usize::MAX)`. LanceDB casts the limit to `i64` internally, and `usize::MAX` (18446744073709551615) overflows to `-1`, triggering the "Limit must be non-negative" check.

## Fix

Replace `usize::MAX` with `i64::MAX as usize` which is the largest value that fits in both `usize` and `i64` without overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix panic in knowledge export by avoiding `usize::MAX` overflow when LanceDB casts the limit to `i64`. Use `i64::MAX as usize` in `find_similar("")` so `export_entries` fetches all entries without triggering "Limit must be non-negative" and unblocks CI.

<sup>Written for commit b778bf636aee53e24f10a79bc1e27ae651413b1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

