### PR TITLE
docs(rules): codify release version alignment checklist

### DIFF
--- a/.claude/commands/caro.release.version.md
+++ b/.claude/commands/caro.release.version.md
@@ -147,7 +147,44 @@ Expected output: `version = "X.Y.Z"`
 - Ask: "Continue with empty release notes? (y/n)"
 - If no, exit with instructions to update CHANGELOG.md first
 
-### 5. Update Version Documentation (if needed)
+### 5. Update User-Facing Version References (MANDATORY)
+
+**Per `.claude/rules/release-version-alignment.md`, every release PR must update
+all version references in a single commit.** The following files drift silently
+if not touched — v1.3.0 shipped with README showing `1.1.1`, homebrew tap
+example at `VERSION=1.1.0`, and nuget installer defaulting to `1.1.0`, requiring
+a post-release alignment PR to fix.
+
+Update these files in addition to `Cargo.toml` and `CHANGELOG.md`:
+
+1. **`README.md`** — find the line `**Current Version:** <old>` (or similar
+   landing-page version banner) and bump to `X.Y.Z`. Search for any other
+   version strings in the README header block.
+
+2. **`ROADMAP.md`** — three edits:
+   - Bump `**Last Updated**: <date>` near the top to today.
+   - In the status / milestone table, either flip the existing `vX.Y.Z` row
+     to `✅ **RELEASED**` with the release date, or prepend a new row
+     newest-first.
+   - Prepend a new `### 🎉 vX.Y.Z - <headline>` section at the top of
+     `## Release Milestones` summarising what shipped, with a link to the
+     feature PR(s).
+
+3. **`homebrew-tap/README.md`** — in the "Computing SHA256 Checksums" code
+   block, bump `VERSION=X.Y.Z` so the example matches this release.
+
+4. **`nuget/tools/install.ps1`** — bump the default parameter value
+   `[string]$Version = "X.Y.Z"` on line 3 so fresh NuGet installs pull the
+   current release by default.
+
+**Scan for any additional version references** that may have been added since
+this checklist was written:
+```bash
+# Any file outside .claude/releases/ still showing the previous version?
+git grep -l "<old-version>" -- ':!.claude/releases/' ':!specs/' ':!kitty-specs/'
+```
+
+### 6. Update Version Documentation (if needed)
 
 **Check if `docs/RELEASE_PROCESS.md` needs updates**:
 - Read the file
@@ -156,7 +193,7 @@ Expected output: `version = "X.Y.Z"`
 
 **This step is optional** - only update if procedures changed.
 
-### 6. Verify Build
+### 7. Verify Build
 
 Run `cargo check` to ensure Cargo.toml is valid:
 ```bash
@@ -168,19 +205,25 @@ cargo check
 - REFUSE to proceed
 - Instruct user to fix issues and re-run
 
-### 7. Review Changes
+### 8. Review Changes
 
 Display summary of changes:
 ```bash
-git diff Cargo.toml CHANGELOG.md
+git diff Cargo.toml Cargo.lock CHANGELOG.md README.md ROADMAP.md \
+        homebrew-tap/README.md nuget/tools/install.ps1
 ```
 
 Show clear summary:
 ```
 Version bump summary:
-- Cargo.toml: X.Y.Z-old → X.Y.Z
-- CHANGELOG.md: Added [X.Y.Z] section with N changes
-- Build verification: ✓ Passed
+- Cargo.toml:              X.Y.Z-old → X.Y.Z
+- Cargo.lock:              regenerated
+- CHANGELOG.md:            Added [X.Y.Z] section with N changes
+- README.md:               Current Version banner bumped
+- ROADMAP.md:              Status table + milestone section updated
+- homebrew-tap/README.md:  VERSION= example bumped
+- nuget/install.ps1:       Default -Version bumped
+- Build verification:      ✓ Passed
 ```
 
 **Ask for confirmation**:
@@ -188,15 +231,18 @@ Version bump summary:
 
 If no, exit without committing.
 
-### 8. Commit Changes
+### 9. Commit Changes
 
-Create a well-formatted commit:
+Create a well-formatted commit staging ALL aligned files:
 ```bash
-git add Cargo.toml CHANGELOG.md docs/
+git add Cargo.toml Cargo.lock CHANGELOG.md README.md ROADMAP.md \
+        homebrew-tap/README.md nuget/tools/install.ps1 docs/
 git commit -m "$(cat <<'EOF'
 chore: Bump version to X.Y.Z
 
-Updated version in Cargo.toml and moved unreleased changes to
+Updated version in Cargo.toml and aligned all user-facing version
+references (README banner, ROADMAP milestone+status, homebrew tap
+example, nuget installer default). Moved unreleased changes to
 CHANGELOG.md release section.
 
 Release notes:
@@ -211,7 +257,7 @@ EOF
 )"
 ```
 
-### 9. Output Summary
+### 10. Output Summary
 
 Display next steps:
 ```

--- a/.claude/rules/release-version-alignment.md
+++ b/.claude/rules/release-version-alignment.md
@@ -1,0 +1,83 @@
+# Release Version Alignment
+
+**APPLIES TO**: Every release PR that bumps `Cargo.toml` version.
+
+Codified from the caro v1.3.0 release (2026-04-20), which shipped with README
+saying "1.1.1", homebrew tap example showing `VERSION=1.1.0`, and nuget
+installer defaulting to `1.1.0`. A follow-up alignment PR (#864) was required —
+this rule prevents that.
+
+## Rule
+
+**Every release PR must update all version references and downstream narrative
+artifacts in a single commit.** A version bump in `Cargo.toml` without the
+matching README/ROADMAP/install-script updates is incomplete.
+
+## The 6-file Checklist
+
+Every `chore(release): vX.Y.Z` PR must touch these files:
+
+| # | File | What to update |
+|---|------|----------------|
+| 1 | `Cargo.toml` | `version = "X.Y.Z"` |
+| 2 | `Cargo.lock` | Regenerate via `cargo check --no-default-features --features embedded-cpu` — commit the lockfile diff |
+| 3 | `CHANGELOG.md` | New `## [X.Y.Z] - YYYY-MM-DD` entry with Added / Changed / Fixed / Security / Internal subsections (Keep a Changelog format) |
+| 4 | `README.md` | `**Current Version:** X.Y.Z` banner line — plus any other version strings in the landing section |
+| 5 | `ROADMAP.md` | (a) `**Last Updated**: <today>`; (b) Status table row marked ✅ RELEASED with the release date; (c) New `### 🎉 vX.Y.Z - <headline>` milestone section prepended to `## Release Milestones` |
+| 6 | Install-script defaults | `homebrew-tap/README.md` checksum snippet `VERSION=X.Y.Z`; `nuget/tools/install.ps1` `[string]$Version = "X.Y.Z"`; any `scripts/install.sh` fallback version |
+
+## After-Merge GitHub Release
+
+The release PR merge is step 1 of 2. Step 2 is the GitHub release itself:
+
+1. Tag the merge commit: `git tag -a vX.Y.Z -m "vX.Y.Z" <merge-sha>` and push.
+   (If `tag.gpgSign = true` but no GPG key is loaded, pass `--no-sign` —
+   unless the user's request was explicitly `-s`.)
+2. The push triggers `.github/workflows/publish.yml`, which uploads to
+   crates.io. If it fails with `403 Forbidden`, the `CARGO_REGISTRY_TOKEN`
+   secret has expired — rotate it in GitHub repo settings, then
+   `gh run rerun <run-id> --failed`.
+3. On Publish success, `.github/workflows/release.yml` chains via
+   `workflow_run` and creates the GitHub Release with binary assets. If it
+   doesn't auto-trigger, dispatch manually:
+   `gh workflow run release.yml --ref vX.Y.Z -f tag=vX.Y.Z`.
+   Do NOT dispatch Release manually *before* crates.io has the version —
+   the workflow's verification poll will fail.
+4. Verify: `gh release view vX.Y.Z` shows binary assets and a body mirroring
+   the CHANGELOG entry.
+
+## Separation of Concerns
+
+- **Feature PRs** carry the actual code changes. Merge into `main` BEFORE
+  opening the release PR.
+- **Release PR** (`chore(release): vX.Y.Z`) contains only the 6 files above.
+  Small, mechanical, fast to review.
+- **Post-release alignment PR** is only needed when drift is discovered
+  *after* merging the release PR. Branch off `main`, not off the merged
+  release branch. See [#864](https://github.com/wildcard/caro/pull/864) for
+  precedent.
+
+## Common Failure Modes
+
+| Failure | Missing file | Fix |
+|---|---|---|
+| README landing page shows old version | #4 | Alignment PR |
+| Homebrew tap example shows old `VERSION=` | #6 | Alignment PR |
+| ROADMAP still marks release as "In Progress" | #5 | Alignment PR |
+| crates.io has vX.Y.Z but no GitHub release | — | `gh workflow run release.yml --ref vX.Y.Z -f tag=vX.Y.Z` |
+| Publish fails with 403 | — | Rotate `CARGO_REGISTRY_TOKEN`, rerun failed jobs |
+
+## Why This Matters
+
+The README, homebrew formula, and install scripts are a user's first
+touchpoint — not `Cargo.toml`. If those show an old version while the actual
+release is newer, the user's mental model is wrong on day one: they file bugs
+against the wrong version, copy outdated install commands, and lose trust.
+
+Six files is small enough to grep and large enough to forget one. The rule
+exists so the grep is a checklist instead of a bug report.
+
+## See Also
+
+- [`~/.claude/rules/release-version-alignment.md`](../../.claude/rules/release-version-alignment.md) — identical rule, loaded globally across all projects
+- `/caro.release.prepare` skill — operational wrapper that should reference this checklist


### PR DESCRIPTION
## Summary

- Add [.claude/rules/release-version-alignment.md](.claude/rules/release-version-alignment.md) — the 6-file checklist every release PR must satisfy so README, ROADMAP, CHANGELOG, and install scripts move in lockstep with `Cargo.toml`.
- Codified from the v1.3.0 release where the feature PR ([#861](https://github.com/wildcard/caro/pull/861)) + release PR ([#863](https://github.com/wildcard/caro/pull/863)) bumped the crate, but README still said 1.1.1, homebrew tap still showed `VERSION=1.1.0`, and `nuget/tools/install.ps1` still defaulted to `1.1.0`. A follow-up alignment PR ([#864](https://github.com/wildcard/caro/pull/864)) caught it.
- Paired with a global-scope copy at `~/.claude/rules/release-version-alignment.md` so the same checklist is loaded by any agent on any machine.

## Test plan
- [x] Rule file renders cleanly in GitHub Markdown
- [x] Cross-reference links ([#861](https://github.com/wildcard/caro/pull/861), [#864](https://github.com/wildcard/caro/pull/864)) resolve
- [ ] Next release PR references this checklist in its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies a 6-file release version alignment checklist and updates the `/caro.release.version` command to enforce it so all user-facing version strings move with `Cargo.toml` in one commit, preventing README/ROADMAP/Homebrew/NuGet drift.

- **New Features**
  - Adds `.claude/rules/release-version-alignment.md` with a 6-file checklist: `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `README.md`, `ROADMAP.md`, and install-script defaults.
  - Updates `.claude/commands/caro.release.version.md` with a mandatory “Update User-Facing Version References” step, a grep to catch stale version strings, and a final commit that stages all aligned files (including `Cargo.lock`) with a clear diff summary.
  - Documents post-merge GitHub release steps and common failure fixes.

<sup>Written for commit d3cd82edb9f967a1350364d5d9f7ca5765b8de1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

