### PR TITLE
list all the word files

### DIFF
--- a/demos/demo_playground/src/main.rs
+++ b/demos/demo_playground/src/main.rs
@@ -1,5 +1,7 @@
 use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 use std::sync::Mutex;
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -13,9 +15,52 @@ struct AppState {
     users: Mutex<Vec<User>>,
 }
 
+fn is_word_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("doc") || ext.eq_ignore_ascii_case("docx"))
+        .unwrap_or(false)
+}
+
+fn collect_word_files(root: &Path, current: &Path, word_files: &mut Vec<String>) -> std::io::Result<()> {
+    for entry in fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            collect_word_files(root, &path, word_files)?;
+        } else if is_word_file(&path) {
+            let display_path = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            word_files.push(display_path);
+        }
+    }
+    Ok(())
+}
+
+fn list_word_files_in_dir<P: AsRef<Path>>(root_dir: P) -> std::io::Result<Vec<String>> {
+    let root = root_dir.as_ref();
+    let mut word_files = Vec::new();
+    collect_word_files(root, root, &mut word_files)?;
+    word_files.sort();
+    Ok(word_files)
+}
+
 #[get("/")]
 async fn index() -> impl Responder {
     HttpResponse::Ok().body("Welcome to the API!")
+}
+
+#[get("/word-files")]
+async fn get_word_files() -> impl Responder {
+    match list_word_files_in_dir(".") {
+        Ok(files) => HttpResponse::Ok().json(files),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("Failed to list Word files: {}", err)),
+    }
 }
 
 #[get("/users")]
@@ -44,10 +89,49 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(app_state.clone())
             .service(index)
+            .service(get_word_files)
             .service(get_users)
             .service(create_user)
     })
     .bind(("127.0.0.1", 8080))?
     .run()
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write_test_file(root: &Path, name: &str) {
+        let path = root.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"test").unwrap();
+    }
+
+    #[test]
+    fn list_word_files_in_dir_returns_doc_and_docx() {
+        let temp_dir = std::env::temp_dir().join(format!("caro_word_files_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        write_test_file(&temp_dir, "one.docx");
+        write_test_file(&temp_dir, "two.doc");
+        write_test_file(&temp_dir, "ignore.txt");
+        write_test_file(&temp_dir.join("nested"), "nested.docx");
+
+        let mut files = list_word_files_in_dir(&temp_dir).unwrap();
+        files.sort();
+
+        assert_eq!(files, vec![
+            "nested/nested.docx".to_string(),
+            "one.docx".to_string(),
+            "two.doc".to_string(),
+        ]);
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
 }


### PR DESCRIPTION
## Description

list all the word files in a directory

### Motivation

<!-- Why are these changes needed? What problem do they solve? -->

### Changes Made

<!-- List the key changes in this PR -->

-
-
-

---

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code restructuring without changing behavior)
- [ ] Documentation update (changes to docs, comments, or guides)
- [ ] Performance improvement (makes code faster or more efficient)
- [ ] Test coverage (adds or improves tests)
- [ ] CI/CD or tooling (changes to build, release, or development tools)

---

## Checklist

<!-- Ensure you have completed these steps before requesting review -->

### Code Quality

- [x] I have run `cargo fmt --all` (code is properly formatted)
- [x] I have run `cargo clippy -- -D warnings` (no clippy warnings)
- [x] I have run `cargo test` (all tests pass)
- [ ] I have run `cargo audit` (no security vulnerabilities in dependencies)

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added contract tests for new public APIs (if applicable)
- [ ] I have added integration tests for cross-module workflows (if applicable)
- [ ] I have verified performance requirements are met (if applicable)

### Documentation

- [ ] I have added rustdoc comments for new public APIs
- [ ] I have updated relevant documentation (README, specs, guides)
- [ ] I have added examples to demonstrate new functionality (if applicable)
- [ ] I have updated the CHANGELOG.md with my changes

### TDD Workflow

- [ ] I followed the Red-Green-Refactor cycle (if implementing new features)
- [ ] I wrote failing tests before implementing the solution
- [ ] I verified tests with `cargo watch -x test` during development

---

## Breaking Changes

<!-- If this PR includes breaking changes, describe them here -->

### API Changes

<!-- List any changes to public APIs, function signatures, or module structure -->

### Migration Guide

<!-- Provide step-by-step instructions for users to migrate from the old behavior to the new behavior -->

### Deprecation Plan

<!-- If applicable, describe how old APIs will be deprecated and when they will be removed -->

---

## Related Issues and Specs

<!-- Link to related issues, feature requests, or specifications -->

- Closes #<!-- issue number -->
- Related to #<!-- issue number -->
- Implements spec: `specs/<!-- feature-id -->/spec.md`
- Addresses contract: `specs/<!-- feature-id -->/contracts/<!-- contract-name -->.md`

---

## Performance Impact

<!-- Describe any performance implications of this PR -->

### Benchmarks

<!-- If applicable, include benchmark results comparing before/after -->

```
cargo bench

Before:
- Startup time: 95ms
- Validation time: 45ms

After:
- Startup time: 85ms (-10.5%)
- Validation time: 38ms (-15.6%)
```

### Binary Size

<!-- If applicable, report changes to release binary size -->

```
Before: 47.2 MB
After:  48.1 MB (+0.9 MB)
```

### Memory Usage

<!-- If applicable, report changes to memory consumption -->

---

## Screenshots / Examples

<!-- For CLI changes, include before/after screenshots or terminal output -->

### Before

```bash
$ caro "list files"
Error: command generation failed
```

### After

```bash
$ caro "list files"
Generated command:
  find . -type f -name "*"

Execute this command? (y/N)
```

---

## Testing Evidence

<!-- Provide evidence that you've tested your changes -->

### Test Output

<!-- Paste relevant test output showing all tests pass -->

```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 2.34s
     Running unittests src/lib.rs (target/debug/deps/caro-...)

running 42 tests
test cache::tests::test_cache_manager_retrieves_model ... ok
test safety::tests::test_dangerous_pattern_detection ... ok
...
test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Manual Testing

<!-- Describe manual testing you performed -->

- [ ] Tested on macOS (Apple Silicon / Intel)
- [ ] Tested on Linux (Ubuntu / Fedora / Arch)
- [ ] Tested on Windows (10 / 11)
- [ ] Tested with different backends (MLX / vLLM / Ollama / Mock)
- [ ] Tested edge cases and error conditions

---

## Additional Context

<!-- Any other information that reviewers should know -->

### Technical Decisions

<!-- Explain any non-obvious technical decisions or trade-offs -->

### Future Work

<!-- List any follow-up work that should be done in future PRs -->

### Questions for Reviewers

<!-- Any specific feedback you're looking for -->

---

## Reviewer Checklist

<!-- For maintainers reviewing this PR -->

- [ ] Code follows Rust best practices and project conventions
- [ ] Tests are comprehensive and follow TDD principles
- [ ] Documentation is clear and complete
- [ ] Changes align with project specifications
- [ ] Performance impact is acceptable
- [ ] Breaking changes are justified and documented
- [ ] Security implications have been considered

---

**By submitting this PR, I confirm that:**

- [ ] My code follows the style guidelines of this project (see [AGENTS.md](https://github.com/wildcard/caro/blob/main/AGENTS.md))
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have read and followed the [contributing guidelines](https://github.com/wildcard/caro/blob/main/CONTRIBUTING.md)
- [ ] I agree to the [Code of Conduct](https://github.com/wildcard/caro/blob/main/CODE_OF_CONDUCT.md)

---

<!-- Thank you for contributing to caro! 🚀 -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds recursive Word file discovery to the demo playground. Exposes GET /word-files that returns a JSON array of .doc/.docx paths relative to the root.

- **New Features**
  - New helpers to collect `.doc` and `.docx` files recursively and return sorted, root-relative paths.
  - GET `/word-files` endpoint that returns the list as JSON, with 500 on read errors.
  - Unit test for `list_word_files_in_dir` covering `.doc`/`.docx`, non-Word files, and nested dirs.

<sup>Written for commit 1ce860ea5f8db8f836ddeb26cdfa506c3b86f636. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

