### PR TITLE
feat(cli): implement --quiet, --no-telemetry, --backend-info flags

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -152,6 +152,21 @@ pub trait IntoCliArgs {
     fn interactive(&self) -> bool;
     fn force_llm(&self) -> bool;
     fn explain(&self) -> bool;
+    /// Suppress timing / progress output (`--quiet`).
+    /// Default implementation returns `false` for backward compatibility.
+    fn quiet(&self) -> bool {
+        false
+    }
+    /// Disable telemetry for this invocation only (`--no-telemetry`).
+    /// Default implementation returns `false` for backward compatibility.
+    fn no_telemetry(&self) -> bool {
+        false
+    }
+    /// Print backend info and exit (`--backend-info`).
+    /// Default implementation returns `false` for backward compatibility.
+    fn backend_info(&self) -> bool {
+        false
+    }
 }
 
 impl CliApp {

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,6 +627,28 @@ struct Cli {
     )]
     explain: bool,
 
+    /// Suppress timing / progress output (show only the command and safety result)
+    #[arg(
+        short = 'q',
+        long,
+        help = "Suppress timing and progress output (show only command + safety result)"
+    )]
+    quiet: bool,
+
+    /// Disable telemetry for this invocation only (does not modify config)
+    #[arg(
+        long = "no-telemetry",
+        help = "Disable telemetry for this invocation only (session-scoped override)"
+    )]
+    no_telemetry: bool,
+
+    /// Print available backends with their status and exit
+    #[arg(
+        long = "backend-info",
+        help = "List available inference backends with their status and exit"
+    )]
+    backend_info: bool,
+
     /// Trailing unquoted arguments forming the prompt
     #[arg(trailing_var_arg = true, num_args = 0..)]
     trailing_args: Vec<String>,
@@ -688,6 +710,18 @@ impl IntoCliArgs for Cli {
 
     fn explain(&self) -> bool {
         self.explain
+    }
+
+    fn quiet(&self) -> bool {
+        self.quiet
+    }
+
+    fn no_telemetry(&self) -> bool {
+        self.no_telemetry
+    }
+
+    fn backend_info(&self) -> bool {
+        self.backend_info
     }
 }
 
@@ -2014,6 +2048,13 @@ async fn main() {
 
     let mut cli = Cli::parse();
 
+    // Handle --backend-info as a meta flag (like --version): print the status
+    // table and exit without requiring a prompt or touching telemetry/setup.
+    if cli.backend_info {
+        print_backend_info();
+        process::exit(0);
+    }
+
     // Handle subcommands first
     match cli.command {
         Some(Commands::Doctor) => match caro::doctor::run_diagnostics().await {
@@ -2197,14 +2238,22 @@ async fn main() {
         .and_then(|cm| cm.load().ok())
         .unwrap_or_default();
 
+    // Session-scoped telemetry override: --no-telemetry disables telemetry
+    // for this invocation only. We do NOT persist this to user_config — the
+    // next invocation will use whatever the stored preference is.
+    let telemetry_enabled_for_session = user_config.telemetry.enabled && !cli.no_telemetry;
+
     // Check for first-run consent
     // Skip interactive consent for non-human output formats (json, yaml)
+    // and also when the user has explicitly asked to run with --no-telemetry
+    // (it would be hostile to prompt them for consent when they just said
+    // "no, thanks, not this time").
     let is_interactive_output = cli
         .output
         .as_deref()
         .is_none_or(|format| format != "json" && format != "yaml");
 
-    if user_config.telemetry.first_run && is_interactive_output {
+    if user_config.telemetry.first_run && is_interactive_output && !cli.no_telemetry {
         // Prompt user for consent
         let consent = caro::telemetry::consent::prompt_consent();
 
@@ -2241,14 +2290,14 @@ async fn main() {
         let telemetry_storage = std::sync::Arc::new(telemetry_storage);
         let telemetry_collector = std::sync::Arc::new(caro::TelemetryCollector::new(
             telemetry_storage.clone(),
-            user_config.telemetry.enabled,
+            telemetry_enabled_for_session,
         ));
 
         // Set as global collector for easy access from all components
         caro::set_global_collector(telemetry_collector.clone());
 
         // Start telemetry uploader if enabled and not air-gapped
-        if user_config.telemetry.enabled && !user_config.telemetry.air_gapped {
+        if telemetry_enabled_for_session && !user_config.telemetry.air_gapped {
             let uploader = std::sync::Arc::new(caro::telemetry::uploader::TelemetryUploader::new(
                 telemetry_storage.clone(),
                 user_config.telemetry.clone(),
@@ -2775,8 +2824,8 @@ async fn print_plain_output(result: &mut caro::cli::CliResult, cli: &Cli) -> Res
             display!("  {}", status_msg);
         }
 
-        // Print execution time
-        if result.timing_info.execution_time_ms > 0 {
+        // Print execution time (suppressed by --quiet)
+        if result.timing_info.execution_time_ms > 0 && !cli.quiet {
             display!(
                 "  Execution time: {}ms",
                 result.timing_info.execution_time_ms
@@ -2841,6 +2890,75 @@ async fn print_plain_output(result: &mut caro::cli::CliResult, cli: &Cli) -> Res
     }
 
     Ok(())
+}
+
+/// Print the list of inference backends along with their current status.
+///
+/// Invoked by the `--backend-info` meta flag. Exits the caller with code 0.
+/// Reports each built-in backend and whether remote backends have the
+/// environment variables / typical endpoints set that would make them
+/// usable. This is a best-effort snapshot, not a live health check.
+fn print_backend_info() {
+    use colored::Colorize;
+
+    // Status helpers. For remote backends we use environment variables as
+    // a lightweight "configured?" signal — probing each endpoint would
+    // turn `--backend-info` into a slow diagnostic command.
+    let env_or = |keys: &[&str]| keys.iter().any(|k| std::env::var(k).is_ok());
+
+    let status_for = |keys: &[&str]| {
+        if env_or(keys) {
+            "configured"
+        } else {
+            "not configured"
+        }
+    };
+
+    let row = |backend: &str, status: &str, notes: &str| {
+        println!("  {:<12}  {:<16}  {}", backend, status, notes);
+    };
+
+    println!("{}", "Available inference backends".bold());
+    println!();
+    println!(
+        "  {:<12}  {:<16}  {}",
+        "Backend".bold(),
+        "Status".bold(),
+        "Notes".bold()
+    );
+    row("-------", "------", "-----");
+
+    // Built-in, always-available backends.
+    row("static", "available", "template-based; no model required");
+    row(
+        "embedded",
+        "available",
+        "local LLM (MLX/CPU); downloads model on first use",
+    );
+
+    // Remote backends: we report "configured" if a credential / endpoint
+    // env var is set, otherwise "not configured".
+    row(
+        "ollama",
+        status_for(&["OLLAMA_HOST", "CARO_OLLAMA_URL"]),
+        "remote Ollama HTTP API (OLLAMA_HOST)",
+    );
+    row(
+        "vllm",
+        status_for(&["VLLM_BASE_URL", "CARO_VLLM_URL"]),
+        "remote vLLM HTTP API (VLLM_BASE_URL)",
+    );
+    row(
+        "claude",
+        status_for(&["ANTHROPIC_API_KEY"]),
+        "Anthropic Claude API (ANTHROPIC_API_KEY)",
+    );
+
+    println!();
+    println!(
+        "{}",
+        "Use --backend <name> to force a specific backend.".dimmed()
+    );
 }
 
 async fn show_configuration(cli: &Cli) -> Result<String, CliError> {

--- a/tests/cli_flag_tests.rs
+++ b/tests/cli_flag_tests.rs
@@ -1,0 +1,228 @@
+//! Integration tests for CLI flags: --quiet, --no-telemetry, --backend-info
+//!
+//! Tracks GitHub issue #793 (task caro-xk0.1): three flags documented at caro.sh/faq
+//! were advertised but not parsed. These tests lock in their observable behavior.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+struct CliRunner {
+    binary: String,
+    temp_dir: TempDir,
+}
+
+impl CliRunner {
+    fn new() -> Self {
+        let binary = if Path::new("target/debug/caro").exists() {
+            "target/debug/caro".to_string()
+        } else {
+            "cargo".to_string()
+        };
+        let temp_dir = TempDir::new().expect("temp dir");
+        Self { binary, temp_dir }
+    }
+
+    fn run(&self, args: &[&str]) -> (String, String, i32) {
+        let mut cmd = if self.binary == "cargo" {
+            let mut c = Command::new("cargo");
+            c.arg("run").arg("--");
+            c.args(args);
+            c
+        } else {
+            let mut c = Command::new(&self.binary);
+            c.args(args);
+            c
+        };
+
+        cmd.env("CARO_CONFIG_DIR", self.temp_dir.path());
+        cmd.env_remove("CARO_CACHE_DIR");
+
+        let out = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("failed to execute caro");
+
+        (
+            String::from_utf8_lossy(&out.stdout).to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+            out.status.code().unwrap_or(-1),
+        )
+    }
+}
+
+// =============================================================================
+// --help advertises the new flags
+// =============================================================================
+
+#[test]
+fn help_lists_quiet_flag() {
+    let runner = CliRunner::new();
+    let (stdout, _stderr, code) = runner.run(&["--help"]);
+    assert_eq!(code, 0, "--help should exit 0");
+    assert!(
+        stdout.contains("--quiet"),
+        "--help output should advertise --quiet, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn help_lists_no_telemetry_flag() {
+    let runner = CliRunner::new();
+    let (stdout, _stderr, code) = runner.run(&["--help"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("--no-telemetry"),
+        "--help output should advertise --no-telemetry, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn help_lists_backend_info_flag() {
+    let runner = CliRunner::new();
+    let (stdout, _stderr, code) = runner.run(&["--help"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("--backend-info"),
+        "--help output should advertise --backend-info, got:\n{}",
+        stdout
+    );
+}
+
+// =============================================================================
+// --quiet: flag is accepted (does not error like pre-fix behavior)
+// =============================================================================
+
+#[test]
+fn quiet_flag_is_accepted_with_prompt() {
+    let runner = CliRunner::new();
+    let (stdout, stderr, code) = runner.run(&["--quiet", "list files"]);
+    // Must not be a clap parse error.
+    assert!(
+        !stderr.contains("unexpected argument '--quiet'"),
+        "clap should recognise --quiet, stderr was:\n{}",
+        stderr
+    );
+    // On successful parse we either exit 0 or show normal output, but never
+    // the "unexpected argument" parse failure exit code pattern.
+    assert!(
+        code == 0 || !stderr.contains("unexpected argument"),
+        "--quiet should be parsed; code={} stderr={}",
+        code,
+        stderr
+    );
+    // stdout should still show the generated command line (command is the
+    // minimum output that --quiet preserves).
+    let _ = stdout;
+}
+
+#[test]
+fn quiet_suppresses_execution_timing_line() {
+    // When the command is actually executed (--dry-run so it's safe), the
+    // non-quiet path prints an "Execution time" / timing-ish line for the run.
+    // With --quiet that timing noise must be suppressed. We assert no
+    // "Execution time" nor a bare "ms" duration trailer leaks to stdout.
+    let runner = CliRunner::new();
+    let (stdout, _stderr, _code) = runner.run(&["--quiet", "--dry-run", "list files"]);
+    assert!(
+        !stdout.contains("Execution time"),
+        "--quiet must not print 'Execution time' timing, got:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn quiet_and_dry_run_combine() {
+    // Combining flags should not parse-error. --dry-run + --quiet is the
+    // canonical non-destructive inspection mode.
+    let runner = CliRunner::new();
+    let (_stdout, stderr, _code) = runner.run(&["--quiet", "--dry-run", "list files"]);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--quiet + --dry-run must co-exist, stderr:\n{}",
+        stderr
+    );
+}
+
+// =============================================================================
+// --no-telemetry: flag is accepted
+// =============================================================================
+
+#[test]
+fn no_telemetry_flag_is_accepted_with_prompt() {
+    let runner = CliRunner::new();
+    let (_stdout, stderr, _code) = runner.run(&["--no-telemetry", "list files"]);
+    assert!(
+        !stderr.contains("unexpected argument '--no-telemetry'"),
+        "clap should recognise --no-telemetry, stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn no_telemetry_combines_with_dry_run() {
+    let runner = CliRunner::new();
+    let (_stdout, stderr, _code) = runner.run(&["--no-telemetry", "--dry-run", "list files"]);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--no-telemetry + --dry-run must co-exist, stderr:\n{}",
+        stderr
+    );
+}
+
+// =============================================================================
+// --backend-info: meta flag that prints a backend table and exits 0
+// =============================================================================
+
+#[test]
+fn backend_info_exits_zero_without_prompt() {
+    let runner = CliRunner::new();
+    let (stdout, stderr, code) = runner.run(&["--backend-info"]);
+    assert_eq!(
+        code, 0,
+        "--backend-info should exit 0 without requiring a prompt. stdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+}
+
+#[test]
+fn backend_info_lists_known_backends() {
+    let runner = CliRunner::new();
+    let (stdout, stderr, _code) = runner.run(&["--backend-info"]);
+    let combined = format!("{}{}", stdout, stderr);
+    // We print a header plus at least these built-in backend names.
+    assert!(
+        combined.to_lowercase().contains("backend"),
+        "--backend-info output should mention 'backend', got:\n{}",
+        combined
+    );
+    for name in ["static", "embedded", "ollama", "vllm"] {
+        assert!(
+            combined.to_lowercase().contains(name),
+            "--backend-info output should list '{}', got:\n{}",
+            name,
+            combined
+        );
+    }
+}
+
+#[test]
+fn backend_info_shows_status_column() {
+    let runner = CliRunner::new();
+    let (stdout, stderr, _code) = runner.run(&["--backend-info"]);
+    let combined = format!("{}{}", stdout, stderr).to_lowercase();
+    // Must show some per-backend status signal (available / not / configured / missing).
+    let has_status = combined.contains("available")
+        || combined.contains("not available")
+        || combined.contains("configured")
+        || combined.contains("status");
+    assert!(
+        has_status,
+        "--backend-info should include a status column/signal, got:\n{}",
+        combined
+    );
+}


### PR DESCRIPTION
## Summary

Closes #793. Implements the three CLI flags documented at caro.sh/faq that still error on `main`:

- **`--quiet`** — suppresses the `Execution time: Xms` line
- **`--no-telemetry`** — session-scoped telemetry opt-out (does not persist)
- **`--backend-info`** — lists registered backends with a status column, exits 0 without consuming a prompt

`-e`/`--execute` and `--explain` already shipped on `main`, so they're out of scope for this PR.

Part of Epic #792 (v1.2.0: Delivering on the Promise) — beads task `caro-xk0.1`.

## Changes

- `src/main.rs` — 3 new `Cli` fields + 3 `IntoCliArgs` methods; wired early-exit for `--backend-info`, session override for `--no-telemetry`, gating on the timing line for `--quiet`; added `print_backend_info()` helper
- `src/cli/mod.rs` — default-implemented accessors on `IntoCliArgs` so existing implementors compile unchanged
- `tests/cli_flag_tests.rs` — 11 new integration tests (help output, flag acceptance, behavior, and flag combinations with `--dry-run`)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 361/361 pass
- [x] `cargo test --test cli_flag_tests` — 11/11 pass
- [x] Pre-existing failures (Metal/LLM flakes) unchanged — verified identical set on `main`
- [ ] Manual smoke: `caro --backend-info`, `caro --quiet "list files" --dry-run`, `caro --no-telemetry "…"`

## Deferred (documented for reviewers)

- Live backend health probes — uses env-var presence as `configured?` signal to keep the flag sub-100ms. Deeper probes belong in `caro doctor`.
- Persisting `--no-telemetry` — deliberately session-scoped per the spec.

🤖 Generated by `/caro-coder-loop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements three CLI flags: `--quiet`, `--no-telemetry`, and `--backend-info` to match the FAQ and close #793. This adds a session-only telemetry opt-out, a quiet mode, and a quick backend status check.

- **New Features**
  - `--quiet` – hides the "Execution time: Xms" line; works with `--dry-run`.
  - `--no-telemetry` – disables telemetry for this run; skips first‑run consent; does not persist.
  - `--backend-info` – prints available backends with a status column (env-var based) and exits 0 without a prompt or telemetry init.

- **Refactors**
  - Added default `quiet`, `no_telemetry`, and `backend_info` accessors to `IntoCliArgs` to keep existing implementors compiling unchanged.

<sup>Written for commit a42aa8dd8c765963c7bbebdd26955ba149bb2d2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

