### PR TITLE
docs: Add ADR-015 and ADR-016 for agent observability and structured context

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -279,8 +279,8 @@ gantt
 | **v1.1.1** | Jan 14, 2026 | 7 | 7 | 100% | ✅ **RELEASED** |
 | **v1.1.0** | Jan 12, 2026 | 19 | 19 | 100% | ✅ **GA RELEASED** |
 | **v1.2.0** | Mar 31, 2026 | 73 (25 issues + 48 PRs) | 4 | 5% | 🔄 In Progress |
-| **v1.3.0** | May 31, 2026 | 54 (17 issues + 37 PRs) | 0 | 0% | ⏸️ Backlog |
-| **v2.0.0** | Jun 30, 2026 | 36 (17 issues + 19 PRs) | 0 | 0% | 🔄 Research Phase |
+| **v1.3.0** | May 31, 2026 | 57 (20 issues + 37 PRs) | 0 | 0% | ⏸️ Backlog |
+| **v2.0.0** | Jun 30, 2026 | 38 (19 issues + 19 PRs) | 0 | 0% | 🔄 Research Phase |
 | **Total** | - | **194** | **35** | **18%** | 🚀 On Track |
 
 ---
@@ -304,6 +304,11 @@ Successfully integrated **104 PRs (#557-660)** into the roadmap:
 - [#672](https://github.com/wildcard/caro/issues/672) - Interactive TUI Welcome Screen (v2.0.0)
 - [#673](https://github.com/wildcard/caro/issues/673) - User Feedback System MVP (v1.3.0)
 - [#674](https://github.com/wildcard/caro/issues/674) - Proactive Suggested Queries (v1.3.0)
+- [#839](https://github.com/wildcard/caro/issues/839) - Typed AgentEvent System for Observability (v1.3.0)
+- [#840](https://github.com/wildcard/caro/issues/840) - SafetyValidator in Agent Loop with PermissionRequired Event (v1.3.0)
+- [#841](https://github.com/wildcard/caro/issues/841) - Subprocess Timeouts and Infallible get_command_info (v1.3.0)
+- [#842](https://github.com/wildcard/caro/issues/842) - Structured GenerationContext (v2.0.0)
+- [#843](https://github.com/wildcard/caro/issues/843) - Provider-Neutral Message Roles for Remote Backends (v2.0.0)
 
 ### Distribution by Milestone
 - **v1.2.0** (Documentation & Website): 48 PRs

--- a/docs/adr/ADR-015-agent-event-system.md
+++ b/docs/adr/ADR-015-agent-event-system.md
@@ -1,0 +1,106 @@
+# ADR-015: Agent Event System
+
+**Status**: Proposed
+
+**Date**: 2026-04-05
+
+**Authors**: @wildcard
+
+**Target**: Community
+
+## Context
+
+Caro's agent loop (`src/agent/mod.rs`) currently mixes generation logic with output formatting and safety handling. There is no structured way for the CLI or other consumers to observe what the agent loop is doing at each step. This creates several problems:
+
+- **Tight coupling**: The agent loop is bound to CLI output patterns
+- **Poor observability**: No structured logging of generation phases
+- **Testing friction**: Integration tests must mock CLI output to verify behavior
+- **Limited extensibility**: Adding new UIs (TUI, web, IDE plugin) requires modifying agent internals
+
+Research into [SafeRL-Lab/nano-claude-code](https://github.com/SafeRL-Lab/nano-claude-code) revealed a clean pattern: the agent loop yields typed events (`TextChunk`, `ToolStart`, `ToolEnd`, `PermissionRequest`, `TurnDone`) via a generator, and the REPL/UI layer consumes them independently. This pattern maps naturally to Rust enums and callbacks.
+
+Additionally, nano-claude-code's permission-as-event pattern (where the agent loop yields `PermissionRequest` instead of directly prompting the user) provides a cleaner model for integrating safety validation into the agent loop rather than handling it at the CLI layer.
+
+## Decision
+
+Introduce a typed `AgentEvent` enum and callback-based event system for the agent loop. Safety validation will move from the CLI layer into the agent loop, with permission decisions yielded as events.
+
+### Core Design
+
+1. **`AgentEvent` enum** in `src/agent/events.rs` covering all generation phases
+2. **Callback pattern**: `AgentLoop` accepts `Option<Box<dyn Fn(AgentEvent) + Send + Sync>>`
+3. **Permission events**: Safety validation moves into agent loop; risky commands yield `PermissionRequired` events
+4. **CLI consumer**: `src/cli/mod.rs` wires the callback for terminal output and user prompts
+
+## Rationale
+
+- **Rust-native**: Enums are Rust's natural discriminated union — zero-cost abstraction, exhaustive matching, no runtime overhead when callback is `None`
+- **Proven pattern**: nano-claude-code demonstrates this works well for AI agent loops
+- **Incremental adoption**: Callback is optional; existing code works unchanged until wired
+- **Safety improvement**: Moving validation into the agent loop ensures all code paths go through safety checks, not just the CLI path
+- **Future-proof**: Event stream can be consumed by TUI, web UI, IDE plugins, or test harnesses
+
+## Consequences
+
+### Benefits
+
+- Clean separation between agent core and UI layer
+- Structured observability for debugging and logging
+- Testable event sequences without CLI mocking
+- Safety validation guaranteed for all consumers, not just CLI
+- Foundation for future streaming UI and multi-frontend support
+
+### Trade-offs
+
+- Callback ergonomics in async Rust require care (closures capturing state)
+- Slight API surface increase (new `events.rs` module)
+- Permission handling becomes async (callback must signal back to agent loop for PermissionRequired)
+
+### Risks
+
+- Callback-based permission requires bidirectional communication → Mitigation: Use `oneshot` channel or `Arc<Mutex<>>` for permission response
+- Performance overhead of event emission → Mitigation: Callback is optional; `None` check is branch-predicted away
+
+## Alternatives Considered
+
+### Alternative 1: Channel-based events (mpsc)
+- Description: Use `tokio::sync::mpsc` channel instead of callback
+- Pros: Natural async pattern, backpressure support
+- Cons: Requires consumer task, more complex setup for simple CLI use case
+
+### Alternative 2: Trait-based observer
+- Description: Define `trait AgentObserver` with methods per event type
+- Pros: Compile-time checked, IDE-friendly
+- Cons: More boilerplate, harder to extend with new events (breaking change)
+
+### Alternative 3: No event system (status quo)
+- Description: Keep current inline approach
+- Pros: No changes needed
+- Cons: Perpetuates coupling, blocks multi-frontend support, safety validation stays in CLI
+
+## Implementation Notes
+
+- **Phase 1** (v1.3.0): AgentEvent enum + callback + safety-in-loop
+- **Files**: New `src/agent/events.rs`, modify `src/agent/mod.rs` and `src/cli/mod.rs`
+- **Testing**: Unit tests asserting event sequence; integration tests for PermissionRequired flow
+- **Migration**: Existing behavior preserved when no callback is provided
+
+## Success Metrics
+
+- Zero performance regression when callback is `None`
+- All existing tests pass without modification
+- Event sequence is deterministic and testable
+- Safety validation works identically from agent loop (zero false positives maintained)
+
+## References
+
+- [SafeRL-Lab/nano-claude-code](https://github.com/SafeRL-Lab/nano-claude-code) — Agent loop event yielding pattern
+- [#839](https://github.com/wildcard/caro/issues/839) — Add typed AgentEvent system
+- [#840](https://github.com/wildcard/caro/issues/840) — Move SafetyValidator into agent loop
+- [#841](https://github.com/wildcard/caro/issues/841) — Subprocess timeouts
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-04-05 | @wildcard | Initial draft based on nano-claude-code research |

--- a/docs/adr/ADR-016-structured-generation-context.md
+++ b/docs/adr/ADR-016-structured-generation-context.md
@@ -1,0 +1,113 @@
+# ADR-016: Structured Generation Context
+
+**Status**: Proposed
+
+**Date**: 2026-04-05
+
+**Authors**: @wildcard
+
+**Target**: Community
+
+## Context
+
+Caro's agent loop builds context for LLM generation by concatenating strings:
+
+```rust
+context: Some(format!("{}{}{}\nSYSTEM_PROMPT:\n{}",
+    context_str, dir_context_str, knowledge_context_str, system_prompt))
+```
+
+This approach has several problems:
+
+- **Type-unsafe**: Context is an opaque string; backends can't introspect or transform it
+- **Not composable**: Adding new context types requires modifying string formatting code
+- **Backend-agnostic lost**: Remote backends (Ollama, vLLM) could use structured messages (system/user/assistant roles) instead of a flat string, but the current interface forces everything through `Option<String>`
+
+Research into [nano-claude-code](https://github.com/SafeRL-Lab/nano-claude-code) revealed that it uses a provider-neutral message format, converting to Anthropic or OpenAI wire format only at API boundaries. This enables zero-cost backend switching and cleaner multi-turn support.
+
+## Decision
+
+Replace `context: Option<String>` in `CommandRequest` with a typed `GenerationContext` struct. Each backend converts this struct to its own wire format. Additionally, introduce a neutral `Message` type with roles for remote backends.
+
+### Core Design
+
+```rust
+pub struct GenerationContext {
+    pub execution: ExecutionContext,
+    pub directory: DirectoryContext,
+    pub capability: CapabilityProfile,
+    pub knowledge: Option<Vec<SimilarCommand>>,
+    pub repair: Option<RepairContext>,
+}
+
+pub enum MessageRole { System, User, Assistant }
+pub struct Message { pub role: MessageRole, pub content: String }
+```
+
+This is a **breaking change** to the `CommandGenerator` trait.
+
+## Rationale
+
+- **Type safety**: Context composition is compile-time checked
+- **Backend flexibility**: Each backend converts structured context to its optimal wire format
+- **Testability**: Context can be inspected and asserted in tests without string parsing
+- **Foundation for multi-turn**: Message roles are essential for future conversational mode
+
+## Consequences
+
+### Benefits
+
+- Compile-time verified context composition
+- Each backend optimizes context for its API format
+- Clean foundation for multi-turn conversation in v2.0.0+
+- Eliminates string concatenation bugs
+
+### Trade-offs
+
+- Breaking change to `CommandGenerator` trait — all backends must update
+- More complex `CommandRequest` struct
+- Conversion logic needed in each backend
+
+### Risks
+
+- Migration effort for all backend implementations → Mitigation: Provide `GenerationContext::to_prompt_string()` helper for backends that just need a flat string
+- Context size management → Mitigation: `GenerationContext` can implement truncation per-field
+
+## Alternatives Considered
+
+### Alternative 1: Keep string context, add structured fields alongside
+- Description: Add `GenerationContext` as optional alongside existing `context: Option<String>`
+- Pros: Non-breaking, gradual migration
+- Cons: Two ways to pass context, confusing API, maintenance burden
+
+### Alternative 2: Use serde_json::Value
+- Description: Pass context as `serde_json::Value` map
+- Pros: Flexible, no breaking change to trait
+- Cons: Loses compile-time safety, runtime errors for missing fields
+
+## Implementation Notes
+
+- **Target**: v2.0.0 (breaking change, coordinate with other v2.0 changes)
+- **Files**: `src/backends/mod.rs` (trait), all backend implementations, `src/agent/mod.rs`
+- **Migration**: Provide `to_prompt_string()` to ease backend migration
+- **Testing**: All backend tests updated; add context composition tests
+
+## Success Metrics
+
+- All backends accept structured context
+- No string concatenation in agent loop for context building
+- Context composition is testable via unit tests
+- Remote backends use proper message roles
+
+## References
+
+- [SafeRL-Lab/nano-claude-code](https://github.com/SafeRL-Lab/nano-claude-code) — Provider-neutral message format
+- [#842](https://github.com/wildcard/caro/issues/842) — Replace string context with structured GenerationContext
+- [#843](https://github.com/wildcard/caro/issues/843) — Provider-neutral message roles
+- ADR-015 — Agent Event System (companion ADR)
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-04-05 | @wildcard | Initial draft based on nano-claude-code research |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,8 @@ Example: `ADR-001-enterprise-community-architecture.md`
 | [ADR-012](./ADR-012-honggfuzz-integration.md) | Honggfuzz Integration for Security-Critical Fuzz Testing | Proposed | 2026-01-02 |
 | [ADR-013](./ADR-013-pre-processing-pipeline.md) | Pre-Processing Pipeline Architecture | Proposed | 2026-01-01 |
 | [ADR-014](./ADR-014-serde-env-evaluation.md) | Environment Variable Deserialization with serde-env | Proposed | 2026-01-01 |
+| [ADR-015](./ADR-015-agent-event-system.md) | Agent Event System | Proposed | 2026-04-05 |
+| [ADR-016](./ADR-016-structured-generation-context.md) | Structured Generation Context | Proposed | 2026-04-05 |
 
 ## Contributing to ADRs
 

--- a/docs/development/TECH_DEBT.md
+++ b/docs/development/TECH_DEBT.md
@@ -303,6 +303,52 @@ impl CacheManager {
 
 ---
 
+### Dual Validation Paths (Agent Loop)
+**Issue**: [#839](https://github.com/wildcard/caro/issues/839), [#840](https://github.com/wildcard/caro/issues/840)
+**Status**: Tracked
+**Complexity**: Medium
+**Impact**: Medium - Architecture cleanliness
+
+**Description**:
+Caro has two separate validation systems: `CommandValidator` (platform compatibility checks in `src/prompts/validation.rs`) and `SafetyValidator` (dangerous pattern matching in `src/safety/mod.rs`). These run at different points in the pipeline (agent loop vs CLI layer) and have overlapping concerns.
+
+**Current State**:
+- `CommandValidator` runs inside agent loop during refinement
+- `SafetyValidator` runs in CLI after agent loop returns
+- Both check the same command but at different stages
+- No unified validation result type
+
+**Future Goal**: Unify into a single validation pipeline within the agent loop (ADR-015).
+
+**Skills needed**: Rust, architecture design
+**Estimated effort**: 8-12 hours
+**Help wanted**: Yes - Requires understanding of both validation paths
+
+---
+
+### String Context Concatenation in CommandRequest
+**Issue**: [#842](https://github.com/wildcard/caro/issues/842)
+**Status**: Tracked (deferred to v2.0.0)
+**Complexity**: High
+**Impact**: Medium - Type safety and backend flexibility
+
+**Description**:
+The agent loop builds LLM context by concatenating strings into `CommandRequest.context: Option<String>`. This is type-unsafe, not composable, and forces all backends to parse the same flat string format. Should be replaced with a structured `GenerationContext` type (ADR-016).
+
+**Current State**:
+```rust
+context: Some(format!("{}{}{}\nSYSTEM_PROMPT:\n{}",
+    context_str, dir_context_str, knowledge_context_str, system_prompt))
+```
+
+**Future Goal**: Replace with typed `GenerationContext` struct per ADR-016.
+
+**Skills needed**: Rust, API design, trait systems
+**Estimated effort**: 16-24 hours (breaking change to CommandGenerator trait)
+**Help wanted**: Yes - Coordinate with backend maintainers
+
+---
+
 ## 🔵 Low Priority / Nice to Have
 
 ### Config Hot Reloading
@@ -418,5 +464,5 @@ fn generate_schema() {
 ---
 
 **Last Updated**: 2026-01-02
-**Total Open Tech Debt Items**: 11
+**Total Open Tech Debt Items**: 13
 **Good First Issues**: 4


### PR DESCRIPTION
## Description

This PR adds two Architecture Decision Records (ADRs) documenting major architectural improvements planned for Caro's agent loop and LLM context handling. These ADRs formalize design decisions informed by research into [nano-claude-code](https://github.com/SafeRL-Lab/nano-claude-code) and establish the foundation for v1.3.0 and v2.0.0 work.

### Motivation

Caro's current agent loop has two architectural limitations:

1. **Tight coupling and poor observability**: The agent loop mixes generation logic with CLI output formatting and safety handling, making it difficult to add new UIs or test behavior without mocking CLI output.

2. **Type-unsafe context handling**: LLM context is built by string concatenation, preventing backends from introspecting or transforming context, and making it impossible to use structured message roles (system/user/assistant) that remote backends like Ollama and vLLM support.

These ADRs document the proposed solutions and provide a clear migration path for the community.

### Changes Made

- **ADR-015: Agent Event System** (`docs/adr/ADR-015-agent-event-system.md`)
  - Introduces typed `AgentEvent` enum for structured observability
  - Moves safety validation from CLI layer into agent loop
  - Enables permission decisions as events via callback pattern
  - Targets v1.3.0 (non-breaking, incremental adoption)

- **ADR-016: Structured Generation Context** (`docs/adr/ADR-016-structured-generation-context.md`)
  - Replaces `context: Option<String>` with typed `GenerationContext` struct
  - Enables compile-time verified context composition
  - Allows each backend to convert to optimal wire format
  - Introduces provider-neutral `Message` type with roles
  - Targets v2.0.0 (breaking change to `CommandGenerator` trait)

- **Updated TECH_DEBT.md**
  - Added two new tracked items (#839-#840 for ADR-015, #842 for ADR-016)
  - Documented dual validation paths issue and string context concatenation problem
  - Increased total tech debt items from 11 to 13

- **Updated ROADMAP.md**
  - Added issues #839-#843 to v1.3.0 and v2.0.0 backlogs
  - Updated issue counts: v1.3.0 (20 issues), v2.0.0 (19 issues)

---

## Type of Change

- [x] Documentation update (ADRs documenting architectural decisions)
- [x] Refactoring (planning for future code restructuring)

---

## Checklist

### Documentation

- [x] ADRs follow established format and structure
- [x] Rationale and consequences clearly documented
- [x] Alternatives considered and evaluated
- [x] Implementation notes and success metrics provided
- [x] References to related issues and research included
- [x] TECH_DEBT.md updated with tracked items
- [x] ROADMAP.md updated with new issues

---

## Related Issues and Specs

- Addresses #839 - Typed AgentEvent System for Observability
- Addresses #840 - SafetyValidator in Agent Loop with PermissionRequired Event
- Addresses #841 - Subprocess Timeouts and Infallible get_command_info
- Addresses #842 - Structured GenerationContext
- Addresses #843 - Provider-Neutral Message Roles for Remote Backends

---

## Additional Context

### Technical Decisions

Both ADRs are **proposed** status and represent research-informed architectural improvements:

- **ADR-015** is non-breaking and targets v1.3.0 for incremental adoption
- **ADR-016** is a breaking change to the `CommandGenerator` trait, coordinated for v2.0.0 alongside other breaking changes
- Both ADRs reference nano-claude-code as a proven pattern for agent loop design

### Future Work

- Implement ADR-015 in v1.3.0: Add `AgentEvent` enum, callback system,

https://claude.ai/code/session_01EbftXXkm5xidh1CM9r4HVz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-015 and ADR-016 to define an agent event system and a structured generation context, improving observability, safety, and type safety. Updates the roadmap and tech debt to track v1.3.0 and v2.0.0 work.

- **ADR Highlights**
  - ADR-015: Typed `AgentEvent` + callback stream; moves safety validation into the agent loop with permission as events. Targets v1.3.0. Links: #839, #840, #841.
  - ADR-016: Replaces `context: Option<String>` with `GenerationContext` and provider-neutral `Message` roles; breaking change to `CommandGenerator`. Targets v2.0.0. Links: #842, #843.

- **Planning Updates**
  - ROADMAP: Added #839–#843; updated v1.3.0 and v2.0.0 counts.
  - TECH_DEBT: Tracked dual validation paths and string context concatenation; total items now 13.

<sup>Written for commit 3e4b5f2b95a303188c4d1a44d1011d666ad0ea52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

