### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.3.0] - 2026-04-20
+
+### Added
+
+- **`caro ai` conversational command generation** (#861): Atuin-AI-style once-mode
+  AI invocation that resumes or creates a session, runs the prompt through the
+  configured backend, validates the result via the existing 52-pattern
+  `SafetyValidator`, and persists the turn.
+  - `caro ai --once "<prompt>"` for scripted use
+  - `caro ai --continue-session` for shell-widget invocation
+  - TTL-based session resume via `session_continue_minutes`
+- **`caro shell-init <bash|zsh|fish>`** (#861): emits a shell integration script
+  that binds `?` on an empty prompt to `caro ai`. Literal `?` is preserved when
+  the prompt already has characters (globs etc.). Fish output is properly quoted
+  to preserve multi-word commands.
+- **`[ai]` config block** (#861): strict opt-in privacy gates — `opening.send_cwd`,
+  `opening.send_last_command`, `capabilities.enable_history_search` all default
+  to `false`. With defaults, only the OS + shell name leaves the process.
+- **Off-host context warning** (#861): when a remote backend (ollama, vllm, exo,
+  claude) is configured alongside any opt-in context toggle and an explicit
+  endpoint, stderr surfaces a warning before the generation happens.
+- **`CliApp::backend_arc()` accessor** (#861): exposes the constructed backend
+  for reuse without re-instantiation.
+
+### Security
+
+- Every command produced by `caro ai` flows through the same 52-pattern
+  `SafetyValidator` used for `caro <prompt>`; `rm -rf /` at `SafetyLevel::Moderate`
+  is unconditionally blocked (covered by a new strict regression test in
+  `src/ai/runner.rs`).
+- Session history is only included in LLM context when
+  `capabilities.enable_history_search` is true, closing the leak that could have
+  bypassed the opening-context opt-in toggles.
+
+### Internal
+
+- New `src/ai/` module: `privacy`, `session`, `store`, `runner`, `shell_init`
+  (23 unit tests covering privacy toggle combinations, session TTL, shell-init
+  snapshots, and safety integration).
+- Collapsed 3 pre-existing clippy `collapsible_match` warnings in
+  `src/evaluation/models.rs` to unblock `-D warnings` on the lint CI job.
+
 ## [1.2.0] - 2026-03-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "caro"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caro"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.83"
 description = "Convert natural language to shell commands using local LLMs"


### PR DESCRIPTION
## Summary

Release v1.3.0 — headline feature is `caro ai` (#861).

- **[Added]** `caro ai --once "<prompt>"` and `caro ai --continue-session` — Atuin-AI-style once-mode conversational command generation, resuming/creating a session, validating via the 52-pattern `SafetyValidator`, and persisting turns.
- **[Added]** `caro shell-init <bash|zsh|fish>` — `?`-on-empty-prompt shell integration with fish output properly quoted to preserve multi-word commands.
- **[Added]** `[ai]` config block — strict opt-in privacy gates (`opening.send_cwd`, `opening.send_last_command`, `capabilities.enable_history_search` all default to `false`). With defaults, only OS + shell name leave the process.
- **[Added]** Off-host context warning when remote backend + opt-in context toggle + explicit endpoint combine.
- **[Security]** Every `caro ai` command flows through the same `SafetyValidator`; `rm -rf /` unconditionally blocked at Moderate safety (strict regression test).
- **[Security]** Session history only joins LLM context when `enable_history_search = true` — closes leak that bypassed opening-context toggles.
- **[Internal]** New `src/ai/` module (23 unit tests); collapsed 3 pre-existing clippy warnings in `src/evaluation/models.rs`.

No breaking changes — minor bump from 1.2.0.

## Test plan

- [ ] CI green: Unit Tests (Linux/macOS/Windows), MSRV 1.83, Build Check matrix, LLM Eval harness, Knowledge Integration, Smoke Tests, Lint & Format
- [ ] Post-merge: tag `v1.3.0`, push tag, verify binary publish + crates.io listing via `caro.release.verify`
- [ ] Spot-check: `cargo install caro --version 1.3.0` on clean system; `caro --version` → `1.3.0`; `caro shell-init bash | head` renders; `caro ai --help` documents subcommand

Pre-existing CI noise expected to stay red (BSD cross-platform, Security Audit RUSTSEC-2026-0098/0099 on `rustls-webpki`, ChromaDB integration, Vercel frontends) — all verified failing identically on main prior to this release. Track as separate follow-ups, do not block the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.3.0 adds `caro ai` for conversational command generation with safety validation and a `?` shell binding, plus strict opt-in privacy defaults. No breaking changes.

- **New Features**
  - `caro ai --once "<prompt>"` and `--continue-session`; sessions resume via `session_continue_minutes`.
  - `caro shell-init <bash|zsh|fish>` binds `?` on an empty prompt to `caro ai`; fish output is properly quoted.
  - `[ai]` config opt-ins (`opening.send_cwd`, `opening.send_last_command`, `capabilities.enable_history_search`) default to `false`; by default only OS and shell name are sent.
  - Off-host context warning when a remote backend is set with opted-in context and an explicit endpoint.

- **Security**
  - All `caro ai` outputs pass the 52-pattern `SafetyValidator`; blocks dangerous commands like `rm -rf /` at Moderate.
  - Session history is only included when `capabilities.enable_history_search` is `true`.

<sup>Written for commit 60849ff8672b5bb74c7ffb47bc2f239e5860326e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

