### PR TITLE
feat(commands): release acceptance routine + pre-release grooming gate

### DIFF
--- a/.claude/commands/caro.release.acceptance.md
+++ b/.claude/commands/caro.release.acceptance.md
@@ -1,0 +1,308 @@
+---
+description: Acceptance-verify a caro release — does it actually deliver what was advertised, what PRs claimed, what beta testers requested? Report gaps as bugs and randomly sample one feature for deep testing.
+---
+
+**Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `CHANGELOG.md`). Never refer to a folder by name alone.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+**If user provides version** (e.g., `v1.3.0` or `1.3.0`): use that version.
+**Otherwise**: default to the latest git tag.
+
+---
+
+## Purpose
+
+This command is the **reality check** between what a release *claimed to do* and
+what it *actually does in the user's hands*. Installability is covered by
+`/caro.release.verify` — this command covers **acceptance**:
+
+1. Every CHANGELOG entry must map to a verifiable, working feature.
+2. Every feature PR in the release must have its headline claim verified.
+3. Every GitHub issue closed-by the release must be reproducibly fixed.
+4. Every beta-tester request logged in `.claude/beta-testing/` must be either
+   shipped or explicitly deferred with a tracking issue.
+5. A randomly-sampled feature gets a deep acceptance test.
+
+**Gaps become GH issues** with `bug` + `release-gap` labels, priority assigned
+via the rubric in Phase 7. The next release cannot proceed (per
+`/caro.release.prepare`) until all `P0`/`P1` release-gap issues for the
+prior release are closed or explicitly waived.
+
+---
+
+## Workflow Context
+
+**Before this**: A release has shipped (`/caro.release.publish` + `/caro.release.verify`).
+
+**This command**: Validates that the release actually delivers what it promised.
+
+**After this**: `/caro.release.prepare` reads this command's audit output to
+decide whether the *next* release is clear to start.
+
+Run this command:
+- Immediately after a release ships (fresh in memory, testers still engaged).
+- As the first step of the next release cycle (grooming gate).
+- Whenever a user reports a regression and you need to triage scope.
+
+---
+
+## Outline
+
+### 1. Determine Target Version
+
+```bash
+if [ -n "$ARG_VERSION" ]; then
+  VERSION="${ARG_VERSION#v}"
+else
+  VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+fi
+TAG="v$VERSION"
+echo "Acceptance-verifying caro $TAG"
+```
+
+If no tag exists, refuse: `ERROR: no git tags — nothing to verify`.
+
+### 2. Gather Claims
+
+Build the **claim set** — every assertion this release made. Claims come from
+four sources; union them.
+
+#### 2a. CHANGELOG.md
+
+Extract the `## [X.Y.Z] - YYYY-MM-DD` section. Parse every bullet under
+`### Added`, `### Changed`, `### Fixed`, `### Security`, `### Internal`. Each
+bullet is one **claim**.
+
+```bash
+awk "/^## \[$VERSION\]/,/^## \[/" CHANGELOG.md | grep -E '^- ' > /tmp/claims-changelog.txt
+```
+
+#### 2b. GitHub Release notes
+
+```bash
+gh release view "$TAG" --json body | jq -r .body > /tmp/claims-release-notes.md
+```
+
+Diff against CHANGELOG — they should match. Any delta is itself a gap
+(advertised but not in changelog, or vice versa).
+
+#### 2c. Feature PRs merged into this release
+
+```bash
+PREV_TAG=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || echo "")
+if [ -n "$PREV_TAG" ]; then
+  gh pr list --state merged --search "merged:>=$(git log -1 --format=%aI "$PREV_TAG") base:main" \
+    --json number,title,body,labels --limit 100 > /tmp/claims-prs.json
+else
+  gh pr list --state merged --base main --json number,title,body,labels --limit 100 > /tmp/claims-prs.json
+fi
+```
+
+Every PR title headline is a claim. Flag PRs labeled `feature` / `feat` for
+deeper verification; PRs labeled `chore` / `docs` can be spot-checked.
+
+#### 2d. Closed-by-this-release issues
+
+```bash
+gh issue list --state closed --search "closed:>=$(git log -1 --format=%aI $PREV_TAG)" \
+  --json number,title,labels,body --limit 200 > /tmp/claims-issues.json
+```
+
+For each issue: does its closing PR belong to this release? If yes, the issue's
+reproduction steps are claims that must still fail on the previous version and
+pass on this one.
+
+#### 2e. Beta-tester requests
+
+Per `CLAUDE.md`, beta-test feedback lives under `.claude/beta-testing/`. Read
+any file there dated between `$PREV_TAG` and `$TAG`:
+
+```bash
+find .claude/beta-testing -type f -newer "$(git log -1 --format=%cI "$PREV_TAG" -- .)" 2>/dev/null
+```
+
+For each request: is it shipped (matched to a CHANGELOG entry), explicitly
+deferred (has a tracking GH issue open), or silently dropped (neither)? The
+third category is a gap.
+
+### 3. Build the Verification Matrix
+
+Produce a table mapping each claim to a verification method:
+
+| Claim source | ID | Statement | Verifier |
+|---|---|---|---|
+| CHANGELOG Added | CHL-01 | `caro ai` once-mode subcommand | `./caro ai --once "list files"` exits 0 with a command on stdout |
+| PR #861 | PR-861 | Safety validator blocks AI-generated `rm -rf /` | `./caro ai --once "rm -rf /"` exits non-zero, stderr mentions Critical |
+| Issue #839 | IS-839 | `caro knowledge` respects `--limit N` | repro steps from issue body |
+| Beta note 2026-04-10 | BT-01 | `?` keybinding works in zsh | manual smoke in a fresh zsh |
+
+Write the matrix to `.claude/releases/v$VERSION-acceptance.md` so the audit is
+reproducible later.
+
+### 4. Execute Verifiers
+
+For each row: run the verifier, capture result (`PASS` / `FAIL` / `SKIP`).
+
+**Automated** (preferred):
+- Unit/integration tests that reference the PR/issue number
+- Smoke tests: `./caro <cmd>` with known input + assertion on stdout/exit
+- Website-claims CI job — grep its last run for this release
+
+**Manual** (when automation isn't feasible):
+- Shell integration (`caro shell-init <shell>`): source into a real shell,
+  press `?` on empty prompt, assert `caro ai` runs
+- Interactive prompts: walk the UX, note any friction
+
+Record each row's result. Keep failures with the full command, stdout, stderr,
+and exit code.
+
+### 5. Random Acceptance Sample
+
+Independent of the matrix above, pick **one feature at random** for deep
+acceptance testing — not just "does it run", but "would a user be happy with
+it".
+
+```bash
+FEATURES=($(grep -E '^### Added' -A100 CHANGELOG.md | \
+  awk "/^## \[$VERSION\]/,/^## \[/" | grep '^- ' | head -20))
+SAMPLE=$(( RANDOM % ${#FEATURES[@]} ))
+echo "Randomly sampled feature: ${FEATURES[$SAMPLE]}"
+```
+
+For the sampled feature, do what a new user would do:
+1. Read the feature's doc (README section, `--help` output, blog post link).
+2. Follow the doc literally — no prior knowledge.
+3. Try the 3 most obvious use-cases.
+4. Try one adversarial / edge case.
+5. Record: did the doc match reality? Did it work? Were errors clear? Were
+   defaults sensible? Where did you get stuck?
+
+This sample often surfaces **polish gaps** that the claim-matrix misses
+because claims are usually "does X exist", not "is X pleasant".
+
+### 6. Compile the Gap Report
+
+Aggregate every `FAIL` from step 4 and every friction point from step 5 into a
+gap report:
+
+```markdown
+# caro v$VERSION acceptance audit — $(date +%Y-%m-%d)
+
+## Summary
+- Claims verified: N/M
+- PRs spot-checked: N
+- Issues re-verified: N
+- Beta requests reconciled: N
+- Random sample: <feature>
+
+## Gaps
+### P0 (blocking next release)
+- [GAP-001] <one-line>. Source: CHL-03 (CHANGELOG claim). Repro: `...`
+### P1 (ship-within-one-release)
+- [GAP-002] ...
+### P2 (track, no deadline)
+- [GAP-003] ...
+
+## Random-sample findings
+<notes from Phase 5>
+```
+
+Write to `.claude/releases/v$VERSION-acceptance.md`.
+
+### 7. File GH Issues for Gaps
+
+For each gap, open a GitHub issue:
+
+```bash
+gh issue create \
+  --title "Release gap (v$VERSION): <one-line>" \
+  --label "bug,release-gap,v$VERSION" \
+  --body "$(cat <<EOF
+Source: <claim source, e.g. CHL-03 CHANGELOG 'caro ai --once respects --timeout'>
+Expected: <what the claim said>
+Actual: <what we observed>
+Reproduction:
+\`\`\`
+<command>
+\`\`\`
+Priority rationale: <why P0/P1/P2>
+
+Found by \`/caro.release.acceptance\` on $(date +%Y-%m-%d).
+EOF
+)"
+```
+
+**Priority rubric** (use this to label):
+
+| Priority | Criteria |
+|---|---|
+| **P0** | Advertised feature doesn't work at all. Security regression. Crash on basic usage. Data loss. Blocks shipping next release until closed. |
+| **P1** | Feature works but not as documented. Confusing error. Edge case advertised in docs fails. Must ship in next release. |
+| **P2** | Polish gap. Minor friction. Advertised "nice-to-have" partially delivered. No deadline, but tracked. |
+| **P3** | Defer / won't-fix — document in the issue why. Examples: platform we don't support, out-of-scope ask, obsoleted by another feature. |
+
+### 8. Feed into Grooming
+
+Print a one-line summary and exit with a status code:
+
+```
+caro v$VERSION acceptance: <P0-count> P0, <P1-count> P1, <P2-count> P2
+
+Release gate: [BLOCKED|CLEAR]
+```
+
+- **BLOCKED** if any open `release-gap` issue from *any* prior release is
+  labeled `P0` or `P1` and not closed. Exit code 1.
+- **CLEAR** otherwise. Exit code 0.
+
+`/caro.release.prepare` must read this status and refuse to start a new release
+if BLOCKED.
+
+### 9. Commit Audit Trail
+
+```bash
+git add .claude/releases/v$VERSION-acceptance.md
+git commit -m "chore(release): acceptance audit for v$VERSION
+
+Claims verified: N/M
+Gaps filed: <list of issue numbers>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+Do **not** create a PR for this — it's an audit artifact, committed straight
+to a short-lived branch (`audit/v$VERSION-acceptance`) and merged fast-forward
+so the history is linear.
+
+---
+
+## Grooming Integration (for `/caro.release.prepare`)
+
+The prepare command should call this routine on the *current latest* release as
+step 0, before touching the next version:
+
+```bash
+# In /caro.release.prepare step 0:
+/caro.release.acceptance  # against latest tag
+# If exit 1, refuse to start a new release and show the blocker list.
+```
+
+This enforces the user's rule:
+> before releasing making sure the already releases are working as requested
+> and no reported bug
+
+---
+
+## References
+
+- Installability verification: `/caro.release.verify`
+- Version alignment: `.claude/rules/release-version-alignment.md`
+- Beta-testing directory: `.claude/beta-testing/` (per `CLAUDE.md`)
+- Release process doc: `docs/RELEASE_PROCESS.md`

--- a/.claude/commands/caro.release.prepare.md
+++ b/.claude/commands/caro.release.prepare.md
@@ -82,7 +82,30 @@ git pull origin main
 git checkout -b release/vX.Y.Z
 ```
 
-### 5. Check for Release Blockers
+### 5. Acceptance Gate on Previous Release (MANDATORY)
+
+**Before starting a new release, the previous release must be working as
+advertised and free of open P0/P1 gaps.** This enforces the rule that we
+don't ship v(N+1) on top of a broken v(N).
+
+```bash
+/caro.release.acceptance
+```
+
+Reads the latest shipped version, verifies every CHANGELOG claim, every
+feature-PR headline, every closed-by-release issue, and reconciles
+beta-tester feedback. Also runs a random-sample acceptance test on one
+feature.
+
+**If exit code is non-zero (BLOCKED)**:
+- Display the open `release-gap` issues labeled `P0` or `P1`.
+- REFUSE to proceed: `ERROR: Prior release has unresolved P0/P1 gaps. Close or waive them before releasing v(next).`
+
+**If CLEAR**: continue to step 6.
+
+See `/caro.release.acceptance` for the full routine and gap-triage rubric.
+
+### 6. Check for Release Blockers
 
 Use GitHub CLI to check for issues labeled `release-blocker`:
 ```bash
@@ -94,7 +117,7 @@ gh issue list --label release-blocker --state open
 - Ask: "Found N release blockers. Continue anyway? (y/n)"
 - If user says no, abort and output: "Resolve blockers and run /caro.release.prepare again"
 
-### 6. Verify CI Status on Main
+### 7. Verify CI Status on Main
 
 Check that latest CI run on main passed:
 ```bash
@@ -105,7 +128,7 @@ gh run list --branch main --limit 5 --json conclusion,status,headSha
 - Warn: "WARNING: Latest CI on main is not green. Recommendation: wait for CI to pass."
 - Ask: "Continue anyway? (y/n)"
 
-### 7. List Pending Changes
+### 8. List Pending Changes
 
 Show what's changed since last release tag:
 ```bash
@@ -114,7 +137,7 @@ echo "Changes since $LAST_TAG:"
 git log --oneline $LAST_TAG..HEAD
 ```
 
-### 8. Output Next Steps
+### 9. Output Next Steps
 
 Display summary:
 ```

--- a/.claude/commands/caro.release.version.md
+++ b/.claude/commands/caro.release.version.md
@@ -147,7 +147,44 @@ Expected output: `version = "X.Y.Z"`
 - Ask: "Continue with empty release notes? (y/n)"
 - If no, exit with instructions to update CHANGELOG.md first
 
-### 5. Update Version Documentation (if needed)
+### 5. Update User-Facing Version References (MANDATORY)
+
+**Per `.claude/rules/release-version-alignment.md`, every release PR must update
+all version references in a single commit.** The following files drift silently
+if not touched — v1.3.0 shipped with README showing `1.1.1`, homebrew tap
+example at `VERSION=1.1.0`, and nuget installer defaulting to `1.1.0`, requiring
+a post-release alignment PR to fix.
+
+Update these files in addition to `Cargo.toml` and `CHANGELOG.md`:
+
+1. **`README.md`** — find the line `**Current Version:** <old>` (or similar
+   landing-page version banner) and bump to `X.Y.Z`. Search for any other
+   version strings in the README header block.
+
+2. **`ROADMAP.md`** — three edits:
+   - Bump `**Last Updated**: <date>` near the top to today.
+   - In the status / milestone table, either flip the existing `vX.Y.Z` row
+     to `✅ **RELEASED**` with the release date, or prepend a new row
+     newest-first.
+   - Prepend a new `### 🎉 vX.Y.Z - <headline>` section at the top of
+     `## Release Milestones` summarising what shipped, with a link to the
+     feature PR(s).
+
+3. **`homebrew-tap/README.md`** — in the "Computing SHA256 Checksums" code
+   block, bump `VERSION=X.Y.Z` so the example matches this release.
+
+4. **`nuget/tools/install.ps1`** — bump the default parameter value
+   `[string]$Version = "X.Y.Z"` on line 3 so fresh NuGet installs pull the
+   current release by default.
+
+**Scan for any additional version references** that may have been added since
+this checklist was written:
+```bash
+# Any file outside .claude/releases/ still showing the previous version?
+git grep -l "<old-version>" -- ':!.claude/releases/' ':!specs/' ':!kitty-specs/'
+```
+
+### 6. Update Version Documentation (if needed)
 
 **Check if `docs/RELEASE_PROCESS.md` needs updates**:
 - Read the file
@@ -156,7 +193,7 @@ Expected output: `version = "X.Y.Z"`
 
 **This step is optional** - only update if procedures changed.
 
-### 6. Verify Build
+### 7. Verify Build
 
 Run `cargo check` to ensure Cargo.toml is valid:
 ```bash
@@ -168,19 +205,25 @@ cargo check
 - REFUSE to proceed
 - Instruct user to fix issues and re-run
 
-### 7. Review Changes
+### 8. Review Changes
 
 Display summary of changes:
 ```bash
-git diff Cargo.toml CHANGELOG.md
+git diff Cargo.toml Cargo.lock CHANGELOG.md README.md ROADMAP.md \
+        homebrew-tap/README.md nuget/tools/install.ps1
 ```
 
 Show clear summary:
 ```
 Version bump summary:
-- Cargo.toml: X.Y.Z-old → X.Y.Z
-- CHANGELOG.md: Added [X.Y.Z] section with N changes
-- Build verification: ✓ Passed
+- Cargo.toml:              X.Y.Z-old → X.Y.Z
+- Cargo.lock:              regenerated
+- CHANGELOG.md:            Added [X.Y.Z] section with N changes
+- README.md:               Current Version banner bumped
+- ROADMAP.md:              Status table + milestone section updated
+- homebrew-tap/README.md:  VERSION= example bumped
+- nuget/install.ps1:       Default -Version bumped
+- Build verification:      ✓ Passed
 ```
 
 **Ask for confirmation**:
@@ -188,15 +231,18 @@ Version bump summary:
 
 If no, exit without committing.
 
-### 8. Commit Changes
+### 9. Commit Changes
 
-Create a well-formatted commit:
+Create a well-formatted commit staging ALL aligned files:
 ```bash
-git add Cargo.toml CHANGELOG.md docs/
+git add Cargo.toml Cargo.lock CHANGELOG.md README.md ROADMAP.md \
+        homebrew-tap/README.md nuget/tools/install.ps1 docs/
 git commit -m "$(cat <<'EOF'
 chore: Bump version to X.Y.Z
 
-Updated version in Cargo.toml and moved unreleased changes to
+Updated version in Cargo.toml and aligned all user-facing version
+references (README banner, ROADMAP milestone+status, homebrew tap
+example, nuget installer default). Moved unreleased changes to
 CHANGELOG.md release section.
 
 Release notes:
@@ -211,7 +257,7 @@ EOF
 )"
 ```
 
-### 9. Output Summary
+### 10. Output Summary
 
 Display next steps:
 ```

--- a/.claude/rules/release-version-alignment.md
+++ b/.claude/rules/release-version-alignment.md
@@ -1,0 +1,83 @@
+# Release Version Alignment
+
+**APPLIES TO**: Every release PR that bumps `Cargo.toml` version.
+
+Codified from the caro v1.3.0 release (2026-04-20), which shipped with README
+saying "1.1.1", homebrew tap example showing `VERSION=1.1.0`, and nuget
+installer defaulting to `1.1.0`. A follow-up alignment PR (#864) was required —
+this rule prevents that.
+
+## Rule
+
+**Every release PR must update all version references and downstream narrative
+artifacts in a single commit.** A version bump in `Cargo.toml` without the
+matching README/ROADMAP/install-script updates is incomplete.
+
+## The 6-file Checklist
+
+Every `chore(release): vX.Y.Z` PR must touch these files:
+
+| # | File | What to update |
+|---|------|----------------|
+| 1 | `Cargo.toml` | `version = "X.Y.Z"` |
+| 2 | `Cargo.lock` | Regenerate via `cargo check --no-default-features --features embedded-cpu` — commit the lockfile diff |
+| 3 | `CHANGELOG.md` | New `## [X.Y.Z] - YYYY-MM-DD` entry with Added / Changed / Fixed / Security / Internal subsections (Keep a Changelog format) |
+| 4 | `README.md` | `**Current Version:** X.Y.Z` banner line — plus any other version strings in the landing section |
+| 5 | `ROADMAP.md` | (a) `**Last Updated**: <today>`; (b) Status table row marked ✅ RELEASED with the release date; (c) New `### 🎉 vX.Y.Z - <headline>` milestone section prepended to `## Release Milestones` |
+| 6 | Install-script defaults | `homebrew-tap/README.md` checksum snippet `VERSION=X.Y.Z`; `nuget/tools/install.ps1` `[string]$Version = "X.Y.Z"`; any `scripts/install.sh` fallback version |
+
+## After-Merge GitHub Release
+
+The release PR merge is step 1 of 2. Step 2 is the GitHub release itself:
+
+1. Tag the merge commit: `git tag -a vX.Y.Z -m "vX.Y.Z" <merge-sha>` and push.
+   (If `tag.gpgSign = true` but no GPG key is loaded, pass `--no-sign` —
+   unless the user's request was explicitly `-s`.)
+2. The push triggers `.github/workflows/publish.yml`, which uploads to
+   crates.io. If it fails with `403 Forbidden`, the `CARGO_REGISTRY_TOKEN`
+   secret has expired — rotate it in GitHub repo settings, then
+   `gh run rerun <run-id> --failed`.
+3. On Publish success, `.github/workflows/release.yml` chains via
+   `workflow_run` and creates the GitHub Release with binary assets. If it
+   doesn't auto-trigger, dispatch manually:
+   `gh workflow run release.yml --ref vX.Y.Z -f tag=vX.Y.Z`.
+   Do NOT dispatch Release manually *before* crates.io has the version —
+   the workflow's verification poll will fail.
+4. Verify: `gh release view vX.Y.Z` shows binary assets and a body mirroring
+   the CHANGELOG entry.
+
+## Separation of Concerns
+
+- **Feature PRs** carry the actual code changes. Merge into `main` BEFORE
+  opening the release PR.
+- **Release PR** (`chore(release): vX.Y.Z`) contains only the 6 files above.
+  Small, mechanical, fast to review.
+- **Post-release alignment PR** is only needed when drift is discovered
+  *after* merging the release PR. Branch off `main`, not off the merged
+  release branch. See [#864](https://github.com/wildcard/caro/pull/864) for
+  precedent.
+
+## Common Failure Modes
+
+| Failure | Missing file | Fix |
+|---|---|---|
+| README landing page shows old version | #4 | Alignment PR |
+| Homebrew tap example shows old `VERSION=` | #6 | Alignment PR |
+| ROADMAP still marks release as "In Progress" | #5 | Alignment PR |
+| crates.io has vX.Y.Z but no GitHub release | — | `gh workflow run release.yml --ref vX.Y.Z -f tag=vX.Y.Z` |
+| Publish fails with 403 | — | Rotate `CARGO_REGISTRY_TOKEN`, rerun failed jobs |
+
+## Why This Matters
+
+The README, homebrew formula, and install scripts are a user's first
+touchpoint — not `Cargo.toml`. If those show an old version while the actual
+release is newer, the user's mental model is wrong on day one: they file bugs
+against the wrong version, copy outdated install commands, and lose trust.
+
+Six files is small enough to grep and large enough to forget one. The rule
+exists so the grep is a checklist instead of a bug report.
+
+## See Also
+
+- [`~/.claude/rules/release-version-alignment.md`](../../.claude/rules/release-version-alignment.md) — identical rule, loaded globally across all projects
+- `/caro.release.prepare` skill — operational wrapper that should reference this checklist


### PR DESCRIPTION
## Summary

- Adds [`/caro.release.acceptance`](.claude/commands/caro.release.acceptance.md) — a new command that verifies a shipped release delivers what it advertised. Distinct from the existing [`/caro.release.verify`](.claude/commands/caro.release.verify.md), which only checks *installability* (can users `cargo install caro` and get the right `--version`).
- Wires the acceptance gate into [`/caro.release.prepare`](.claude/commands/caro.release.prepare.md) as step 5 — before starting a new release we re-audit the *current* release and refuse to proceed if any P0/P1 release-gap issues remain open against it.

## What `/caro.release.acceptance` does

1. **Gather claims** from five sources and union them: CHANGELOG entry, GitHub release notes, merged feature PRs, closed-by-release issues, and beta-tester feedback under `.claude/beta-testing/`.
2. **Build a verification matrix** — every claim gets an automated (unit test / smoke test / CLI assertion) or manual (shell-integration walkthrough) verifier.
3. **Execute verifiers** and record PASS/FAIL/SKIP with full stdout, stderr, exit code.
4. **Random acceptance sample** — roll dice, pick one feature, pretend to be a new user: read the docs, follow them literally, try three happy-path use-cases and one adversarial one. Catches polish gaps the claim matrix misses.
5. **Gap report** written to `.claude/releases/vX.Y.Z-acceptance.md`.
6. **File GH issues** for each gap, labeled `bug` + `release-gap` + `vX.Y.Z`, triaged via this rubric:
   - **P0**: advertised feature doesn't work, security regression, crash, data loss → blocks next release
   - **P1**: feature works but not as documented → must ship in next release
   - **P2**: polish / minor friction → tracked, no deadline
   - **P3**: defer / won't-fix with explicit reason
7. **Exit code gates the next release** — `/caro.release.prepare` refuses to start v(N+1) if v(N) has open P0/P1 gaps.

## Why both exist

| Command | Question it answers |
|---|---|
| `/caro.release.verify` | Can a user install it and run it? |
| `/caro.release.acceptance` | Does it actually do what the release notes promised? |

Installability ≠ acceptance. A release can pass `verify` (binary runs, `--version` correct) while still having a documented feature that silently no-ops.

## Motivation

User request: codify a routine that (a) verifies advertised-vs-actual, (b) reconciles beta-tester requests, (c) files gaps as GH issues with priorities, and (d) gates the next release on prior-release gap closure, plus picks a random feature for deep acceptance testing.

## Test plan
- [ ] Dry-run on v1.3.0: `/caro.release.acceptance v1.3.0` should gather claims from [#861](https://github.com/wildcard/caro/pull/861), [#863](https://github.com/wildcard/caro/pull/863), the v1.3.0 CHANGELOG entry, and produce an audit file
- [ ] Verify it exits 0 when no P0/P1 gaps exist and exit 1 when one is filed
- [ ] Verify `/caro.release.prepare` refuses to proceed when acceptance returns non-zero
- [ ] Confirm the random-sample section picks deterministically with a seeded run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `\caro.release.acceptance` to audit a shipped release against its claims and block the next release until P0/P1 gaps are closed. Also wires this gate into `\caro.release.prepare` and enforces a 6‑file version alignment checklist in `\caro.release.version`.

- New Features
  - Added `\caro.release.acceptance`: gathers claims from `CHANGELOG.md`, GitHub release notes, merged feature PRs, closed-by-release issues, and `.claude/beta-testing/`.
  - Builds and runs a verification matrix (automated/manual), writes `.claude/releases/vX.Y.Z-acceptance.md`, files gap issues with `bug`, `release-gap`, `vX.Y.Z` labels and P0–P3 priority, and exits non-zero if any P0/P1 remain.
  - Includes a random feature acceptance sample for deeper UX checks.
  - `\caro.release.prepare` now runs this gate first and refuses to start when P0/P1 gaps are open.

- Refactors
  - Added `.claude/rules/release-version-alignment.md` and updated `\caro.release.version` with a mandatory step to align all user-facing version references (per the 6‑file checklist, including `README.md`, `ROADMAP.md`, `homebrew-tap/README.md`, `nuget/tools/install.ps1`).
  - Commit flow in `\caro.release.version` now stages all aligned files and shows an expanded diff summary.

<sup>Written for commit 11db554f950536deb686449839c62b6b8320c729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

