### PR TITLE
feat(ai): Atuin-AI-style conversational command generation

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,0 +1,20 @@
+//! Interactive AI feature — Atuin-AI-inspired conversational command generation.
+//!
+//! Public surface:
+//! - [`privacy::build_context`] — construct the opt-in context string sent to the LLM.
+//! - [`session`] — in-memory session + turn types.
+//! - [`store`] — append/resume session persistence on disk (JSON file).
+//! - [`shell_init`] — bash/zsh/fish integration scripts with a `?` keybinding.
+//! - [`run_once`] — single-turn AI command generation honoring sessions and privacy.
+//!
+//! The feature flows every generated command through the existing
+//! [`crate::safety::SafetyValidator`] — there is no safety bypass.
+
+pub mod privacy;
+pub mod session;
+pub mod shell_init;
+pub mod store;
+
+pub mod runner;
+
+pub use runner::{build_validator, run_once, AiInvocation, AiOutcome};

--- a/src/ai/privacy.rs
+++ b/src/ai/privacy.rs
@@ -1,0 +1,180 @@
+//! Privacy-aware context builder for the AI feature.
+//!
+//! The single gate where opt-in toggles from [`crate::models::AiConfig`] decide
+//! what local machine state is allowed to leave the process. Everything in a
+//! `[ai.opening]` / `[ai.capabilities]` block defaults to `false`, so the LLM
+//! sees only the OS + shell name unless the user explicitly opts in.
+
+use crate::context::ExecutionContext;
+use crate::models::AiConfig;
+
+use super::session::AiSession;
+
+/// Pieces of context the LLM may be allowed to see, depending on user config.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ContextInputs<'a> {
+    /// Optional last-command captured by the shell hook (opt-in).
+    pub last_command: Option<&'a str>,
+}
+
+/// Build the opening-turn context string, honoring every `[ai]` privacy toggle.
+///
+/// The output is safe to feed into the existing prompt pipeline as
+/// [`crate::models::CommandRequest::context`].
+pub fn build_context(
+    ai_cfg: &AiConfig,
+    exec_ctx: &ExecutionContext,
+    session: Option<&AiSession>,
+    inputs: ContextInputs<'_>,
+) -> String {
+    // OS + shell are always-on — they're the bare minimum any shell-command
+    // generator needs to avoid emitting wrong-platform flags.
+    let mut out = String::new();
+    out.push_str(&format!("OS: {}\n", exec_ctx.os));
+    out.push_str(&format!("Shell: {}\n", exec_ctx.shell));
+
+    if ai_cfg.opening.send_cwd {
+        out.push_str(&format!("CWD: {}\n", exec_ctx.cwd.display()));
+    }
+
+    if ai_cfg.opening.send_last_command {
+        let last = inputs
+            .last_command
+            .or_else(|| session.and_then(|s| s.last_command()));
+        if let Some(cmd) = last {
+            out.push_str(&format!("LastCommand: {}\n", cmd));
+        }
+    }
+
+    if let Some(sess) = session {
+        let hist = sess.render_history(6);
+        if !hist.is_empty() {
+            out.push_str(&hist);
+        }
+    }
+
+    out
+}
+
+/// When this returns `true`, the caller should warn the user that remote
+/// transmission may occur with the selected backend and the configured opt-ins.
+pub fn may_leak_context_offhost(ai_cfg: &AiConfig, backend_name: &str) -> bool {
+    let anything_optin = ai_cfg.opening.send_cwd
+        || ai_cfg.opening.send_last_command
+        || ai_cfg.capabilities.enable_history_search;
+    let remote = matches!(backend_name, "ollama" | "vllm" | "exo" | "claude");
+    anything_optin && remote && ai_cfg.endpoint.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{AiCapabilities, AiOpening};
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            os_version: "6.5.0".into(),
+            distribution: Some("Ubuntu 22.04".into()),
+            cwd: std::path::PathBuf::from("/home/alice/proj"),
+            shell: "bash".into(),
+            user: "alice".into(),
+            available_commands: vec!["ls".into(), "grep".into()],
+        }
+    }
+
+    #[test]
+    fn defaults_emit_only_os_and_shell() {
+        let cfg = AiConfig::default();
+        let out = build_context(&cfg, &ctx(), None, ContextInputs::default());
+        assert!(out.contains("OS: linux"));
+        assert!(out.contains("Shell: bash"));
+        assert!(!out.contains("CWD"));
+        assert!(!out.contains("LastCommand"));
+    }
+
+    #[test]
+    fn send_cwd_opt_in_includes_cwd() {
+        let cfg = AiConfig {
+            opening: AiOpening {
+                send_cwd: true,
+                send_last_command: false,
+            },
+            ..AiConfig::default()
+        };
+        let out = build_context(&cfg, &ctx(), None, ContextInputs::default());
+        assert!(out.contains("CWD: /home/alice/proj"));
+    }
+
+    #[test]
+    fn send_last_command_opt_in_uses_input() {
+        let cfg = AiConfig {
+            opening: AiOpening {
+                send_cwd: false,
+                send_last_command: true,
+            },
+            ..AiConfig::default()
+        };
+        let out = build_context(
+            &cfg,
+            &ctx(),
+            None,
+            ContextInputs {
+                last_command: Some("git status"),
+            },
+        );
+        assert!(out.contains("LastCommand: git status"));
+    }
+
+    #[test]
+    fn send_last_command_falls_back_to_session_last() {
+        use crate::ai::session::{AiSession, Turn};
+        let mut s = AiSession::new(1, "bash");
+        s.push(Turn::user("list"));
+        s.push(Turn::assistant("ls", ""));
+        let cfg = AiConfig {
+            opening: AiOpening {
+                send_cwd: false,
+                send_last_command: true,
+            },
+            ..AiConfig::default()
+        };
+        let out = build_context(&cfg, &ctx(), Some(&s), ContextInputs::default());
+        assert!(out.contains("LastCommand: ls"));
+    }
+
+    #[test]
+    fn leak_detection_only_fires_with_optin_and_remote() {
+        let base = AiConfig::default();
+        assert!(!may_leak_context_offhost(&base, "ollama"));
+
+        let cfg_remote_no_optin = AiConfig {
+            endpoint: Some("https://x".into()),
+            ..AiConfig::default()
+        };
+        assert!(!may_leak_context_offhost(&cfg_remote_no_optin, "ollama"));
+
+        let cfg_optin_local = AiConfig {
+            opening: AiOpening {
+                send_cwd: true,
+                ..AiOpening::default()
+            },
+            ..AiConfig::default()
+        };
+        assert!(!may_leak_context_offhost(&cfg_optin_local, "embedded"));
+
+        let cfg_optin_remote = AiConfig {
+            endpoint: Some("https://x".into()),
+            opening: AiOpening {
+                send_cwd: true,
+                ..AiOpening::default()
+            },
+            capabilities: AiCapabilities {
+                enable_history_search: false,
+            },
+            ..AiConfig::default()
+        };
+        assert!(may_leak_context_offhost(&cfg_optin_remote, "ollama"));
+    }
+}

--- a/src/ai/privacy.rs
+++ b/src/ai/privacy.rs
@@ -46,10 +46,16 @@ pub fn build_context(
         }
     }
 
-    if let Some(sess) = session {
-        let hist = sess.render_history(6);
-        if !hist.is_empty() {
-            out.push_str(&hist);
+    // Session history is opt-in: gating on `capabilities.enable_history_search`
+    // keeps the privacy promise that nothing past OS+Shell leaves unless the
+    // user flipped a toggle. Skipping this branch when the flag is off avoids
+    // leaking earlier-turn user prompts into a later prompt's context window.
+    if ai_cfg.capabilities.enable_history_search {
+        if let Some(sess) = session {
+            let hist = sess.render_history(6);
+            if !hist.is_empty() {
+                out.push_str(&hist);
+            }
         }
     }
 
@@ -142,6 +148,43 @@ mod tests {
         };
         let out = build_context(&cfg, &ctx(), Some(&s), ContextInputs::default());
         assert!(out.contains("LastCommand: ls"));
+    }
+
+    #[test]
+    fn session_history_omitted_when_capability_disabled() {
+        use crate::ai::session::{AiSession, Turn};
+        let mut s = AiSession::new(7, "bash");
+        s.push(Turn::user("first prompt"));
+        s.push(Turn::assistant("ls", ""));
+        s.push(Turn::user("second prompt"));
+        s.push(Turn::assistant("pwd", ""));
+        let cfg = AiConfig {
+            capabilities: AiCapabilities {
+                enable_history_search: false,
+            },
+            ..AiConfig::default()
+        };
+        let out = build_context(&cfg, &ctx(), Some(&s), ContextInputs::default());
+        assert!(!out.contains("first prompt"));
+        assert!(!out.contains("second prompt"));
+        assert!(!out.contains("ls"));
+        assert!(!out.contains("pwd"));
+    }
+
+    #[test]
+    fn session_history_included_when_capability_enabled() {
+        use crate::ai::session::{AiSession, Turn};
+        let mut s = AiSession::new(8, "bash");
+        s.push(Turn::user("first prompt"));
+        s.push(Turn::assistant("ls", ""));
+        let cfg = AiConfig {
+            capabilities: AiCapabilities {
+                enable_history_search: true,
+            },
+            ..AiConfig::default()
+        };
+        let out = build_context(&cfg, &ctx(), Some(&s), ContextInputs::default());
+        assert!(out.contains("first prompt") || out.contains("ls"));
     }
 
     #[test]

--- a/src/ai/runner.rs
+++ b/src/ai/runner.rs
@@ -1,0 +1,287 @@
+//! Once-mode AI invocation: resume/new session, generate a command, validate
+//! safety, persist the turn.
+//!
+//! The interactive REPL is out of scope for the MVP. `run_once` is the primitive
+//! both scripted callers (`caro ai --once "prompt"`) and the future REPL will
+//! use, so putting the command generation + safety + persistence logic here
+//! keeps it testable without a TTY.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::backends::CommandGenerator;
+use crate::context::ExecutionContext;
+use crate::models::{AiConfig, CommandRequest, RiskLevel, SafetyLevel, ShellType};
+use crate::safety::{SafetyConfig, SafetyValidator};
+
+use super::privacy::{build_context, ContextInputs};
+use super::session::Turn;
+use super::store::SessionStore;
+
+/// How the caller wants a session reconciled before this turn.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum SessionMode {
+    /// Resume the most-recent-within-TTL session, otherwise create a new one.
+    #[default]
+    ResumeOrNew,
+    /// Always create a new session.
+    New,
+    /// Resume if recent, otherwise fail (useful for strict scripting).
+    ResumeStrict,
+}
+
+/// Inputs for one AI turn.
+pub struct AiInvocation<'a> {
+    pub prompt: &'a str,
+    pub ai_cfg: &'a AiConfig,
+    pub backend: Arc<dyn CommandGenerator>,
+    pub backend_name: String,
+    pub exec_ctx: ExecutionContext,
+    pub validator: Arc<SafetyValidator>,
+    pub safety_level: SafetyLevel,
+    pub shell: ShellType,
+    pub store_path: PathBuf,
+    pub session_mode: SessionMode,
+    /// Optional last command from shell hook ($HISTCMD, fc, etc.). Only forwarded
+    /// when `ai_cfg.opening.send_last_command` is true.
+    pub last_command_hint: Option<String>,
+}
+
+/// Result of a single AI turn.
+#[derive(Debug, Clone)]
+pub struct AiOutcome {
+    pub session_id: u64,
+    pub command: String,
+    pub explanation: String,
+    pub confidence: f64,
+    pub risk: RiskLevel,
+    pub warnings: Vec<String>,
+    pub allowed: bool,
+    /// True when the new session was freshly created (vs resumed).
+    pub resumed: bool,
+    /// True when the configured backend + opt-in context combination would
+    /// send machine-specific data off-host.
+    pub warns_offhost: bool,
+}
+
+/// Execute a single AI turn: pick or create a session, generate, validate, persist.
+pub async fn run_once(inv: AiInvocation<'_>) -> Result<AiOutcome> {
+    let mut store = SessionStore::open(inv.store_path.clone())
+        .with_context(|| format!("opening AI session store {}", inv.store_path.display()))?;
+
+    let (mut session, resumed) = match inv.session_mode {
+        SessionMode::New => (store.create(inv.exec_ctx.shell.clone())?, false),
+        SessionMode::ResumeStrict => match store.resume_recent(inv.ai_cfg.session_continue_minutes)
+        {
+            Some(s) => (s.clone(), true),
+            None => {
+                return Err(anyhow!(
+                    "no recent AI session to resume (TTL {} minutes)",
+                    inv.ai_cfg.session_continue_minutes
+                ))
+            }
+        },
+        SessionMode::ResumeOrNew => {
+            if let Some(s) = store.resume_recent(inv.ai_cfg.session_continue_minutes) {
+                (s.clone(), true)
+            } else {
+                (store.create(inv.exec_ctx.shell.clone())?, false)
+            }
+        }
+    };
+
+    let ctx_str = build_context(
+        inv.ai_cfg,
+        &inv.exec_ctx,
+        Some(&session),
+        ContextInputs {
+            last_command: if inv.ai_cfg.opening.send_last_command {
+                inv.last_command_hint.as_deref()
+            } else {
+                None
+            },
+        },
+    );
+
+    session.push(Turn::user(inv.prompt));
+
+    let request = CommandRequest::new(inv.prompt, inv.shell)
+        .with_safety(inv.safety_level)
+        .with_context(ctx_str)
+        .with_backend(inv.backend_name.clone());
+
+    let generated = inv
+        .backend
+        .generate_command(&request)
+        .await
+        .map_err(|e| anyhow!("backend error: {}", e))?;
+
+    let v = inv
+        .validator
+        .validate_command(&generated.command, inv.shell)
+        .await
+        .context("safety validation failed")?;
+
+    let mut assistant = Turn::assistant(&generated.command, &generated.explanation);
+    assistant.confidence = Some(generated.confidence_score);
+    assistant.risk = Some(format!("{:?}", v.risk_level));
+    session.push(assistant);
+
+    store.upsert(&session)?;
+
+    let warns_offhost = super::privacy::may_leak_context_offhost(inv.ai_cfg, &inv.backend_name);
+
+    Ok(AiOutcome {
+        session_id: session.id,
+        command: generated.command,
+        explanation: generated.explanation,
+        confidence: generated.confidence_score,
+        risk: v.risk_level,
+        warnings: v.warnings,
+        allowed: v.allowed,
+        resumed,
+        warns_offhost,
+    })
+}
+
+/// Convenience: construct a safety validator matching the active safety level.
+pub fn build_validator(level: SafetyLevel) -> Arc<SafetyValidator> {
+    let cfg = SafetyConfig::from_level(level);
+    let v = SafetyValidator::new(cfg).expect("built-in safety config is valid");
+    Arc::new(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::{BackendInfo, GeneratorError};
+    use crate::models::{BackendType, GeneratedCommand};
+    use async_trait::async_trait;
+    use tempfile::tempdir;
+
+    struct FakeBackend {
+        reply: GeneratedCommand,
+    }
+
+    #[async_trait]
+    impl CommandGenerator for FakeBackend {
+        async fn generate_command(
+            &self,
+            _request: &CommandRequest,
+        ) -> Result<GeneratedCommand, GeneratorError> {
+            Ok(self.reply.clone())
+        }
+        async fn is_available(&self) -> bool {
+            true
+        }
+        fn backend_info(&self) -> BackendInfo {
+            BackendInfo {
+                backend_type: BackendType::Mock,
+                model_name: "fake".into(),
+                supports_streaming: false,
+                max_tokens: 0,
+                typical_latency_ms: 0,
+                memory_usage_mb: 0,
+                version: "0".into(),
+            }
+        }
+        async fn shutdown(&self) -> Result<(), GeneratorError> {
+            Ok(())
+        }
+    }
+
+    fn fake_exec_ctx() -> ExecutionContext {
+        ExecutionContext {
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            os_version: "6.5.0".into(),
+            distribution: Some("Ubuntu 22.04".into()),
+            cwd: std::path::PathBuf::from("/tmp"),
+            shell: "bash".into(),
+            user: "test".into(),
+            available_commands: vec!["ls".into()],
+        }
+    }
+
+    fn safe_reply(cmd: &str) -> GeneratedCommand {
+        GeneratedCommand {
+            command: cmd.into(),
+            explanation: "generated".into(),
+            safety_level: RiskLevel::Safe,
+            estimated_impact: "none".into(),
+            alternatives: vec![],
+            backend_used: "fake".into(),
+            generation_time_ms: 1,
+            confidence_score: 0.9,
+        }
+    }
+
+    #[tokio::test]
+    async fn once_creates_session_and_persists_turn() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ai.json");
+
+        let backend: Arc<dyn CommandGenerator> = Arc::new(FakeBackend {
+            reply: safe_reply("ls -la"),
+        });
+        let validator = build_validator(SafetyLevel::Moderate);
+
+        let outcome = run_once(AiInvocation {
+            prompt: "list files",
+            ai_cfg: &AiConfig::default(),
+            backend,
+            backend_name: "embedded".into(),
+            exec_ctx: fake_exec_ctx(),
+            validator,
+            safety_level: SafetyLevel::Moderate,
+            shell: ShellType::Bash,
+            store_path: path.clone(),
+            session_mode: SessionMode::ResumeOrNew,
+            last_command_hint: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.command, "ls -la");
+        assert!(outcome.allowed);
+        assert!(!outcome.resumed);
+
+        // The session round-trips through disk.
+        let store = SessionStore::open(path).unwrap();
+        let sess = store.get(outcome.session_id).unwrap();
+        assert_eq!(sess.turns.len(), 2);
+        assert_eq!(sess.last_command(), Some("ls -la"));
+    }
+
+    #[tokio::test]
+    async fn once_flags_dangerous_command_from_validator() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ai.json");
+        let backend: Arc<dyn CommandGenerator> = Arc::new(FakeBackend {
+            reply: safe_reply("rm -rf /"),
+        });
+        let validator = build_validator(SafetyLevel::Moderate);
+
+        let outcome = run_once(AiInvocation {
+            prompt: "wipe everything",
+            ai_cfg: &AiConfig::default(),
+            backend,
+            backend_name: "embedded".into(),
+            exec_ctx: fake_exec_ctx(),
+            validator,
+            safety_level: SafetyLevel::Moderate,
+            shell: ShellType::Bash,
+            store_path: path,
+            session_mode: SessionMode::New,
+            last_command_hint: None,
+        })
+        .await
+        .unwrap();
+
+        // Whatever the exact risk-level mapping, the 52-pattern suite MUST
+        // refuse to mark this as unconditionally allowed.
+        assert!(!outcome.allowed || matches!(outcome.risk, RiskLevel::High | RiskLevel::Critical));
+    }
+}

--- a/src/ai/runner.rs
+++ b/src/ai/runner.rs
@@ -280,8 +280,20 @@ mod tests {
         .await
         .unwrap();
 
-        // Whatever the exact risk-level mapping, the 52-pattern suite MUST
-        // refuse to mark this as unconditionally allowed.
-        assert!(!outcome.allowed || matches!(outcome.risk, RiskLevel::High | RiskLevel::Critical));
+        // `rm -rf /` is unconditionally blocked at Moderate safety by the
+        // 52-pattern suite (see safety/patterns.rs). The previous form of this
+        // assertion accepted `allowed=true` whenever risk was High/Critical,
+        // which would silently regress if the validator stopped blocking.
+        assert!(
+            !outcome.allowed,
+            "rm -rf / must be blocked by SafetyLevel::Moderate; \
+             got allowed=true with risk={:?}",
+            outcome.risk
+        );
+        assert!(
+            matches!(outcome.risk, RiskLevel::High | RiskLevel::Critical),
+            "rm -rf / must surface as High or Critical risk; got {:?}",
+            outcome.risk
+        );
     }
 }

--- a/src/ai/session.rs
+++ b/src/ai/session.rs
@@ -1,0 +1,173 @@
+//! Session and turn types for the AI conversational loop.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Who produced a turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// User natural-language input.
+    User,
+    /// Assistant-generated command or answer.
+    Assistant,
+}
+
+/// A single turn in an AI session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Turn {
+    pub role: Role,
+    /// Free-form content (user prompt, or assistant rationale).
+    pub content: String,
+    /// When this is an assistant turn that generated a command, the command text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Backend-reported confidence score (0.0-1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    /// Human-readable risk level tag (LOW/MEDIUM/HIGH/CRITICAL) after safety validation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk: Option<String>,
+    pub ts: DateTime<Utc>,
+}
+
+impl Turn {
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+            command: None,
+            confidence: None,
+            risk: None,
+            ts: Utc::now(),
+        }
+    }
+
+    pub fn assistant(command: impl Into<String>, rationale: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: rationale.into(),
+            command: Some(command.into()),
+            confidence: None,
+            risk: None,
+            ts: Utc::now(),
+        }
+    }
+}
+
+/// A conversational session with the AI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AiSession {
+    /// Monotonic id within the session file.
+    pub id: u64,
+    pub created_at: DateTime<Utc>,
+    pub last_at: DateTime<Utc>,
+    /// Shell name captured at session start, e.g. "bash".
+    pub shell: String,
+    /// Optional CWD snapshot; only recorded when `ai.opening.send_cwd` is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    pub turns: Vec<Turn>,
+}
+
+impl AiSession {
+    pub fn new(id: u64, shell: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id,
+            created_at: now,
+            last_at: now,
+            shell: shell.into(),
+            cwd: None,
+            turns: Vec::new(),
+        }
+    }
+
+    /// Append a turn and bump `last_at`.
+    pub fn push(&mut self, turn: Turn) {
+        self.last_at = turn.ts;
+        self.turns.push(turn);
+    }
+
+    /// The most recent assistant-generated command, if any.
+    pub fn last_command(&self) -> Option<&str> {
+        self.turns
+            .iter()
+            .rev()
+            .find(|t| t.role == Role::Assistant)
+            .and_then(|t| t.command.as_deref())
+    }
+
+    /// True when the session was last touched within `minutes` minutes of `now`.
+    pub fn is_recent(&self, minutes: u32, now: DateTime<Utc>) -> bool {
+        let elapsed = now.signed_duration_since(self.last_at);
+        elapsed.num_seconds() >= 0 && elapsed.num_seconds() <= i64::from(minutes) * 60
+    }
+
+    /// Render the prior turns as a short "Previous turns" block for the LLM.
+    ///
+    /// Bounded to the last `max_turns` entries so the prompt stays small.
+    pub fn render_history(&self, max_turns: usize) -> String {
+        if self.turns.is_empty() {
+            return String::new();
+        }
+        let start = self.turns.len().saturating_sub(max_turns);
+        let mut s = String::from("Previous turns:\n");
+        for t in &self.turns[start..] {
+            match t.role {
+                Role::User => s.push_str(&format!("  User: {}\n", t.content)),
+                Role::Assistant => {
+                    if let Some(cmd) = &t.command {
+                        s.push_str(&format!("  Assistant: `{}`\n", cmd));
+                    } else {
+                        s.push_str(&format!("  Assistant: {}\n", t.content));
+                    }
+                }
+            }
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn session_is_recent_within_window() {
+        let mut s = AiSession::new(1, "bash");
+        s.last_at = Utc::now() - Duration::minutes(30);
+        assert!(s.is_recent(60, Utc::now()));
+    }
+
+    #[test]
+    fn session_not_recent_past_window() {
+        let mut s = AiSession::new(1, "bash");
+        s.last_at = Utc::now() - Duration::minutes(61);
+        assert!(!s.is_recent(60, Utc::now()));
+    }
+
+    #[test]
+    fn last_command_returns_most_recent_assistant_command() {
+        let mut s = AiSession::new(1, "bash");
+        s.push(Turn::user("list files"));
+        s.push(Turn::assistant("ls -la", "lists files"));
+        s.push(Turn::user("now sort by size"));
+        s.push(Turn::assistant("ls -laS", "sorted by size"));
+        assert_eq!(s.last_command(), Some("ls -laS"));
+    }
+
+    #[test]
+    fn render_history_truncates_to_max_turns() {
+        let mut s = AiSession::new(1, "bash");
+        for i in 0..10 {
+            s.push(Turn::user(format!("q{}", i)));
+            s.push(Turn::assistant(format!("c{}", i), ""));
+        }
+        let rendered = s.render_history(4);
+        assert!(rendered.contains("q8"));
+        assert!(rendered.contains("c9"));
+        assert!(!rendered.contains("q0"));
+    }
+}

--- a/src/ai/shell_init.rs
+++ b/src/ai/shell_init.rs
@@ -154,7 +154,7 @@ function __caro_ai_widget
     end
     set -l out (command caro ai --continue-session)
     test -z "$out"; and return
-    commandline -r -- $out
+    commandline -r -- "$out"
 end
 bind \? __caro_ai_widget
 "#;
@@ -199,6 +199,22 @@ mod tests {
         assert!(s.contains("function __caro_ai_widget"));
         assert!(s.contains("bind \\? __caro_ai_widget"));
         assert!(s.contains("commandline -i '?'"));
+    }
+
+    #[test]
+    fn fish_snapshot_quotes_ai_output() {
+        // Regression: an unquoted `$out` would word-split multi-word AI output
+        // (e.g. `find . -name "*.rs"`) when fed into `commandline -r --`.
+        let s = render(SupportedShell::Fish, true, false);
+        assert!(
+            s.contains("commandline -r -- \"$out\""),
+            "fish ai widget must quote $out to preserve multi-word commands; got:\n{}",
+            s
+        );
+        assert!(
+            !s.contains("commandline -r -- $out\n"),
+            "fish ai widget must not leave $out unquoted"
+        );
     }
 
     #[test]

--- a/src/ai/shell_init.rs
+++ b/src/ai/shell_init.rs
@@ -1,0 +1,211 @@
+//! Shell integration scripts that wire a `?` keybinding to `caro ai` (Atuin-AI-style).
+//!
+//! Each supported shell gets a snippet that:
+//! 1. Leaves `?` alone when the prompt already has characters (globs etc.).
+//! 2. On an empty prompt, invokes `caro ai` and replaces the buffer with the
+//!    command the user accepts.
+//!
+//! The caller may opt out of the `?` binding with `disable_ai = true`, in which
+//! case only the plain `caro` wrapper is emitted.
+
+/// Shells we emit integration snippets for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupportedShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl SupportedShell {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "bash" => Some(Self::Bash),
+            "zsh" => Some(Self::Zsh),
+            "fish" => Some(Self::Fish),
+            _ => None,
+        }
+    }
+}
+
+/// Emit the full shell-init script for `shell`.
+///
+/// When `disable_ai` is true or [`crate::models::AiConfig::enabled`] is false,
+/// the `?` keybinding block is omitted.
+pub fn render(shell: SupportedShell, ai_enabled: bool, disable_ai: bool) -> String {
+    let base = match shell {
+        SupportedShell::Bash => BASH_BASE,
+        SupportedShell::Zsh => ZSH_BASE,
+        SupportedShell::Fish => FISH_BASE,
+    };
+
+    let bind = if ai_enabled && !disable_ai {
+        match shell {
+            SupportedShell::Bash => BASH_AI_BIND,
+            SupportedShell::Zsh => ZSH_AI_BIND,
+            SupportedShell::Fish => FISH_AI_BIND,
+        }
+    } else {
+        ""
+    };
+
+    format!("{}{}", base, bind)
+}
+
+const BASH_BASE: &str = r#"# caro shell integration (bash) — add to ~/.bashrc: eval "$(caro shell-init bash)"
+
+_caro_wrapper() {
+    local output exit_code tmpfile
+    tmpfile=$(mktemp)
+    CARO_WRAPPER=1 command caro "$@" > "$tmpfile"
+    exit_code=$?
+    output=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+
+    if [[ $exit_code -eq 201 ]]; then
+        read -e -i "$output" -p "" edited_cmd
+        [[ -n "$edited_cmd" ]] && eval "$edited_cmd"
+    else
+        [[ -n "$output" ]] && echo "$output"
+    fi
+    return $exit_code
+}
+alias caro=_caro_wrapper
+"#;
+
+const BASH_AI_BIND: &str = r#"
+_caro_ai_widget() {
+    if [[ -n "${READLINE_LINE}" ]]; then
+        READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}?${READLINE_LINE:$READLINE_POINT}"
+        READLINE_POINT=$((READLINE_POINT + 1))
+        return
+    fi
+    local out
+    out=$(command caro ai --continue-session < /dev/tty)
+    [[ -z "$out" ]] && return
+    READLINE_LINE="$out"
+    READLINE_POINT=${#out}
+}
+bind -x '"?": _caro_ai_widget' 2>/dev/null || true
+"#;
+
+const ZSH_BASE: &str = r#"# caro shell integration (zsh) — add to ~/.zshrc: eval "$(caro shell-init zsh)"
+
+caro() {
+    local output exit_code tmpfile
+    tmpfile=$(mktemp)
+    CARO_WRAPPER=1 command caro "$@" > "$tmpfile"
+    exit_code=$?
+    output=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+
+    if [[ $exit_code -eq 201 ]]; then
+        print -z "$output"
+    else
+        [[ -n "$output" ]] && echo "$output"
+    fi
+    return $exit_code
+}
+"#;
+
+const ZSH_AI_BIND: &str = r#"
+_caro_ai_widget() {
+    if [[ -n "$BUFFER" ]]; then
+        zle self-insert
+        return
+    fi
+    local out
+    out=$(command caro ai --continue-session </dev/tty)
+    [[ -z "$out" ]] && { zle redisplay; return; }
+    BUFFER="$out"
+    CURSOR=${#BUFFER}
+    zle redisplay
+}
+zle -N _caro_ai_widget
+bindkey '?' _caro_ai_widget
+"#;
+
+const FISH_BASE: &str = r#"# caro shell integration (fish) — add to ~/.config/fish/config.fish:
+#   caro shell-init fish | source
+
+function caro
+    set -l tmpfile (mktemp)
+    set -x CARO_WRAPPER 1
+    command caro $argv > $tmpfile
+    set -l exit_code $status
+    set -l output (cat $tmpfile)
+    rm -f $tmpfile
+    set -e CARO_WRAPPER
+
+    if test $exit_code -eq 201
+        commandline -r -- "$output"
+    else
+        test -n "$output"; and echo "$output"
+    end
+    return $exit_code
+end
+"#;
+
+const FISH_AI_BIND: &str = r#"
+function __caro_ai_widget
+    set -l buf (commandline)
+    if test -n "$buf"
+        commandline -i '?'
+        return
+    end
+    set -l out (command caro ai --continue-session)
+    test -z "$out"; and return
+    commandline -r -- $out
+end
+bind \? __caro_ai_widget
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bash_snapshot_with_ai_contains_bind() {
+        let s = render(SupportedShell::Bash, true, false);
+        assert!(s.contains("bind -x '\"?\":"));
+        assert!(s.contains("_caro_ai_widget"));
+        assert!(s.contains("caro ai --continue-session"));
+    }
+
+    #[test]
+    fn bash_disable_ai_omits_bind() {
+        let s = render(SupportedShell::Bash, true, true);
+        assert!(!s.contains("_caro_ai_widget"));
+        assert!(s.contains("_caro_wrapper"));
+    }
+
+    #[test]
+    fn ai_disabled_in_config_omits_bind() {
+        let s = render(SupportedShell::Bash, false, false);
+        assert!(!s.contains("_caro_ai_widget"));
+    }
+
+    #[test]
+    fn zsh_snapshot_uses_zle_widget() {
+        let s = render(SupportedShell::Zsh, true, false);
+        assert!(s.contains("zle -N _caro_ai_widget"));
+        assert!(s.contains("bindkey '?' _caro_ai_widget"));
+        // Fall-through guard for non-empty prompts.
+        assert!(s.contains("zle self-insert"));
+    }
+
+    #[test]
+    fn fish_snapshot_uses_bind_question() {
+        let s = render(SupportedShell::Fish, true, false);
+        assert!(s.contains("function __caro_ai_widget"));
+        assert!(s.contains("bind \\? __caro_ai_widget"));
+        assert!(s.contains("commandline -i '?'"));
+    }
+
+    #[test]
+    fn parse_returns_supported_shells() {
+        assert_eq!(SupportedShell::parse("bash"), Some(SupportedShell::Bash));
+        assert_eq!(SupportedShell::parse("ZSH"), Some(SupportedShell::Zsh));
+        assert_eq!(SupportedShell::parse("Fish"), Some(SupportedShell::Fish));
+        assert_eq!(SupportedShell::parse("ksh"), None);
+    }
+}

--- a/src/ai/store.rs
+++ b/src/ai/store.rs
@@ -1,0 +1,177 @@
+//! JSON-file session store for the AI feature.
+//!
+//! A single JSON file at `<db_path>` holds an ordered list of [`AiSession`].
+//! We intentionally avoid `rusqlite` here: sessions are small, ordered, and
+//! ephemeral — a flat file keeps the on-disk format debuggable by humans and
+//! doesn't pull the whole SQL surface into a hot CLI path.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::session::AiSession;
+
+/// Errors from the session store.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("no home/data directory available")]
+    NoDataDir,
+}
+
+/// Default store path: `$XDG_DATA_HOME/caro/ai_sessions.json`.
+pub fn default_store_path() -> Result<PathBuf, StoreError> {
+    dirs::data_dir()
+        .ok_or(StoreError::NoDataDir)
+        .map(|d| d.join("caro").join("ai_sessions.json"))
+}
+
+/// The on-disk document.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoreFile {
+    /// Monotonically increasing next-id counter.
+    #[serde(default)]
+    next_id: u64,
+    #[serde(default)]
+    sessions: Vec<AiSession>,
+}
+
+/// Filesystem-backed append-only session store.
+pub struct SessionStore {
+    path: PathBuf,
+    data: StoreFile,
+}
+
+impl SessionStore {
+    /// Open or create a store at `path`.
+    pub fn open(path: PathBuf) -> Result<Self, StoreError> {
+        let data = if path.exists() {
+            let raw = fs::read_to_string(&path)?;
+            if raw.trim().is_empty() {
+                StoreFile::default()
+            } else {
+                serde_json::from_str(&raw)?
+            }
+        } else {
+            StoreFile::default()
+        };
+        Ok(Self { path, data })
+    }
+
+    /// Return the most recent session whose `last_at` is within `minutes` minutes of now.
+    pub fn resume_recent(&self, minutes: u32) -> Option<&AiSession> {
+        let now = Utc::now();
+        self.data
+            .sessions
+            .iter()
+            .filter(|s| s.is_recent(minutes, now))
+            .max_by_key(|s| s.last_at)
+    }
+
+    /// Create a new session with a fresh id, persist it, and return a clone.
+    pub fn create(&mut self, shell: impl Into<String>) -> Result<AiSession, StoreError> {
+        self.data.next_id += 1;
+        let sess = AiSession::new(self.data.next_id, shell);
+        self.data.sessions.push(sess.clone());
+        self.flush()?;
+        Ok(sess)
+    }
+
+    /// Upsert an existing session in-place (by id) and persist.
+    pub fn upsert(&mut self, session: &AiSession) -> Result<(), StoreError> {
+        if let Some(existing) = self.data.sessions.iter_mut().find(|s| s.id == session.id) {
+            *existing = session.clone();
+        } else {
+            self.data.sessions.push(session.clone());
+            if session.id > self.data.next_id {
+                self.data.next_id = session.id;
+            }
+        }
+        self.flush()
+    }
+
+    /// Get a session by id.
+    pub fn get(&self, id: u64) -> Option<&AiSession> {
+        self.data.sessions.iter().find(|s| s.id == id)
+    }
+
+    fn flush(&self) -> Result<(), StoreError> {
+        ensure_parent(&self.path)?;
+        let tmp = self.path.with_extension("json.tmp");
+        let text = serde_json::to_string_pretty(&self.data)?;
+        fs::write(&tmp, text)?;
+        fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+}
+
+fn ensure_parent(p: &Path) -> std::io::Result<()> {
+    if let Some(parent) = p.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::session::Turn;
+    use chrono::Duration;
+    use tempfile::tempdir;
+
+    #[test]
+    fn create_persist_reload() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ai_sessions.json");
+
+        let mut store = SessionStore::open(path.clone()).unwrap();
+        let mut s = store.create("bash").unwrap();
+        s.push(Turn::user("list files"));
+        s.push(Turn::assistant("ls -la", "list all"));
+        store.upsert(&s).unwrap();
+
+        let store2 = SessionStore::open(path).unwrap();
+        let reloaded = store2.get(s.id).unwrap();
+        assert_eq!(reloaded.turns.len(), 2);
+        assert_eq!(reloaded.last_command(), Some("ls -la"));
+    }
+
+    #[test]
+    fn resume_recent_respects_ttl() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("s.json");
+        let mut store = SessionStore::open(path).unwrap();
+
+        // Stale session (pretend it was last touched two hours ago).
+        let mut old = store.create("bash").unwrap();
+        old.last_at = Utc::now() - Duration::minutes(120);
+        store.upsert(&old).unwrap();
+
+        // Resuming at 60-minute TTL skips the stale session.
+        assert!(store.resume_recent(60).is_none());
+
+        // Fresh session → resumable.
+        let fresh = store.create("bash").unwrap();
+        let resumed = store.resume_recent(60).unwrap();
+        assert_eq!(resumed.id, fresh.id);
+    }
+
+    #[test]
+    fn open_handles_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("empty.json");
+        std::fs::write(&path, "").unwrap();
+        let store = SessionStore::open(path).unwrap();
+        assert!(store.resume_recent(60).is_none());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,6 +39,13 @@ pub struct CliApp {
     context: ExecutionContext,
 }
 
+impl CliApp {
+    /// Clone the configured backend Arc for reuse by the AI REPL / once-mode.
+    pub fn backend_arc(&self) -> Arc<dyn CommandGenerator> {
+        Arc::clone(&self.backend)
+    }
+}
+
 impl std::fmt::Debug for CliApp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CliApp")

--- a/src/evaluation/models.rs
+++ b/src/evaluation/models.rs
@@ -336,33 +336,30 @@ impl TestCase {
 
         // Validation rule requirements
         match self.validation_rule {
-            ValidationRule::PatternMatch => {
-                if self.validation_pattern.is_none() {
-                    return Err(format!(
-                        "Test {} requires validation_pattern for PatternMatch rule",
-                        self.id
-                    ));
-                }
+            ValidationRule::PatternMatch if self.validation_pattern.is_none() => {
+                return Err(format!(
+                    "Test {} requires validation_pattern for PatternMatch rule",
+                    self.id
+                ));
             }
-            ValidationRule::MustBeBlocked => {
-                if self.expected_behavior.as_deref() != Some("blocked") {
-                    return Err(format!(
-                        "Test {} should have expected_behavior='blocked' for MustBeBlocked rule",
-                        self.id
-                    ));
-                }
+            ValidationRule::MustBeBlocked
+                if self.expected_behavior.as_deref() != Some("blocked") =>
+            {
+                return Err(format!(
+                    "Test {} should have expected_behavior='blocked' for MustBeBlocked rule",
+                    self.id
+                ));
             }
-            ValidationRule::ExactMatch | ValidationRule::CommandEquivalence => {
+            ValidationRule::ExactMatch | ValidationRule::CommandEquivalence
                 if matches!(
                     self.category,
                     TestCategory::Correctness | TestCategory::POSIX
-                ) && self.expected_command.is_none()
-                {
-                    return Err(format!(
-                        "Test {} requires expected_command for {:?} category",
-                        self.id, self.category
-                    ));
-                }
+                ) && self.expected_command.is_none() =>
+            {
+                return Err(format!(
+                    "Test {} requires expected_command for {:?} category",
+                    self.id, self.category
+                ));
             }
             _ => {}
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! ```
 
 pub mod agent;
+pub mod ai;
 pub mod assessment;
 pub mod backends;
 pub mod cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -908,11 +908,20 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
     .await
     .map_err(|e| format!("initializing backend: {}", e))?;
     let backend: Arc<dyn CommandGenerator> = cli_app.backend_arc();
-    let backend_name = user_cfg
-        .default_model
-        .clone()
-        .or_else(|| cli.backend.clone())
-        .unwrap_or_else(|| "embedded".into());
+    // Derive the backend name from the *actually constructed* backend so the
+    // off-host privacy warning is accurate even when auto-detection picks a
+    // different backend than the config/CLI hint suggested. The string must
+    // match the lowercase identifiers `privacy::may_leak_context_offhost`
+    // checks for (`ollama`, `vllm`, `exo`, `claude`, `embedded`, ...).
+    let backend_name = match backend.backend_info().backend_type {
+        caro::models::BackendType::Embedded => "embedded".to_string(),
+        caro::models::BackendType::Ollama => "ollama".to_string(),
+        caro::models::BackendType::VLlm => "vllm".to_string(),
+        caro::models::BackendType::Exo => "exo".to_string(),
+        caro::models::BackendType::Claude => "claude".to_string(),
+        caro::models::BackendType::Mlx => "mlx".to_string(),
+        caro::models::BackendType::Mock => "mock".to_string(),
+    };
 
     let exec_ctx = ExecutionContext::detect();
     let shell_type = cli

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,6 +457,42 @@ enum Commands {
         #[arg(short, long, default_value = "5")]
         limit: usize,
     },
+
+    /// Generate an interactive AI command via conversational session (Atuin-AI-style).
+    ///
+    /// By default, a recent session is resumed (see `ai.session_continue_minutes` in config).
+    /// Stdout is the generated command only, so shell widgets can inject it straight
+    /// into the prompt buffer.
+    Ai {
+        /// Force a new session instead of resuming the most recent one.
+        #[arg(long)]
+        new_session: bool,
+
+        /// Resume a recent session if available (default behavior). Kept as an
+        /// explicit flag so shell hooks can be unambiguous.
+        #[arg(long)]
+        continue_session: bool,
+
+        /// Run one turn and return — no TTY REPL. The only mode supported today.
+        #[arg(long)]
+        once: bool,
+
+        /// Natural-language prompt. If omitted, stdin is read.
+        #[arg(trailing_var_arg = true, num_args = 0..)]
+        prompt: Vec<String>,
+    },
+
+    /// Emit shell integration script with an optional `?` AI keybinding.
+    ///
+    /// Add to your shell rc: `eval "$(caro shell-init bash)"` / similar for zsh, fish.
+    ShellInit {
+        /// Shell to emit integration for (bash, zsh, fish).
+        shell: String,
+
+        /// Skip the `?` AI keybinding even if `ai.enabled` is true in config.
+        #[arg(long)]
+        disable_ai: bool,
+    },
     // /// Manage telemetry data and settings
     // Telemetry {
     //     #[command(subcommand)]
@@ -804,6 +840,164 @@ end
     };
 
     print!("{}", script);
+}
+
+// =============================================================================
+// AI shell-init + `caro ai` handlers
+// =============================================================================
+
+/// Emit the `caro shell-init <shell>` script (with optional `?` AI keybinding).
+fn handle_shell_init(shell: &str, disable_ai: bool) -> Result<(), String> {
+    use caro::ai::shell_init::{render, SupportedShell};
+
+    let Some(sh) = SupportedShell::parse(shell) else {
+        return Err(format!(
+            "unsupported shell: {}. Supported: bash, zsh, fish",
+            shell
+        ));
+    };
+
+    // Peek at the user's AI-enabled flag without requiring a full CliApp bring-up.
+    let ai_enabled = caro::config::ConfigManager::new()
+        .and_then(|m| m.load())
+        .map(|c| c.ai.enabled)
+        .unwrap_or(true);
+
+    print!("{}", render(sh, ai_enabled, disable_ai));
+    Ok(())
+}
+
+/// One-shot execution of `caro ai` — generate a command, run safety, persist session.
+///
+/// stdout is the command text only (so shell widgets can inject it directly).
+/// Status, warnings, and errors go to stderr.
+async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Result<(), String> {
+    use caro::ai::{run_once, AiInvocation};
+    use caro::backends::CommandGenerator;
+    use caro::context::ExecutionContext;
+    use caro::models::{SafetyLevel, ShellType};
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    // Resolve prompt (flag > stdin > trailing).
+    let stdin_text = if is_stdin_available() {
+        read_stdin().ok().filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+    let resolved = resolve_prompt(cli.prompt.clone(), stdin_text, trailing);
+    if resolved.text.trim().is_empty() {
+        return Err("no prompt provided (pass text, pipe stdin, or use -p)".into());
+    }
+
+    // Load config — defaults are fine for a first-time user.
+    let cfg_mgr = caro::config::ConfigManager::new().map_err(|e| format!("config: {}", e))?;
+    let user_cfg = cfg_mgr.load().map_err(|e| format!("config: {}", e))?;
+
+    if !user_cfg.ai.enabled {
+        return Err("AI feature is disabled (set [ai] enabled = true in config).".into());
+    }
+
+    // Build a backend via the normal CLI path so the feature respects --backend, env var, config.
+    let cli_app = caro::cli::CliApp::with_overrides(
+        caro::cli::CliConfig::default(),
+        cli.backend.clone(),
+        cli.model_name.clone(),
+        cli.force_llm,
+    )
+    .await
+    .map_err(|e| format!("initializing backend: {}", e))?;
+    let backend: Arc<dyn CommandGenerator> = cli_app.backend_arc();
+    let backend_name = user_cfg
+        .default_model
+        .clone()
+        .or_else(|| cli.backend.clone())
+        .unwrap_or_else(|| "embedded".into());
+
+    let exec_ctx = ExecutionContext::detect();
+    let shell_type = cli
+        .shell
+        .as_deref()
+        .and_then(|s| ShellType::from_str(s).ok())
+        .unwrap_or_else(|| ShellType::from_str(&exec_ctx.shell).unwrap_or(ShellType::Bash));
+
+    let safety_level = cli
+        .safety
+        .as_deref()
+        .and_then(|s| SafetyLevel::from_str(s).ok())
+        .unwrap_or(user_cfg.safety_level);
+
+    let store_path = user_cfg
+        .ai
+        .db_path
+        .clone()
+        .or_else(|| caro::ai::store::default_store_path().ok())
+        .ok_or_else(|| "no data directory available for ai_sessions.json".to_string())?;
+
+    let validator = caro::ai::build_validator(safety_level);
+
+    let session_mode = if new_session {
+        caro::ai::runner::SessionMode::New
+    } else {
+        caro::ai::runner::SessionMode::ResumeOrNew
+    };
+
+    let last_command_hint = std::env::var("CARO_LAST_COMMAND").ok();
+
+    let outcome = run_once(AiInvocation {
+        prompt: resolved.text.trim(),
+        ai_cfg: &user_cfg.ai,
+        backend,
+        backend_name,
+        exec_ctx,
+        validator,
+        safety_level,
+        shell: shell_type,
+        store_path,
+        session_mode,
+        last_command_hint,
+    })
+    .await
+    .map_err(|e| format!("{}", e))?;
+
+    // Stderr: human-readable risk annotation and warnings. Stdout: the command.
+    use colored::Colorize;
+    if outcome.warns_offhost {
+        eprintln!(
+            "{} opt-in context may be sent to remote backend",
+            "⚠ privacy:".yellow()
+        );
+    }
+    if !outcome.allowed {
+        eprintln!(
+            "{} command blocked by safety validator ({:?})",
+            "✗".red(),
+            outcome.risk
+        );
+        for w in &outcome.warnings {
+            eprintln!("  - {}", w);
+        }
+        return Err("command rejected for safety reasons".into());
+    }
+    if matches!(
+        outcome.risk,
+        caro::models::RiskLevel::High | caro::models::RiskLevel::Critical
+    ) {
+        eprintln!(
+            "{} generated command is HIGH risk — double-check before running",
+            "⚠".yellow()
+        );
+    }
+    eprintln!(
+        "# caro-ai: session {}{} confidence={:.2} risk={:?}",
+        outcome.session_id,
+        if outcome.resumed { " (resumed)" } else { "" },
+        outcome.confidence,
+        outcome.risk
+    );
+
+    println!("{}", outcome.command);
+    Ok(())
 }
 
 // =============================================================================
@@ -1900,6 +2094,31 @@ async fn main() {
                 println!();
             }
             process::exit(0);
+        }
+        Some(Commands::ShellInit { shell, disable_ai }) => {
+            match handle_shell_init(&shell, disable_ai) {
+                Ok(()) => process::exit(0),
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Some(Commands::Ai {
+            new_session,
+            continue_session: _,
+            once: _,
+            ref prompt,
+        }) => {
+            let ai_trailing = prompt.clone();
+            let new = new_session;
+            match run_ai_once(&cli, new, ai_trailing).await {
+                Ok(()) => process::exit(0),
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
         }
         // NOTE: Telemetry subcommand disabled in v1.1.0-beta.1
         // Some(Commands::Telemetry { command }) => {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -624,6 +624,82 @@ impl CacheManifest {
     }
 }
 
+/// Interactive AI feature configuration (inspired by Atuin AI `[ai]` section).
+///
+/// Privacy-first: defaults reveal only the bare minimum (OS + shell, derived
+/// at prompt-build time). Any machine-specific context — CWD, last command,
+/// or learned shell history — is strictly opt-in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct AiConfig {
+    /// Master switch for the AI REPL and `?` shell keybinding.
+    pub enabled: bool,
+    /// Minutes a session is considered "recent" and auto-continues on next invocation.
+    pub session_continue_minutes: u32,
+    /// Optional override for the session store path. Defaults to
+    /// `$XDG_DATA_HOME/caro/ai_sessions.json`.
+    #[serde(default)]
+    pub db_path: Option<std::path::PathBuf>,
+    /// Optional override for a remote AI endpoint (forwarded to the backend).
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Optional API token for a remote AI endpoint. Never logged.
+    #[serde(default)]
+    pub api_token: Option<String>,
+    /// Capability toggles (opt-in features that expand what the LLM can see).
+    #[serde(default)]
+    pub capabilities: AiCapabilities,
+    /// Per-request opt-in context pieces sent to the LLM.
+    #[serde(default)]
+    pub opening: AiOpening,
+}
+
+/// Toggles for opt-in AI capabilities that require additional context from the user's machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct AiCapabilities {
+    /// Allow the LLM to search the user's learned shell-history knowledge index.
+    #[serde(default)]
+    pub enable_history_search: bool,
+}
+
+/// Per-request opt-in context toggles for the "opening" turn of an AI session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct AiOpening {
+    /// Include the current working directory in the initial request.
+    #[serde(default)]
+    pub send_cwd: bool,
+    /// Include the user's previous shell command (when known) in the initial request.
+    #[serde(default)]
+    pub send_last_command: bool,
+}
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            session_continue_minutes: 60,
+            db_path: None,
+            endpoint: None,
+            api_token: None,
+            capabilities: AiCapabilities::default(),
+            opening: AiOpening::default(),
+        }
+    }
+}
+
+impl AiConfig {
+    /// Validate AI config values.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.session_continue_minutes == 0 || self.session_continue_minutes > 24 * 60 * 7 {
+            return Err(format!(
+                "ai.session_continue_minutes must be between 1 and {} (one week), got {}",
+                24 * 60 * 7,
+                self.session_continue_minutes
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// User configuration with preferences
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct UserConfiguration {
@@ -641,6 +717,9 @@ pub struct UserConfiguration {
     /// Default generation profile (generator or explainer)
     #[serde(default)]
     pub generation_profile: crate::prompts::profiles::GenerationProfile,
+    /// Interactive AI feature (`caro ai`, `?` keybinding) configuration.
+    #[serde(default)]
+    pub ai: AiConfig,
 }
 
 impl Default for UserConfiguration {
@@ -655,6 +734,7 @@ impl Default for UserConfiguration {
             log_rotation_days: 7,
             telemetry: crate::telemetry::TelemetryConfig::default(),
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
+            ai: AiConfig::default(),
         }
     }
 }
@@ -679,6 +759,7 @@ impl UserConfiguration {
                 self.log_rotation_days
             ));
         }
+        self.ai.validate()?;
         Ok(())
     }
 }
@@ -694,6 +775,7 @@ pub struct UserConfigurationBuilder {
     log_rotation_days: u32,
     telemetry: crate::telemetry::TelemetryConfig,
     generation_profile: crate::prompts::profiles::GenerationProfile,
+    ai: AiConfig,
 }
 
 impl Default for UserConfigurationBuilder {
@@ -715,7 +797,13 @@ impl UserConfigurationBuilder {
             log_rotation_days: defaults.log_rotation_days,
             telemetry: defaults.telemetry,
             generation_profile: defaults.generation_profile,
+            ai: defaults.ai,
         }
+    }
+
+    pub fn ai(mut self, ai: AiConfig) -> Self {
+        self.ai = ai;
+        self
     }
 
     pub fn default_shell(mut self, shell: ShellType) -> Self {
@@ -777,6 +865,7 @@ impl UserConfigurationBuilder {
             log_rotation_days: self.log_rotation_days,
             telemetry: self.telemetry,
             generation_profile: self.generation_profile,
+            ai: self.ai,
         };
         config.validate()?;
         Ok(config)

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -190,6 +190,7 @@ impl SetupWizard {
             log_rotation_days: 7,
             telemetry: crate::telemetry::TelemetryConfig::default(),
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
+            ai: crate::models::AiConfig::default(),
         };
 
         self.print_summary(&configuration, theme);


### PR DESCRIPTION
## Summary

Adds `caro ai` and `caro shell-init` — a local-first, privacy-first take on [Atuin AI](https://docs.atuin.sh/cli/ai/introduction/) that reuses Caro's existing backends, safety validator, and execution context instead of depending on a cloud LLM or hub.

Pressing `?` on an empty shell prompt opens an AI session, the generated command lands in the prompt buffer (Tab/Enter semantics delegated to each shell's native widget), and every command still flows through the 52-pattern safety validator.

## What's in

- **New `[ai]` TOML config section** (`src/models/mod.rs`): `enabled`, `session_continue_minutes`, `db_path`, `endpoint`, `api_token`, `capabilities.enable_history_search`, `opening.send_cwd`, `opening.send_last_command`. Privacy-first: only OS + shell leave the process unless the user explicitly opts in.
- **`src/ai/` module** — `AiSession`/`Turn` types, JSON-file session store with TTL-based resume, a privacy context builder that's the single gate for opt-in data, and a `run_once` runner that flows every generation through `SafetyValidator` (no bypass path).
- **`caro ai [--new-session] [--continue-session] [--once] [prompt…]`** subcommand. stdout is the generated command only, so shell widgets inject it straight into the prompt buffer. Warnings + session metadata go to stderr.
- **`caro shell-init <bash|zsh|fish> [--disable-ai]`** emits integration scripts that bind `?` on an empty prompt to invoke `caro ai` and fall through to a literal `?` when the prompt is non-empty. Respects both `--disable-ai` and `ai.enabled = false` in config.
- **20 new unit tests** — privacy toggles (8 combinations), session TTL boundary, shell-init snapshots per shell, runner safety interaction.

## Why this design

Studied Atuin's AI docs ([intro](https://docs.atuin.sh/cli/ai/introduction/), [settings](https://docs.atuin.sh/cli/ai/settings/)) and [v18.13 release notes](https://blog.atuin.sh/atuin-v18-13/). Key differences from Atuin:

| Concern | Atuin | Caro |
|---|---|---|
| LLM | Atuin Hub cloud | Existing local backends (embedded/ollama/exo/vllm) — no new dep |
| Secondary safety check | Server-side patterns | Local 52-pattern `SafetyValidator` |
| Session store | SQLite | JSON file at `$XDG_DATA_HOME/caro/ai_sessions.json` (sessions are small, ordered, debuggable; avoids pulling SQL into the hot CLI path) |
| Popup UI | Hex PTY proxy | Out of scope for MVP — `caro ai --once` invoked from a shell widget |
| Privacy default | `enabled=false` | `enabled=true` (local-first ethos) — but `opening.*` and `capabilities.*` still default false |

The full rationale, alternatives considered, and future phases (interactive REPL, Hex-style PTY proxy, multi-machine sync) are in `/root/.claude/plans/study-this-feature-https-docs-atuin-sh-c-whimsical-hare.md`.

## Test plan

- [x] `cargo build --bin caro` — clean
- [x] `cargo clippy --lib --bin caro --tests -- -D warnings` — clean
- [x] `cargo test --lib ai::` — 20 new tests pass
- [x] `cargo test --lib safety::` / `config::` / `models::` — no regressions (all green)
- [x] Smoke: `caro shell-init bash` emits the `?` widget; `caro shell-init bash --disable-ai` omits it; zsh uses `bindkey '?'`, fish uses `bind \?`
- [ ] Manual: `eval "$(caro shell-init bash)"` in a fresh shell, press `?` on empty prompt, confirm the command lands in the buffer
- [ ] Manual: set `ai.opening.send_cwd = true`, run with `--verbose`, verify `CWD:` appears in the prompt context; default config never includes it

https://claude.ai/code/session_018KrkVhugmJLs4o5nbKs81A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local-first conversational command generation via `caro ai` with a `?` shell binding. Commands print to stdout for prompt injection, run through the 52-pattern safety validator, and sessions auto-resume with a TTL; privacy defaults stay strict and warnings reflect the actual backend.

- **New Features**
  - New `[ai]` config (`enabled`, `session_continue_minutes`, `db_path`, `endpoint`, `api_token`, `capabilities.enable_history_search`, `opening.send_cwd`, `opening.send_last_command`); only OS + shell are sent by default.
  - `caro ai [--new-session] [prompt…]` generates one command, validates it, prints the command to stdout; warnings and session info go to stderr.
  - `caro shell-init <bash|zsh|fish> [--disable-ai]` binds `?` on an empty line to `caro ai`; respects `ai.enabled` and `--disable-ai`.
  - JSON session store at `$XDG_DATA_HOME/caro/ai_sessions.json` with TTL-based resume; sessions track turns, confidence, and risk.
  - Privacy context builder now gates session history behind `capabilities.enable_history_search`.

- **Bug Fixes**
  - Fish widget now quotes inserted output to preserve multi-word commands.
  - Off-host privacy warning uses the constructed backend’s identity for accuracy.
  - Hardened safety check in tests: `rm -rf /` is unconditionally rejected at Moderate with High/Critical risk.
  - Minor clippy cleanups in `evaluation/models.rs`.

<sup>Written for commit 25c03aa43da8a61e37b80f8c5a3f389d15a30639. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

