### PR TITLE
Add Nono kernel sandbox integration for command execution

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -145,6 +145,12 @@ pub trait IntoCliArgs {
     fn interactive(&self) -> bool;
     fn force_llm(&self) -> bool;
     fn explain(&self) -> bool;
+    /// Whether to wrap execution in a Nono sandbox
+    fn sandbox(&self) -> bool { false }
+    /// Nono security profile name
+    fn nono_profile(&self) -> Option<String> { None }
+    /// Enable Nono snapshot / rollback
+    fn rollback(&self) -> bool { false }
 }
 
 impl CliApp {
@@ -576,8 +582,20 @@ impl CliApp {
         let (exit_code, stdout, stderr, execution_error, execution_time_ms) =
             if (args.execute() || args.interactive()) && can_execute && !args.dry_run() {
                 use crate::execution::CommandExecutor;
+                use crate::sandbox::NonoSandbox;
 
-                let executor = CommandExecutor::new(shell);
+                let mut executor = CommandExecutor::new(shell);
+                if args.sandbox() {
+                    let mut sandbox = NonoSandbox::new();
+                    if let Some(profile) = args.nono_profile() {
+                        sandbox = sandbox.with_profile(profile);
+                    }
+                    if args.rollback() {
+                        sandbox = sandbox.with_rollback();
+                    }
+                    executor = executor.with_sandbox(sandbox);
+                }
+                let executor = executor;
                 match executor.execute(&generated.command) {
                     Ok(result) => (
                         Some(result.exit_code),

--- a/src/execution/executor.rs
+++ b/src/execution/executor.rs
@@ -3,6 +3,7 @@
 //! Provides safe command execution with output capture and platform-specific handling.
 
 use crate::models::ShellType;
+use crate::sandbox::NonoSandbox;
 use std::process::{Command, Output, Stdio};
 use std::time::Instant;
 
@@ -36,6 +37,8 @@ pub enum ExecutorError {
 pub struct CommandExecutor {
     shell_type: ShellType,
     timeout_ms: Option<u64>,
+    /// Optional Nono sandbox wrapper
+    sandbox: Option<NonoSandbox>,
 }
 
 impl CommandExecutor {
@@ -44,12 +47,22 @@ impl CommandExecutor {
         Self {
             shell_type,
             timeout_ms: None,
+            sandbox: None,
         }
     }
 
     /// Set execution timeout in milliseconds
     pub fn with_timeout(mut self, timeout_ms: u64) -> Self {
         self.timeout_ms = Some(timeout_ms);
+        self
+    }
+
+    /// Wrap execution in a Nono kernel sandbox.
+    ///
+    /// If `nono` is not found in PATH at execution time, a warning is emitted
+    /// and execution proceeds without sandboxing.
+    pub fn with_sandbox(mut self, sandbox: NonoSandbox) -> Self {
+        self.sandbox = Some(sandbox);
         self
     }
 
@@ -80,53 +93,26 @@ impl CommandExecutor {
         Ok(self.process_output(output, execution_time_ms))
     }
 
-    /// Create shell command based on platform and shell type
+    /// Create shell command based on platform and shell type.
+    ///
+    /// When a [`NonoSandbox`] is configured and `nono` is available in PATH,
+    /// the command is wrapped as `nono run [...] -- <shell> -c <command>`.
+    /// If `nono` is configured but not found, a warning is logged and execution
+    /// proceeds without sandboxing.
     fn create_shell_command(&self, command: &str) -> Result<Command, ExecutorError> {
-        let cmd = match self.shell_type {
-            ShellType::PowerShell => {
-                let mut c = Command::new("powershell");
-                c.arg("-NoProfile").arg("-Command").arg(command);
-                c
-            }
-            ShellType::Cmd => {
-                let mut c = Command::new("cmd");
-                c.arg("/C").arg(command);
-                c
-            }
-            ShellType::Bash => {
-                let mut c = Command::new("bash");
-                c.arg("-c").arg(command);
-                c
-            }
-            ShellType::Zsh => {
-                let mut c = Command::new("zsh");
-                c.arg("-c").arg(command);
-                c
-            }
-            ShellType::Fish => {
-                let mut c = Command::new("fish");
-                c.arg("-c").arg(command);
-                c
-            }
-            ShellType::Sh => {
-                let mut c = Command::new("sh");
-                c.arg("-c").arg(command);
-                c
-            }
+        // Determine the inner shell binary and its flag style
+        let (shell_bin, shell_flag) = match self.shell_type {
+            ShellType::PowerShell => ("powershell", "-Command"),
+            ShellType::Cmd => ("cmd", "/C"),
+            ShellType::Bash => ("bash", "-c"),
+            ShellType::Zsh => ("zsh", "-c"),
+            ShellType::Fish => ("fish", "-c"),
+            ShellType::Sh => ("sh", "-c"),
             ShellType::Unknown => {
-                // Default to sh on Unix-like systems, cmd on Windows
                 #[cfg(unix)]
-                {
-                    let mut c = Command::new("sh");
-                    c.arg("-c").arg(command);
-                    c
-                }
+                { ("sh", "-c") }
                 #[cfg(windows)]
-                {
-                    let mut c = Command::new("cmd");
-                    c.arg("/C").arg(command);
-                    c
-                }
+                { ("cmd", "/C") }
                 #[cfg(not(any(unix, windows)))]
                 {
                     return Err(ExecutorError::InvalidCommand(
@@ -136,6 +122,39 @@ impl CommandExecutor {
             }
         };
 
+        // PowerShell uses `-NoProfile` as an extra flag
+        let extra_flags: &[&str] = if self.shell_type == ShellType::PowerShell {
+            &["-NoProfile"]
+        } else {
+            &[]
+        };
+
+        // Optionally wrap in Nono sandbox
+        if let Some(ref sandbox) = self.sandbox {
+            if NonoSandbox::is_available() {
+                let inner_args: Vec<&str> = extra_flags
+                    .iter()
+                    .copied()
+                    .chain([shell_flag, command])
+                    .collect();
+                let (prog, args) = sandbox.wrap(shell_bin, &inner_args);
+                let mut cmd = Command::new(prog);
+                cmd.args(args);
+                return Ok(cmd);
+            } else {
+                tracing::warn!(
+                    "nono not found in PATH — running command without sandbox. \
+                     Install nono (https://github.com/always-further/nono) to enable sandboxing."
+                );
+            }
+        }
+
+        // Plain execution (no sandbox)
+        let mut cmd = Command::new(shell_bin);
+        for flag in extra_flags {
+            cmd.arg(flag);
+        }
+        cmd.arg(shell_flag).arg(command);
         Ok(cmd)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod models;
 pub mod platform;
 pub mod prompts;
 pub mod safety;
+pub mod sandbox;
 pub mod setup;
 pub mod telemetry;
 pub mod version;
@@ -58,7 +59,7 @@ pub use model_catalog::{ModelCatalog, ModelInfo, ModelSize};
 pub use models::{
     BackendInfo, BackendType, CacheManifest, CachedModel, CommandRequest, ConfigSchema,
     ExecutionContext, GeneratedCommand, LogEntry, LogLevel, Platform, RiskLevel, SafetyLevel,
-    ShellType, UserConfiguration, UserConfigurationBuilder,
+    SandboxConfig, ShellType, UserConfiguration, UserConfigurationBuilder,
 };
 
 // Re-export infrastructure module types and errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,6 +591,25 @@ struct Cli {
     )]
     explain: bool,
 
+    /// Wrap command execution in a Nono kernel sandbox (requires nono in PATH)
+    #[arg(
+        long,
+        help = "Execute commands inside a Nono kernel-enforced security sandbox"
+    )]
+    sandbox: bool,
+
+    /// Nono security profile to use when --sandbox is active
+    #[arg(
+        long,
+        value_name = "PROFILE",
+        help = "Nono security profile (e.g. safe, read-only)"
+    )]
+    nono_profile: Option<String>,
+
+    /// Enable Nono file snapshot and rollback when --sandbox is active
+    #[arg(long, help = "Enable Nono file snapshot/rollback support")]
+    rollback: bool,
+
     /// Trailing unquoted arguments forming the prompt
     #[arg(trailing_var_arg = true, num_args = 0..)]
     trailing_args: Vec<String>,
@@ -652,6 +671,18 @@ impl IntoCliArgs for Cli {
 
     fn explain(&self) -> bool {
         self.explain
+    }
+
+    fn sandbox(&self) -> bool {
+        self.sandbox
+    }
+
+    fn nono_profile(&self) -> Option<String> {
+        self.nono_profile.clone()
+    }
+
+    fn rollback(&self) -> bool {
+        self.rollback
     }
 }
 
@@ -2424,6 +2455,27 @@ async fn print_plain_output(result: &mut caro::cli::CliResult, cli: &Cli) -> Res
             "  The command would be executed with shell: {:?}",
             result.shell_used
         );
+        if cli.sandbox {
+            use caro::sandbox::NonoSandbox;
+            if NonoSandbox::is_available() {
+                let profile_info = cli
+                    .nono_profile
+                    .as_deref()
+                    .map(|p| format!(" (profile: {})", p))
+                    .unwrap_or_default();
+                display!(
+                    "  {} Nono sandbox enabled{}{}",
+                    "🔒".green(),
+                    profile_info,
+                    if cli.rollback { " +rollback" } else { "" }
+                );
+            } else {
+                display!(
+                    "  {} --sandbox requested but nono not found in PATH",
+                    "⚠".yellow()
+                );
+            }
+        }
         if result.blocked_reason.is_some() || result.requires_confirmation {
             display!(
                 "  {} This command would be blocked or require confirmation",
@@ -2458,8 +2510,20 @@ async fn print_plain_output(result: &mut caro::cli::CliResult, cli: &Cli) -> Res
 
                     // Execute the command
                     use caro::execution::CommandExecutor;
+                    use caro::sandbox::NonoSandbox;
 
-                    let executor = CommandExecutor::new(result.shell_used);
+                    let mut executor = CommandExecutor::new(result.shell_used);
+                    if cli.sandbox {
+                        let mut sandbox = NonoSandbox::new();
+                        if let Some(ref profile) = cli.nono_profile {
+                            sandbox = sandbox.with_profile(profile.clone());
+                        }
+                        if cli.rollback {
+                            sandbox = sandbox.with_rollback();
+                        }
+                        executor = executor.with_sandbox(sandbox);
+                    }
+                    let executor = executor;
 
                     match executor.execute(&result.generated_command) {
                         Ok(exec_result) => {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -624,6 +624,23 @@ impl CacheManifest {
     }
 }
 
+/// Sandbox configuration for Nono integration
+///
+/// When `enabled` is true, generated commands are executed inside a
+/// kernel-enforced Nono sandbox (if the `nono` binary is available).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct SandboxConfig {
+    /// Enable Nono sandbox for command execution (default: false)
+    #[serde(default)]
+    pub enabled: bool,
+    /// Nono security profile name (e.g. "safe", "read-only")
+    #[serde(default)]
+    pub nono_profile: Option<String>,
+    /// Enable Nono file snapshot / rollback support (default: false)
+    #[serde(default)]
+    pub rollback: bool,
+}
+
 /// User configuration with preferences
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct UserConfiguration {
@@ -641,6 +658,9 @@ pub struct UserConfiguration {
     /// Default generation profile (generator or explainer)
     #[serde(default)]
     pub generation_profile: crate::prompts::profiles::GenerationProfile,
+    /// Nono sandbox configuration
+    #[serde(default)]
+    pub sandbox: SandboxConfig,
 }
 
 impl Default for UserConfiguration {
@@ -655,6 +675,7 @@ impl Default for UserConfiguration {
             log_rotation_days: 7,
             telemetry: crate::telemetry::TelemetryConfig::default(),
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
+            sandbox: SandboxConfig::default(),
         }
     }
 }
@@ -777,6 +798,7 @@ impl UserConfigurationBuilder {
             log_rotation_days: self.log_rotation_days,
             telemetry: self.telemetry,
             generation_profile: self.generation_profile,
+            sandbox: SandboxConfig::default(),
         };
         config.validate()?;
         Ok(config)

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,0 +1,134 @@
+//! Nono sandbox integration
+//!
+//! Wraps command execution in a kernel-enforced security sandbox using
+//! [nono](https://github.com/always-further/nono) when available.
+//!
+//! Nono applies OS-level restrictions (macOS Seatbelt / Linux Landlock) that
+//! are structurally impossible to circumvent from within the sandboxed process,
+//! providing an additional layer of protection beyond Caro's pattern-based
+//! safety validation.
+
+use std::process::Command;
+
+/// Configuration for the Nono sandbox wrapper
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonoSandbox {
+    /// Named security profile (e.g. "safe", "read-only"). If None, nono's
+    /// defaults apply.
+    pub profile: Option<String>,
+    /// Enable file snapshot / rollback support
+    pub rollback: bool,
+}
+
+impl Default for NonoSandbox {
+    fn default() -> Self {
+        Self {
+            profile: None,
+            rollback: false,
+        }
+    }
+}
+
+impl NonoSandbox {
+    /// Create a new sandbox with default settings
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the nono security profile
+    pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
+    /// Enable snapshot / rollback support
+    pub fn with_rollback(mut self) -> Self {
+        self.rollback = true;
+        self
+    }
+
+    /// Check whether the `nono` binary is available in PATH.
+    pub fn is_available() -> bool {
+        Command::new("nono")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    }
+
+    /// Build the nono wrapper argv prefix for a given inner shell command.
+    ///
+    /// Returns `(program, args)` ready for `std::process::Command::new(program)`.
+    /// The caller should append the inner shell invocation arguments after these.
+    ///
+    /// # Example
+    ///
+    /// For `NonoSandbox { profile: Some("safe"), rollback: false }` and inner
+    /// command `sh -c "ls"` the result is:
+    ///
+    /// ```text
+    /// program = "nono"
+    /// args    = ["run", "--profile", "safe", "--", "sh", "-c", "ls"]
+    /// ```
+    pub fn wrap(&self, shell_program: &str, shell_args: &[&str]) -> (String, Vec<String>) {
+        let mut args: Vec<String> = vec!["run".to_string()];
+
+        if let Some(ref profile) = self.profile {
+            args.push("--profile".to_string());
+            args.push(profile.clone());
+        }
+
+        if self.rollback {
+            args.push("--rollback".to_string());
+        }
+
+        args.push("--".to_string());
+        args.push(shell_program.to_string());
+        for arg in shell_args {
+            args.push(arg.to_string());
+        }
+
+        ("nono".to_string(), args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wrap_no_profile() {
+        let sandbox = NonoSandbox::new();
+        let (prog, args) = sandbox.wrap("sh", &["-c", "ls"]);
+        assert_eq!(prog, "nono");
+        assert_eq!(args, ["run", "--", "sh", "-c", "ls"]);
+    }
+
+    #[test]
+    fn test_wrap_with_profile() {
+        let sandbox = NonoSandbox::new().with_profile("safe");
+        let (prog, args) = sandbox.wrap("sh", &["-c", "ls"]);
+        assert_eq!(prog, "nono");
+        assert_eq!(args, ["run", "--profile", "safe", "--", "sh", "-c", "ls"]);
+    }
+
+    #[test]
+    fn test_wrap_with_rollback() {
+        let sandbox = NonoSandbox::new().with_rollback();
+        let (prog, args) = sandbox.wrap("bash", &["-c", "echo hi"]);
+        assert_eq!(prog, "nono");
+        assert_eq!(args, ["run", "--rollback", "--", "bash", "-c", "echo hi"]);
+    }
+
+    #[test]
+    fn test_wrap_profile_and_rollback() {
+        let sandbox = NonoSandbox::new().with_profile("read-only").with_rollback();
+        let (prog, args) = sandbox.wrap("sh", &["-c", "cat file.txt"]);
+        assert_eq!(prog, "nono");
+        assert_eq!(
+            args,
+            ["run", "--profile", "read-only", "--rollback", "--", "sh", "-c", "cat file.txt"]
+        );
+    }
+}

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -190,6 +190,7 @@ impl SetupWizard {
             log_rotation_days: 7,
             telemetry: crate::telemetry::TelemetryConfig::default(),
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
+            sandbox: crate::models::SandboxConfig::default(),
         };
 
         self.print_summary(&configuration, theme);


### PR DESCRIPTION
## Description

This PR adds optional kernel-enforced sandboxing via [Nono](https://github.com/always-further/nono) to Caro's command execution pipeline. When enabled, generated commands are wrapped in OS-level security restrictions (macOS Seatbelt / Linux Landlock) that provide an additional layer of protection beyond pattern-based safety validation.

### Motivation

Caro's safety system validates commands before execution, but pattern-based detection has inherent limitations. Kernel-enforced sandboxing provides structurally impossible-to-circumvent OS-level restrictions, offering defense-in-depth security. This is particularly valuable for users who want to execute AI-generated commands with maximum confidence.

### Changes Made

- **New `sandbox` module** (`src/sandbox/mod.rs`): Implements `NonoSandbox` configuration struct with builder pattern for:
  - Named security profiles (e.g., "safe", "read-only")
  - File snapshot/rollback support
  - Availability detection via `nono --version`
  - Command wrapping logic that builds `nono run [--profile X] [--rollback] -- <shell> <args>`

- **CLI integration** (`src/main.rs`):
  - `--sandbox`: Enable Nono sandboxing
  - `--nono-profile PROFILE`: Specify security profile
  - `--rollback`: Enable file snapshot/rollback
  - Display sandbox status in dry-run output with lock emoji and warning if nono unavailable

- **Executor enhancement** (`src/execution/executor.rs`):
  - Added `sandbox: Option<NonoSandbox>` field to `CommandExecutor`
  - `with_sandbox()` builder method
  - Refactored `create_shell_command()` to wrap commands when sandbox is configured
  - Graceful fallback with warning if nono not found in PATH

- **Configuration model** (`src/models/mod.rs`):
  - New `SandboxConfig` struct for persistent configuration
  - Added `sandbox` field to `UserConfiguration`
  - Serializable with serde for config file support

- **CLI trait** (`src/cli/mod.rs`):
  - Extended `IntoCliArgs` trait with `sandbox()`, `nono_profile()`, `rollback()` methods
  - Default implementations for backward compatibility

- **Comprehensive unit tests** covering:
  - Command wrapping with/without profile
  - Rollback flag handling
  - Combined profile + rollback scenarios

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (executor command building refactored for sandbox support)

---

## Testing

- Added 4 unit tests in `sandbox/mod.rs` covering all wrapping scenarios
- Existing executor tests remain unaffected (sandbox is optional)
- Graceful degradation: if nono unavailable, warning logged and execution proceeds without sandboxing
- CLI integration tested through existing command execution paths

---

## Breaking Changes

None. All changes are additive:
- New CLI flags are optional
- `CommandExecutor` sandbox field defaults to `None`
- `IntoCliArgs` trait methods have default implementations
- Existing code paths unaffected when sandbox not configured

---

## Related Issues and Specs

- Implements defense-in-depth security via kernel sandboxing
- Complements existing pattern-based safety validation

---

## Additional Context

### Technical Decisions

1. **Optional dependency on nono**: Rather than requiring nono as a hard dependency, we detect availability at runtime and gracefully degrade. This allows users to opt-in without forcing installation.

2. **Builder pattern**: `NonoSandbox` uses builder methods (`with_profile()`, `with_rollback()`) for ergonomic configuration matching Caro's existing patterns.

3. **Executor refactoring**: Extracted shell binary/flag logic from command creation to support both sandboxed and non-sandboxed paths cleanly.

4. **Persistent configuration**: Added `SandboxConfig` to `UserConfiguration` for future support of config-file-based sandbox settings.

### Future Work

- Integration with config file to set default sandbox profile
- Additional Nono

https://claude.ai/code/session_012cv54X11QmbMTvbikKKope

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional kernel-enforced sandboxing for command execution via `nono`, providing OS-level restrictions for safer runs. Opt-in through CLI or config, with clear dry-run status and graceful fallback if `nono` is missing.

- **New Features**
  - CLI flags: `--sandbox`, `--nono-profile <PROFILE>`, `--rollback` to run commands inside `nono`.
  - Dry-run shows sandbox status, profile, and rollback; warns when `nono` isn’t in PATH.
  - Persisted settings via `SandboxConfig` on `UserConfiguration` (default off).

- **Refactors**
  - Introduced `NonoSandbox` and availability check; `CommandExecutor::with_sandbox()` wraps as `nono run [--profile] [--rollback] -- <shell> <args>`.
  - Consolidated shell command creation for consistent wrapping; added unit tests for sandbox wrapping scenarios.

<sup>Written for commit 52c44125b0303ba0f3eaac421059e14b42fa667b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

