### PR TITLE
feat: add Paperclip AI agent orchestration integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ embedded-mlx = ["cxx", "llama_cpp"]
 embedded-cpu = ["candle-core", "candle-transformers"]
 knowledge = ["lancedb", "fastembed", "arrow-array", "arrow-schema"]
 chromadb = ["knowledge", "dep:chromadb"]  # ChromaDB backend (requires knowledge base features)
+paperclip = ["remote-backends"]  # Paperclip AI agent orchestration integration
 
 [profile.release]
 # Optimize for binary size (<50MB target)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ pub mod version;
 #[cfg(feature = "knowledge")]
 pub mod knowledge;
 
+#[cfg(feature = "paperclip")]
+pub mod paperclip;
+
 // Re-export commonly used types for convenience
 pub use model_catalog::{ModelCatalog, ModelInfo, ModelSize};
 pub use models::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,7 +475,6 @@ enum Commands {
     //     #[command(subcommand)]
     //     command: caro::cli::telemetry::TelemetryCommands,
     // },
-
     /// Run as a Paperclip AI managed agent (requires --features paperclip)
     #[cfg(feature = "paperclip")]
     Paperclip {
@@ -1711,7 +1710,10 @@ async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), Stri
             println!("  Agent ID:  {}", config.agent_id.cyan());
             println!("  API URL:   {}", config.api_url);
             println!("  Run ID:    {}", config.run_id);
-            println!("  API Key:   {}...", &config.api_key[..config.api_key.len().min(8)]);
+            println!(
+                "  API Key:   {}...",
+                &config.api_key[..config.api_key.len().min(8)]
+            );
             Ok(())
         }
         PaperclipCommands::Status => {
@@ -1737,21 +1739,15 @@ async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), Stri
 
             // Build backend (reuse existing static matcher as default)
             let profile = CapabilityProfile::detect().await;
-            let backend: Arc<dyn CommandGenerator> =
-                Arc::new(StaticMatcher::new(profile));
+            let backend: Arc<dyn CommandGenerator> = Arc::new(StaticMatcher::new(profile));
 
             // Build safety validator
             let safety_config = SafetyConfig::from_level(caro::SafetyLevel::Moderate);
             let safety = SafetyValidator::new(safety_config).map_err(|e| e.to_string())?;
 
             let shell = caro::ShellType::Bash; // Default for agent mode
-            let runner = PaperclipRunner::new(
-                client,
-                backend,
-                safety,
-                shell,
-                caro::SafetyLevel::Moderate,
-            );
+            let runner =
+                PaperclipRunner::new(client, backend, safety, shell, caro::SafetyLevel::Moderate);
 
             runner.print_agent_info();
             println!();
@@ -2008,15 +2004,13 @@ async fn main() {
             process::exit(0);
         }
         #[cfg(feature = "paperclip")]
-        Some(Commands::Paperclip { command }) => {
-            match handle_paperclip_command(command).await {
-                Ok(()) => process::exit(0),
-                Err(e) => {
-                    eprintln!("Paperclip error: {}", e);
-                    process::exit(1);
-                }
+        Some(Commands::Paperclip { command }) => match handle_paperclip_command(command).await {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Paperclip error: {}", e);
+                process::exit(1);
             }
-        }
+        },
         // NOTE: Telemetry subcommand disabled in v1.1.0-beta.1
         // Some(Commands::Telemetry { command }) => {
         //     let storage_path = dirs::data_dir()

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,19 @@ enum KnowledgeCommands {
     },
 }
 
+/// Paperclip AI agent subcommands
+#[cfg(feature = "paperclip")]
+#[derive(Parser, Clone)]
+#[command(arg_required_else_help = true)]
+enum PaperclipCommands {
+    /// Execute one heartbeat cycle (fetch tasks, generate commands, report results)
+    Run,
+    /// Check connectivity to the Paperclip API server
+    Status,
+    /// Display agent configuration and capabilities
+    Info,
+}
+
 /// Subcommands for caro
 #[derive(Parser, Clone)]
 enum Commands {
@@ -462,6 +475,13 @@ enum Commands {
     //     #[command(subcommand)]
     //     command: caro::cli::telemetry::TelemetryCommands,
     // },
+
+    /// Run as a Paperclip AI managed agent (requires --features paperclip)
+    #[cfg(feature = "paperclip")]
+    Paperclip {
+        #[command(subcommand)]
+        command: PaperclipCommands,
+    },
 }
 
 /// caro - Convert natural language to shell commands using local LLMs
@@ -1666,6 +1686,92 @@ async fn handle_profile_command(command: ProfileCommands) -> Result<(), String> 
 }
 
 // =============================================================================
+// Paperclip Agent Commands
+// =============================================================================
+
+/// Handle Paperclip AI agent subcommands
+#[cfg(feature = "paperclip")]
+async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), String> {
+    use caro::paperclip::{PaperclipClient, PaperclipConfig, PaperclipRunner};
+    use caro::safety::{SafetyConfig, SafetyValidator};
+    use colored::Colorize;
+    use std::sync::Arc;
+
+    let config = PaperclipConfig::from_env().ok_or_else(|| {
+        "Paperclip environment variables not found.\n\
+         Required: PAPERCLIP_AGENT_ID, PAPERCLIP_API_KEY, PAPERCLIP_API_URL, PAPERCLIP_RUN_ID\n\
+         \n\
+         Caro must be launched by a Paperclip orchestration server to use this command."
+            .to_string()
+    })?;
+
+    match command {
+        PaperclipCommands::Info => {
+            println!("{}", "Caro Paperclip Agent Configuration".bold());
+            println!("  Agent ID:  {}", config.agent_id.cyan());
+            println!("  API URL:   {}", config.api_url);
+            println!("  Run ID:    {}", config.run_id);
+            println!("  API Key:   {}...", &config.api_key[..config.api_key.len().min(8)]);
+            Ok(())
+        }
+        PaperclipCommands::Status => {
+            let client = PaperclipClient::new(config).map_err(|e| e.to_string())?;
+            print!("Checking Paperclip API connectivity... ");
+            match client.health_check().await {
+                Ok(true) => {
+                    println!("{}", "OK".green().bold());
+                    Ok(())
+                }
+                Ok(false) => {
+                    println!("{}", "UNREACHABLE".red().bold());
+                    Err("Could not connect to Paperclip API".to_string())
+                }
+                Err(e) => {
+                    println!("{}", "ERROR".red().bold());
+                    Err(format!("Health check failed: {}", e))
+                }
+            }
+        }
+        PaperclipCommands::Run => {
+            let client = PaperclipClient::new(config).map_err(|e| e.to_string())?;
+
+            // Build backend (reuse existing static matcher as default)
+            let profile = CapabilityProfile::detect().await;
+            let backend: Arc<dyn CommandGenerator> =
+                Arc::new(StaticMatcher::new(profile));
+
+            // Build safety validator
+            let safety_config = SafetyConfig::from_level(caro::SafetyLevel::Moderate);
+            let safety = SafetyValidator::new(safety_config).map_err(|e| e.to_string())?;
+
+            let shell = caro::ShellType::Bash; // Default for agent mode
+            let runner = PaperclipRunner::new(
+                client,
+                backend,
+                safety,
+                shell,
+                caro::SafetyLevel::Moderate,
+            );
+
+            runner.print_agent_info();
+            println!();
+
+            match runner.run_heartbeat().await {
+                Ok(summary) => {
+                    println!("{}", summary);
+                    if summary.tasks_failed > 0 {
+                        Err(format!("{} task(s) failed", summary.tasks_failed))
+                    } else {
+                        Ok(())
+                    }
+                }
+                Err(e) => Err(format!("Heartbeat failed: {}", e)),
+            }
+        }
+    }
+}
+
+// =============================================================================
 // Evaluation Tests
 // =============================================================================
 
@@ -1900,6 +2006,16 @@ async fn main() {
                 println!();
             }
             process::exit(0);
+        }
+        #[cfg(feature = "paperclip")]
+        Some(Commands::Paperclip { command }) => {
+            match handle_paperclip_command(command).await {
+                Ok(()) => process::exit(0),
+                Err(e) => {
+                    eprintln!("Paperclip error: {}", e);
+                    process::exit(1);
+                }
+            }
         }
         // NOTE: Telemetry subcommand disabled in v1.1.0-beta.1
         // Some(Commands::Telemetry { command }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1711,8 +1711,16 @@ async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), Stri
             println!("  API URL:   {}", config.api_url);
             println!("  Run ID:    {}", config.run_id);
             println!(
-                "  API Key:   {}...",
-                &config.api_key[..config.api_key.len().min(8)]
+                "  API Key:   {}",
+                if config.api_key.len() > 4 {
+                    format!(
+                        "{}...{}",
+                        &config.api_key[..2],
+                        &config.api_key[config.api_key.len() - 2..]
+                    )
+                } else {
+                    "****".to_string()
+                }
             );
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1710,7 +1710,7 @@ async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), Stri
             println!("  Agent ID:  {}", config.agent_id.cyan());
             println!("  API URL:   {}", config.api_url);
             println!("  Run ID:    {}", config.run_id);
-            println!("  API Key:   **** ({} chars)", config.api_key.len());
+            println!("  API Key:   ****");
             Ok(())
         }
         PaperclipCommands::Status => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1710,18 +1710,7 @@ async fn handle_paperclip_command(command: PaperclipCommands) -> Result<(), Stri
             println!("  Agent ID:  {}", config.agent_id.cyan());
             println!("  API URL:   {}", config.api_url);
             println!("  Run ID:    {}", config.run_id);
-            println!(
-                "  API Key:   {}",
-                if config.api_key.len() > 4 {
-                    format!(
-                        "{}...{}",
-                        &config.api_key[..2],
-                        &config.api_key[config.api_key.len() - 2..]
-                    )
-                } else {
-                    "****".to_string()
-                }
-            );
+            println!("  API Key:   **** ({} chars)", config.api_key.len());
             Ok(())
         }
         PaperclipCommands::Status => {

--- a/src/paperclip/client.rs
+++ b/src/paperclip/client.rs
@@ -1,0 +1,236 @@
+//! HTTP client for the Paperclip AI orchestration API.
+//!
+//! Handles authentication, task retrieval, progress reporting, and budget
+//! checks against the Paperclip control plane.
+
+use super::config::PaperclipConfig;
+use anyhow::{Context, Result};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// Data types returned by / sent to the Paperclip API
+// ---------------------------------------------------------------------------
+
+/// A task assigned to this agent by Paperclip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub description: String,
+    #[serde(default)]
+    pub priority: Option<String>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+/// Status of a task in progress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// Result payload sent back to Paperclip on task completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskResult {
+    pub command: String,
+    pub safety_level: String,
+    #[serde(default)]
+    pub explanation: Option<String>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+/// Budget information for this agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetStatus {
+    pub remaining: f64,
+    pub limit: f64,
+    pub currency: String,
+    #[serde(default)]
+    pub exceeded: bool,
+}
+
+/// Payload for progress/status updates.
+#[derive(Debug, Serialize)]
+struct ProgressPayload {
+    status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<TaskResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/// HTTP client for communicating with the Paperclip orchestration API.
+pub struct PaperclipClient {
+    http: reqwest::Client,
+    config: PaperclipConfig,
+}
+
+impl PaperclipClient {
+    /// Create a new client from a Paperclip configuration.
+    pub fn new(config: PaperclipConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", config.api_key))
+                .context("invalid API key for header")?,
+        );
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("failed to build HTTP client")?;
+
+        Ok(Self { http, config })
+    }
+
+    /// Fetch tasks assigned to this agent for the current run.
+    pub async fn get_tasks(&self) -> Result<Vec<Task>> {
+        let url = format!(
+            "{}/api/agents/{}/tasks?run_id={}",
+            self.config.api_url, self.config.agent_id, self.config.run_id
+        );
+        debug!("Fetching tasks from {}", url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("failed to reach Paperclip API")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Paperclip API returned {}: {}", status, body);
+        }
+
+        let tasks: Vec<Task> = resp.json().await.context("failed to parse tasks response")?;
+        debug!("Received {} task(s)", tasks.len());
+        Ok(tasks)
+    }
+
+    /// Report that work on a task has started.
+    pub async fn report_progress(&self, task_id: &str) -> Result<()> {
+        self.send_status_update(
+            task_id,
+            ProgressPayload {
+                status: TaskStatus::InProgress,
+                result: None,
+                error: None,
+            },
+        )
+        .await
+    }
+
+    /// Report successful completion of a task with a result.
+    pub async fn report_completion(&self, task_id: &str, result: TaskResult) -> Result<()> {
+        self.send_status_update(
+            task_id,
+            ProgressPayload {
+                status: TaskStatus::Completed,
+                result: Some(result),
+                error: None,
+            },
+        )
+        .await
+    }
+
+    /// Report that a task failed.
+    pub async fn report_error(&self, task_id: &str, error: &str) -> Result<()> {
+        self.send_status_update(
+            task_id,
+            ProgressPayload {
+                status: TaskStatus::Failed,
+                result: None,
+                error: Some(error.to_string()),
+            },
+        )
+        .await
+    }
+
+    /// Check the remaining budget for this agent.
+    pub async fn check_budget(&self) -> Result<BudgetStatus> {
+        let url = format!(
+            "{}/api/agents/{}/budget",
+            self.config.api_url, self.config.agent_id
+        );
+        debug!("Checking budget at {}", url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("failed to reach Paperclip API for budget check")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            warn!("Budget check failed ({}): {}", status, body);
+            // Return a permissive default so budget failures don't block work
+            return Ok(BudgetStatus {
+                remaining: f64::MAX,
+                limit: f64::MAX,
+                currency: "USD".to_string(),
+                exceeded: false,
+            });
+        }
+
+        resp.json()
+            .await
+            .context("failed to parse budget response")
+    }
+
+    /// Check connectivity to the Paperclip API.
+    pub async fn health_check(&self) -> Result<bool> {
+        let url = format!("{}/api/health", self.config.api_url);
+        match self.http.get(&url).send().await {
+            Ok(resp) => Ok(resp.status().is_success()),
+            Err(e) => {
+                warn!("Paperclip health check failed: {}", e);
+                Ok(false)
+            }
+        }
+    }
+
+    /// Send a status update for a specific task.
+    async fn send_status_update(&self, task_id: &str, payload: ProgressPayload) -> Result<()> {
+        let url = format!(
+            "{}/api/agents/{}/tasks/{}/status",
+            self.config.api_url, self.config.agent_id, task_id
+        );
+        debug!("Sending {:?} update for task {}", payload.status, task_id);
+
+        let resp = self
+            .http
+            .post(&url)
+            .json(&payload)
+            .send()
+            .await
+            .context("failed to send status update")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Status update failed ({}): {}", status, body);
+        }
+
+        Ok(())
+    }
+
+    /// Get the underlying config (for display / diagnostics).
+    pub fn config(&self) -> &PaperclipConfig {
+        &self.config
+    }
+}

--- a/src/paperclip/client.rs
+++ b/src/paperclip/client.rs
@@ -115,7 +115,10 @@ impl PaperclipClient {
             anyhow::bail!("Paperclip API returned {}: {}", status, body);
         }
 
-        let tasks: Vec<Task> = resp.json().await.context("failed to parse tasks response")?;
+        let tasks: Vec<Task> = resp
+            .json()
+            .await
+            .context("failed to parse tasks response")?;
         debug!("Received {} task(s)", tasks.len());
         Ok(tasks)
     }
@@ -187,9 +190,7 @@ impl PaperclipClient {
             });
         }
 
-        resp.json()
-            .await
-            .context("failed to parse budget response")
+        resp.json().await.context("failed to parse budget response")
     }
 
     /// Check connectivity to the Paperclip API.

--- a/src/paperclip/config.rs
+++ b/src/paperclip/config.rs
@@ -1,0 +1,136 @@
+//! Paperclip AI environment variable detection and configuration.
+//!
+//! When Caro is launched as a Paperclip agent, the platform injects environment
+//! variables that identify the agent, provide API credentials, and track the
+//! current execution run. This module detects those variables and builds a
+//! typed configuration struct.
+
+use serde::{Deserialize, Serialize};
+use std::env;
+
+/// Environment variable names injected by Paperclip.
+const ENV_AGENT_ID: &str = "PAPERCLIP_AGENT_ID";
+const ENV_API_KEY: &str = "PAPERCLIP_API_KEY";
+const ENV_API_URL: &str = "PAPERCLIP_API_URL";
+const ENV_RUN_ID: &str = "PAPERCLIP_RUN_ID";
+
+/// Configuration derived from Paperclip-injected environment variables.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaperclipConfig {
+    /// Unique identifier for this agent within the Paperclip org.
+    pub agent_id: String,
+    /// API key for authenticating with the Paperclip control plane.
+    pub api_key: String,
+    /// Base URL of the Paperclip API (e.g. `http://localhost:3000`).
+    pub api_url: String,
+    /// Identifier for the current heartbeat / execution run.
+    pub run_id: String,
+}
+
+impl PaperclipConfig {
+    /// Attempt to build configuration from environment variables.
+    ///
+    /// Returns `Some` only when **all** required `PAPERCLIP_*` variables are
+    /// set and non-empty. Returns `None` if any are missing, which signals
+    /// that Caro is running in normal (non-agent) mode.
+    pub fn from_env() -> Option<Self> {
+        let agent_id = non_empty_env(ENV_AGENT_ID)?;
+        let api_key = non_empty_env(ENV_API_KEY)?;
+        let api_url = non_empty_env(ENV_API_URL)?;
+        let run_id = non_empty_env(ENV_RUN_ID)?;
+
+        Some(Self {
+            agent_id,
+            api_key,
+            api_url,
+            run_id,
+        })
+    }
+
+    /// Returns `true` when Paperclip environment variables are detected,
+    /// without fully validating them.
+    pub fn is_paperclip_env() -> bool {
+        env::var(ENV_AGENT_ID).is_ok()
+    }
+}
+
+/// Helper: read an env var, returning `None` for missing or empty values.
+fn non_empty_env(key: &str) -> Option<String> {
+    match env::var(key) {
+        Ok(val) if !val.is_empty() => Some(val),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    #[test]
+    #[serial]
+    fn from_env_returns_none_when_missing() {
+        // Ensure vars are not set (they shouldn't be in test env)
+        env::remove_var(ENV_AGENT_ID);
+        env::remove_var(ENV_API_KEY);
+        env::remove_var(ENV_API_URL);
+        env::remove_var(ENV_RUN_ID);
+
+        assert!(PaperclipConfig::from_env().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_returns_none_when_partial() {
+        env::set_var(ENV_AGENT_ID, "agent-1");
+        env::set_var(ENV_API_KEY, "key-123");
+        // Deliberately omit API_URL and RUN_ID
+        env::remove_var(ENV_API_URL);
+        env::remove_var(ENV_RUN_ID);
+
+        assert!(PaperclipConfig::from_env().is_none());
+
+        // Cleanup
+        env::remove_var(ENV_AGENT_ID);
+        env::remove_var(ENV_API_KEY);
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_returns_config_when_all_set() {
+        env::set_var(ENV_AGENT_ID, "agent-1");
+        env::set_var(ENV_API_KEY, "key-123");
+        env::set_var(ENV_API_URL, "http://localhost:3000");
+        env::set_var(ENV_RUN_ID, "run-456");
+
+        let config = PaperclipConfig::from_env().expect("should parse config");
+        assert_eq!(config.agent_id, "agent-1");
+        assert_eq!(config.api_key, "key-123");
+        assert_eq!(config.api_url, "http://localhost:3000");
+        assert_eq!(config.run_id, "run-456");
+
+        // Cleanup
+        env::remove_var(ENV_AGENT_ID);
+        env::remove_var(ENV_API_KEY);
+        env::remove_var(ENV_API_URL);
+        env::remove_var(ENV_RUN_ID);
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_rejects_empty_values() {
+        env::set_var(ENV_AGENT_ID, "agent-1");
+        env::set_var(ENV_API_KEY, "");
+        env::set_var(ENV_API_URL, "http://localhost:3000");
+        env::set_var(ENV_RUN_ID, "run-456");
+
+        assert!(PaperclipConfig::from_env().is_none());
+
+        // Cleanup
+        env::remove_var(ENV_AGENT_ID);
+        env::remove_var(ENV_API_KEY);
+        env::remove_var(ENV_API_URL);
+        env::remove_var(ENV_RUN_ID);
+    }
+}

--- a/src/paperclip/mod.rs
+++ b/src/paperclip/mod.rs
@@ -1,0 +1,24 @@
+//! Paperclip AI integration for Caro.
+//!
+//! This module allows Caro to operate as a managed agent within a
+//! [Paperclip](https://github.com/paperclipai/paperclip) orchestration
+//! platform. Paperclip provides organizational structure, budget management,
+//! governance, and audit trails for autonomous AI agent companies.
+//!
+//! # How it works
+//!
+//! 1. Paperclip triggers Caro with injected `PAPERCLIP_*` environment variables
+//! 2. Caro detects these and enters **agent mode**
+//! 3. Tasks are fetched from the Paperclip API, each containing a natural
+//!    language description
+//! 4. Caro converts each description to a safe shell command (using its
+//!    existing backends and safety validation)
+//! 5. Results are reported back to Paperclip for audit and governance
+
+pub mod client;
+pub mod config;
+pub mod runner;
+
+pub use client::{BudgetStatus, PaperclipClient, Task, TaskResult, TaskStatus};
+pub use config::PaperclipConfig;
+pub use runner::{HeartbeatSummary, PaperclipRunner};

--- a/src/paperclip/runner.rs
+++ b/src/paperclip/runner.rs
@@ -1,0 +1,201 @@
+//! Heartbeat runner for Paperclip agent mode.
+//!
+//! When Caro is triggered by Paperclip, the runner:
+//! 1. Fetches assigned tasks from the Paperclip API
+//! 2. Checks budget constraints
+//! 3. For each task: converts the NL description → shell command
+//! 4. Runs safety validation on the generated command
+//! 5. Reports results (or errors) back to Paperclip
+
+use super::client::{PaperclipClient, TaskResult};
+use crate::backends::CommandGenerator;
+use crate::models::{CommandRequest, SafetyLevel, ShellType};
+use crate::safety::SafetyValidator;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::sync::Arc;
+use tracing::{debug, error, info, warn};
+
+/// Orchestrates a single heartbeat cycle for Paperclip agent mode.
+pub struct PaperclipRunner {
+    client: PaperclipClient,
+    backend: Arc<dyn CommandGenerator>,
+    safety: SafetyValidator,
+    shell: ShellType,
+    safety_level: SafetyLevel,
+}
+
+/// Summary of a heartbeat execution.
+#[derive(Debug)]
+pub struct HeartbeatSummary {
+    pub tasks_received: usize,
+    pub tasks_completed: usize,
+    pub tasks_failed: usize,
+    pub tasks_blocked_safety: usize,
+}
+
+impl PaperclipRunner {
+    pub fn new(
+        client: PaperclipClient,
+        backend: Arc<dyn CommandGenerator>,
+        safety: SafetyValidator,
+        shell: ShellType,
+        safety_level: SafetyLevel,
+    ) -> Self {
+        Self {
+            client,
+            backend,
+            safety,
+            shell,
+            safety_level,
+        }
+    }
+
+    /// Execute a single heartbeat cycle: fetch tasks, process them, report back.
+    pub async fn run_heartbeat(&self) -> Result<HeartbeatSummary> {
+        // 1. Check budget first
+        let budget = self.client.check_budget().await?;
+        if budget.exceeded {
+            warn!(
+                "Budget exceeded ({:.2}/{:.2} {}). Skipping heartbeat.",
+                budget.remaining, budget.limit, budget.currency
+            );
+            return Ok(HeartbeatSummary {
+                tasks_received: 0,
+                tasks_completed: 0,
+                tasks_failed: 0,
+                tasks_blocked_safety: 0,
+            });
+        }
+        debug!(
+            "Budget OK: {:.2}/{:.2} {} remaining",
+            budget.remaining, budget.limit, budget.currency
+        );
+
+        // 2. Fetch tasks
+        let tasks = self
+            .client
+            .get_tasks()
+            .await
+            .context("failed to fetch tasks")?;
+
+        let total = tasks.len();
+        info!("Received {} task(s) from Paperclip", total);
+
+        let mut completed = 0usize;
+        let mut failed = 0usize;
+        let mut blocked = 0usize;
+
+        // 3. Process each task
+        for task in &tasks {
+            info!("Processing task {}: {}", task.id, task.description);
+
+            // Report progress
+            if let Err(e) = self.client.report_progress(&task.id).await {
+                warn!("Failed to report progress for task {}: {}", task.id, e);
+            }
+
+            // Generate command from natural language description
+            let request =
+                CommandRequest::new(&task.description, self.shell.clone())
+                    .with_safety(self.safety_level.clone());
+
+            match self.backend.generate_command(&request).await {
+                Ok(generated) => {
+                    // Run safety validation
+                    let validation = self
+                        .safety
+                        .validate_command(&generated.command, self.shell.clone())
+                        .await;
+
+                    match validation {
+                        Ok(result) if result.allowed => {
+                            let task_result = TaskResult {
+                                command: generated.command.clone(),
+                                safety_level: format!("{:?}", result.risk_level),
+                                explanation: Some(generated.explanation.clone()),
+                                warnings: result.warnings.clone(),
+                            };
+
+                            match self.client.report_completion(&task.id, task_result).await {
+                                Ok(()) => {
+                                    info!("Task {} completed: {}", task.id, generated.command);
+                                    completed += 1;
+                                }
+                                Err(e) => {
+                                    error!("Failed to report completion for {}: {}", task.id, e);
+                                    failed += 1;
+                                }
+                            }
+                        }
+                        Ok(result) => {
+                            // Command blocked by safety validation
+                            let msg = format!(
+                                "Command blocked by safety validation (risk: {:?}): {}",
+                                result.risk_level,
+                                result.warnings.join("; ")
+                            );
+                            warn!("{}", msg);
+                            let _ = self.client.report_error(&task.id, &msg).await;
+                            blocked += 1;
+                        }
+                        Err(e) => {
+                            let msg = format!("Safety validation error: {}", e);
+                            error!("{}", msg);
+                            let _ = self.client.report_error(&task.id, &msg).await;
+                            failed += 1;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let msg = format!("Command generation failed: {}", e);
+                    error!("{}", msg);
+                    let _ = self.client.report_error(&task.id, &msg).await;
+                    failed += 1;
+                }
+            }
+        }
+
+        let summary = HeartbeatSummary {
+            tasks_received: total,
+            tasks_completed: completed,
+            tasks_failed: failed,
+            tasks_blocked_safety: blocked,
+        };
+
+        info!(
+            "Heartbeat complete: {} received, {} completed, {} failed, {} blocked",
+            summary.tasks_received,
+            summary.tasks_completed,
+            summary.tasks_failed,
+            summary.tasks_blocked_safety
+        );
+
+        Ok(summary)
+    }
+
+    /// Print a human-readable status report.
+    pub fn print_agent_info(&self) {
+        let config = self.client.config();
+        println!("{}", "Caro Paperclip Agent".bold());
+        println!("  Agent ID:  {}", config.agent_id.cyan());
+        println!("  API URL:   {}", config.api_url);
+        println!("  Run ID:    {}", config.run_id);
+        println!("  Backend:   {}", self.backend.backend_info().model_name);
+        println!("  Shell:     {:?}", self.shell);
+        println!("  Safety:    {:?}", self.safety_level);
+    }
+}
+
+impl std::fmt::Display for HeartbeatSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Heartbeat: {} tasks ({} completed, {} failed, {} blocked by safety)",
+            self.tasks_received,
+            self.tasks_completed,
+            self.tasks_failed,
+            self.tasks_blocked_safety
+        )
+    }
+}

--- a/src/paperclip/runner.rs
+++ b/src/paperclip/runner.rs
@@ -97,15 +97,14 @@ impl PaperclipRunner {
 
             // Generate command from natural language description
             let request =
-                CommandRequest::new(&task.description, self.shell.clone())
-                    .with_safety(self.safety_level.clone());
+                CommandRequest::new(&task.description, self.shell).with_safety(self.safety_level);
 
             match self.backend.generate_command(&request).await {
                 Ok(generated) => {
                     // Run safety validation
                     let validation = self
                         .safety
-                        .validate_command(&generated.command, self.shell.clone())
+                        .validate_command(&generated.command, self.shell)
                         .await;
 
                     match validation {
@@ -192,10 +191,7 @@ impl std::fmt::Display for HeartbeatSummary {
         write!(
             f,
             "Heartbeat: {} tasks ({} completed, {} failed, {} blocked by safety)",
-            self.tasks_received,
-            self.tasks_completed,
-            self.tasks_failed,
-            self.tasks_blocked_safety
+            self.tasks_received, self.tasks_completed, self.tasks_failed, self.tasks_blocked_safety
         )
     }
 }

--- a/tests/paperclip_integration.rs
+++ b/tests/paperclip_integration.rs
@@ -1,0 +1,245 @@
+//! Integration tests for the Paperclip AI agent integration.
+//!
+//! Uses wiremock to simulate the Paperclip orchestration API and verifies
+//! the full heartbeat cycle: task fetch → command generation → result reporting.
+
+#![cfg(feature = "paperclip")]
+
+use async_trait::async_trait;
+use caro::backends::{BackendInfo, CommandGenerator, GeneratorError};
+use caro::models::{BackendType, CommandRequest, GeneratedCommand, RiskLevel};
+use caro::paperclip::{PaperclipClient, PaperclipConfig, PaperclipRunner};
+use caro::safety::{SafetyConfig, SafetyValidator};
+use caro::SafetyLevel;
+use serde_json::json;
+use std::sync::Arc;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A simple mock backend that always returns "ls -la" for any query.
+struct MockBackend;
+
+#[async_trait]
+impl CommandGenerator for MockBackend {
+    async fn generate_command(
+        &self,
+        _request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        Ok(GeneratedCommand {
+            command: "ls -la".to_string(),
+            explanation: "List files in long format".to_string(),
+            safety_level: RiskLevel::Safe,
+            estimated_impact: "Read-only operation".to_string(),
+            alternatives: vec![],
+            backend_used: "mock".to_string(),
+            generation_time_ms: 1,
+            confidence_score: 0.95,
+        })
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+
+    fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            backend_type: BackendType::Mock,
+            model_name: "mock-backend".to_string(),
+            supports_streaming: false,
+            max_tokens: 256,
+            typical_latency_ms: 1,
+            memory_usage_mb: 0,
+            version: "test".to_string(),
+        }
+    }
+
+    async fn shutdown(&self) -> Result<(), GeneratorError> {
+        Ok(())
+    }
+}
+
+fn test_config(api_url: &str) -> PaperclipConfig {
+    PaperclipConfig {
+        agent_id: "test-agent-001".to_string(),
+        api_key: "test-key-abc".to_string(),
+        api_url: api_url.to_string(),
+        run_id: "run-123".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn health_check_returns_true_when_server_is_up() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"status": "ok"})))
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    assert!(client.health_check().await.unwrap());
+}
+
+#[tokio::test]
+async fn health_check_returns_false_when_server_is_down() {
+    // Use a port that nothing is listening on
+    let client = PaperclipClient::new(test_config("http://127.0.0.1:1")).unwrap();
+    assert!(!client.health_check().await.unwrap());
+}
+
+#[tokio::test]
+async fn get_tasks_returns_empty_list() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    let tasks = client.get_tasks().await.unwrap();
+    assert!(tasks.is_empty());
+}
+
+#[tokio::test]
+async fn get_tasks_returns_tasks() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "task-1",
+                "description": "list all files in the current directory",
+                "priority": "high",
+                "metadata": {}
+            },
+            {
+                "id": "task-2",
+                "description": "show disk usage",
+                "metadata": {}
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    let tasks = client.get_tasks().await.unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].id, "task-1");
+    assert_eq!(
+        tasks[0].description,
+        "list all files in the current directory"
+    );
+    assert_eq!(tasks[1].id, "task-2");
+}
+
+#[tokio::test]
+async fn full_heartbeat_cycle_completes_tasks() {
+    let server = MockServer::start().await;
+
+    // Mock budget check - within budget
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/budget"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "remaining": 50.0,
+            "limit": 100.0,
+            "currency": "USD",
+            "exceeded": false
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock task fetch - one safe task
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "task-1",
+                "description": "list files",
+                "metadata": {}
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    // Mock status updates (progress + completion)
+    Mock::given(method("POST"))
+        .and(path_regex(r"/api/agents/test-agent-001/tasks/.+/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .expect(2) // One progress, one completion
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    let backend: Arc<dyn CommandGenerator> = Arc::new(MockBackend);
+    let safety_config = SafetyConfig::from_level(SafetyLevel::Moderate);
+    let safety = SafetyValidator::new(safety_config).unwrap();
+
+    let runner = PaperclipRunner::new(
+        client,
+        backend,
+        safety,
+        caro::ShellType::Bash,
+        SafetyLevel::Moderate,
+    );
+
+    let summary = runner.run_heartbeat().await.unwrap();
+    assert_eq!(summary.tasks_received, 1);
+    assert_eq!(summary.tasks_completed, 1);
+    assert_eq!(summary.tasks_failed, 0);
+    assert_eq!(summary.tasks_blocked_safety, 0);
+}
+
+#[tokio::test]
+async fn heartbeat_skips_when_budget_exceeded() {
+    let server = MockServer::start().await;
+
+    // Mock budget check - exceeded
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/budget"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "remaining": 0.0,
+            "limit": 100.0,
+            "currency": "USD",
+            "exceeded": true
+        })))
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    let backend: Arc<dyn CommandGenerator> = Arc::new(MockBackend);
+    let safety_config = SafetyConfig::from_level(SafetyLevel::Moderate);
+    let safety = SafetyValidator::new(safety_config).unwrap();
+
+    let runner = PaperclipRunner::new(
+        client,
+        backend,
+        safety,
+        caro::ShellType::Bash,
+        SafetyLevel::Moderate,
+    );
+
+    let summary = runner.run_heartbeat().await.unwrap();
+    assert_eq!(summary.tasks_received, 0);
+    assert_eq!(summary.tasks_completed, 0);
+}
+
+#[tokio::test]
+async fn check_budget_returns_permissive_default_on_failure() {
+    let server = MockServer::start().await;
+
+    // Mock budget endpoint returning 500
+    Mock::given(method("GET"))
+        .and(path("/api/agents/test-agent-001/budget"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let client = PaperclipClient::new(test_config(&server.uri())).unwrap();
+    let budget = client.check_budget().await.unwrap();
+    // Should return permissive default (not error out)
+    assert!(!budget.exceeded);
+}


### PR DESCRIPTION
## Summary

- Adds `paperclip` feature flag enabling Caro to operate as a managed agent within [Paperclip AI](https://github.com/paperclipai/paperclip) orchestration platform
- New `src/paperclip/` module with config detection, HTTP API client, and heartbeat runner
- Three new CLI subcommands: `caro paperclip run`, `status`, and `info`
- Reuses existing `CommandGenerator`, `SafetyValidator`, and `StaticMatcher` infrastructure — zero changes to existing functionality
- All generated commands pass through safety validation before reporting back to Paperclip

## Test plan

- [x] `cargo check --features paperclip` compiles clean
- [x] `cargo check` (default build) unaffected
- [x] 4/4 unit tests pass for `paperclip::config` (env var detection)
- [ ] Integration tests with wiremock for full heartbeat cycle (follow-up)
- [ ] End-to-end test with local Paperclip instance

https://claude.ai/code/session_011zqex43oCCPUnYHAZz3HTD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Paperclip orchestration behind the `paperclip` feature so Caro can run as a managed agent that fetches tasks, generates shell commands, validates safety, and reports results. Build with `--features paperclip`; requires `PAPERCLIP_AGENT_ID`, `PAPERCLIP_API_KEY`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID` (default builds are unchanged).

- **New Features**
  - New `src/paperclip/` module (config, HTTP client, heartbeat runner) and CLI: `caro paperclip run|status|info`.
  - Reuses `CommandGenerator`, `SafetyValidator`, and `StaticMatcher`; adds health and budget checks with a permissive default on budget API failures.
  - Wiremock integration tests for health, task fetch, heartbeat, and budget flows.

- **Bug Fixes**
  - `caro paperclip info` no longer accesses or prints the API key; shows a fixed placeholder only to avoid logging secrets.

<sup>Written for commit a6446519bc77003f6a8225308afbd3e6bd255b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

