### PR TITLE
docs: align versions to 1.3.0 across README, roadmap, install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Have questions or want to discuss caro with other users? Join the community!
   - - **[Documentation](https://caro.sh)** - Check out our comprehensive docs
 ## 📋 Project Status
 
-**Current Version:** 1.1.1 (General Availability)
+**Current Version:** 1.3.0 (General Availability)
 
 This project is **generally available** with all core features implemented, tested, and working. The CLI achieves 93.1% pass rate on comprehensive test suite with zero false positives in safety validation.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Caro Development Roadmap
 
-**Last Updated**: January 19, 2026
+**Last Updated**: April 20, 2026
 
 > **Recent Update**: Integrated 104 PRs (#557-660) into roadmap with milestone assignments and tracking issues.
 
@@ -48,6 +48,28 @@ gantt
 ---
 
 ## Release Milestones
+
+### 🎉 v1.3.0 - Conversational AI Command Generation
+**Released**: April 20, 2026 ✅
+**Status**: 100% Complete - **RELEASED**
+**Focus**: Atuin-AI-style conversational command generation with privacy-first defaults
+
+#### Key Deliverables
+- **`caro ai` once-mode** ✅ — Resume-or-new session, generate via configured backend, safety-validate, persist turn ([#861](https://github.com/wildcard/caro/pull/861))
+- **`caro shell-init <bash|zsh|fish>`** ✅ — `?`-on-empty-prompt shell widget; literal `?` preserved on non-empty prompts
+- **`[ai]` config block** ✅ — Strict opt-in privacy gates: `opening.send_cwd`, `opening.send_last_command`, `capabilities.enable_history_search` all default to `false`
+- **Off-host context warning** ✅ — Stderr warning when remote backend + opt-in context + explicit endpoint combine
+- **Safety integration** ✅ — Every AI-generated command flows through the 52-pattern `SafetyValidator`; `rm -rf /` unconditionally blocked at `Moderate` safety
+
+### 🎉 v1.2.0 - Website & Documentation
+**Released**: March 26, 2026 ✅
+**Status**: 100% Complete - **RELEASED**
+**Focus**: Documentation pages, version headers, security notes; CI/publish hardening
+
+#### Key Deliverables
+- Version header, security notes, documentation pages ([#639](https://github.com/wildcard/caro/pull/639))
+- Publish workflow protoc/cmake install fix ([#811](https://github.com/wildcard/caro/pull/811))
+- LanceDB `usize::MAX` cast hotfix ([#812](https://github.com/wildcard/caro/pull/812))
 
 ### 🎉 v1.1.2 - Performance & Infrastructure
 **Released**: January 15, 2026 ✅
@@ -275,11 +297,11 @@ gantt
 
 | Milestone | Due Date | Items (Issues + PRs) | Complete | Progress | Status |
 |-----------|----------|---------------------|----------|----------|---------|
+| **v1.3.0** | Apr 20, 2026 | `caro ai` + `caro shell-init` | 1 | 100% | ✅ **RELEASED** |
+| **v1.2.0** | Mar 26, 2026 | Docs & website launch | — | 100% | ✅ **RELEASED** |
 | **v1.1.2** | Jan 15, 2026 | 5 | 5 | 100% | ✅ **RELEASED** |
 | **v1.1.1** | Jan 14, 2026 | 7 | 7 | 100% | ✅ **RELEASED** |
 | **v1.1.0** | Jan 12, 2026 | 19 | 19 | 100% | ✅ **GA RELEASED** |
-| **v1.2.0** | Mar 31, 2026 | 73 (25 issues + 48 PRs) | 4 | 5% | 🔄 In Progress |
-| **v1.3.0** | May 31, 2026 | 54 (17 issues + 37 PRs) | 0 | 0% | ⏸️ Backlog |
 | **v2.0.0** | Jun 30, 2026 | 36 (17 issues + 19 PRs) | 0 | 0% | 🔄 Research Phase |
 | **Total** | - | **194** | **35** | **18%** | 🚀 On Track |
 

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -87,7 +87,7 @@ When releasing a new version of caro:
 
 ```bash
 # Download and compute checksums for a release
-VERSION=1.1.0
+VERSION=1.3.0
 for platform in macos-silicon macos-intel linux-amd64 linux-arm64; do
   curl -sL "https://github.com/wildcard/caro/releases/download/v${VERSION}/caro-${VERSION}-${platform}" | sha256sum
 done

--- a/nuget/tools/install.ps1
+++ b/nuget/tools/install.ps1
@@ -1,6 +1,6 @@
 # Download and install caro binary for Windows
 param(
-    [string]$Version = "1.1.0",
+    [string]$Version = "1.3.0",
     [string]$InstallPath = $PSScriptRoot
 )
 


### PR DESCRIPTION
## Summary

Post-release cleanup after v1.3.0 shipped. User-facing and onboarding surfaces still referenced older versions.

- **[README.md]** `Current Version: 1.1.1` → `1.3.0`
- **[homebrew-tap/README.md]** `VERSION=1.1.0` snippet → `1.3.0`
- **[nuget/tools/install.ps1]** default `-Version` param `1.1.0` → `1.3.0`
- **[ROADMAP.md]** marks v1.2.0 and v1.3.0 as RELEASED, reorders status table newest-first, adds a v1.3.0 milestone section summarising the headline `caro ai` + `caro shell-init` features; last-updated date bumped

Historical files under `.claude/releases/v1.1.0-*`, `specs/`, and `kitty-specs/` intentionally left alone — they document past state or minimum-version constraints, not current version.

## Test plan

- [ ] CI green on README/roadmap lint, spellcheck, markdownlint
- [ ] Visual check of rendered ROADMAP table on GitHub

## Follow-up — establish this as standard practice

Every release must update all of the following in the same PR as the Cargo.toml bump:
1. `Cargo.toml` + `Cargo.lock` (version bump)
2. `CHANGELOG.md` (new version entry)
3. `README.md` (Current Version line)
4. `ROADMAP.md` (mark milestone released, update status table)
5. `homebrew-tap/README.md` (VERSION= example)
6. `nuget/tools/install.ps1` (-Version default)

After tag push, verify the `Release` workflow chains cleanly from `Publish to crates.io` (it depends on `workflow_run` succeeded) so the GitHub release with binary assets is created automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns all user-facing version references to 1.3.0 and refreshes the roadmap to show v1.2.0 and v1.3.0 as released, reducing confusion in installs and docs.
Updates: `README.md` current version → 1.3.0; `homebrew-tap/README.md` checksum snippet uses `VERSION=1.3.0`; `nuget/tools/install.ps1` default `-Version` → 1.3.0; `ROADMAP.md` adds a v1.3.0 milestone summary, reorders the status table newest-first, marks v1.2.0 and v1.3.0 released, and refreshes the last-updated date.

<sup>Written for commit 873b7bfe0cba4253052c9f7cf28745496b6ddf1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

