### PR TITLE
feat(caroml): PR 1 — parser, AST, lock format, and `caro check`

### DIFF
--- a/.claude/tsc-cache/c5f5fcf0-89e1-4923-aa9d-56a6fd411a71/affected-repos.txt
+++ b/.claude/tsc-cache/c5f5fcf0-89e1-4923-aa9d-56a6fd411a71/affected-repos.txt
@@ -1,0 +1,4 @@
+src
+examples/library
+examples/Carofile
+root

--- a/.claude/tsc-cache/c5f5fcf0-89e1-4923-aa9d-56a6fd411a71/affected-repos.txt
+++ b/.claude/tsc-cache/c5f5fcf0-89e1-4923-aa9d-56a6fd411a71/affected-repos.txt
@@ -1,4 +1,0 @@
-src
-examples/library
-examples/Carofile
-root

--- a/src/caroml/ast.rs
+++ b/src/caroml/ast.rs
@@ -222,7 +222,10 @@ mod tests {
     #[test]
     fn parse_error_display_with_col() {
         let err = ParseError::new(7, ParseErrorKind::MalformedLet).with_col(12);
-        assert_eq!(err.to_string(), "line 7:12: expected `LET <name> = <value>`");
+        assert_eq!(
+            err.to_string(),
+            "line 7:12: expected `LET <name> = <value>`"
+        );
     }
 
     #[test]

--- a/src/caroml/ast.rs
+++ b/src/caroml/ast.rs
@@ -144,12 +144,23 @@ pub enum ParseErrorKind {
     MalformedOn,
     /// A `{name}` interpolation in a `DO` line was never closed.
     UnclosedInterpolation { line: usize },
+    /// `{}` with no name between the braces.
+    EmptyInterpolation,
     /// A `{name}` referenced a name not defined by any prior `LET`.
     UndefinedParam(String),
     /// A `TASK` line had no title.
     EmptyTaskTitle,
     /// The file parsed cleanly but had zero `DO` steps.
     NoSteps,
+    // ---- Carofile-specific variants (used by `caroml::carofile`) ----
+    /// `USE` line could not be parsed as `USE <target> AS <alias>`.
+    MalformedUse,
+    /// `JOB` had no name.
+    EmptyJobName,
+    /// `RUN` appeared outside any `JOB` body.
+    RunOutsideJob,
+    /// `RUN <alias>` referenced an alias not declared by any prior `USE`.
+    UndefinedAlias(String),
 }
 
 impl std::fmt::Display for ParseErrorKind {
@@ -171,6 +182,12 @@ impl std::fmt::Display for ParseErrorKind {
             Self::UnclosedInterpolation { line } => {
                 write!(f, "unclosed `{{...}}` interpolation in DO on line {}", line)
             }
+            Self::EmptyInterpolation => {
+                write!(
+                    f,
+                    "empty `{{}}` in DO; either name a parameter or escape with `{{{{`"
+                )
+            }
             Self::UndefinedParam(name) => write!(
                 f,
                 "DO references `{{{}}}` but no `LET {} = ...` was declared",
@@ -178,6 +195,18 @@ impl std::fmt::Display for ParseErrorKind {
             ),
             Self::EmptyTaskTitle => write!(f, "TASK line has no title"),
             Self::NoSteps => write!(f, "task has no `DO` steps"),
+            Self::MalformedUse => {
+                write!(f, "expected `USE <target> AS <alias>`")
+            }
+            Self::EmptyJobName => write!(f, "JOB has no name"),
+            Self::RunOutsideJob => {
+                write!(f, "RUN appeared outside a JOB body")
+            }
+            Self::UndefinedAlias(name) => write!(
+                f,
+                "RUN references `{}` but no `USE ... AS {}` was declared",
+                name, name
+            ),
         }
     }
 }

--- a/src/caroml/ast.rs
+++ b/src/caroml/ast.rs
@@ -1,0 +1,238 @@
+//! Abstract Syntax Tree for parsed `.caro` files.
+//!
+//! A `.caro` file is line-oriented; each non-blank, non-`REM` line begins
+//! with one of eight keywords. The parser produces a [`Task`] containing
+//! exactly one title, optional `WHY`, zero-or-more pragmas, and one-or-more
+//! [`Step`]s (the `DO` lines that drive generation).
+//!
+//! # Example
+//! ```text
+//! TASK Clean up old log files
+//! WHY  Free disk space, runs weekly via cron
+//!
+//! NEED sudo
+//! ON   macos PREFER bsd-tools
+//! LET  path = /var/log
+//!
+//! NOTE prefer single-pass find
+//! DO   find log files in {path}
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// A fully parsed CaroML task — one `.caro` file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Task {
+    /// Source path on disk, if loaded from a file.
+    pub source_path: Option<PathBuf>,
+
+    /// Required: title from the single `TASK` line. Always non-empty.
+    pub title: String,
+
+    /// Optional: motivation from a single `WHY` line.
+    pub why: Option<String>,
+
+    /// Zero or more `NEED <thing>` declarations (sudo, network, etc.).
+    pub needs: Vec<String>,
+
+    /// Zero or more `ON <platform> [PREFER ...] [AVOID ...]` pragmas.
+    pub platform_pragmas: Vec<PlatformPragma>,
+
+    /// Zero or more `LET <name> = <value>` parameters, in source order.
+    /// Used for `{name}` substitution in `DO` line intents.
+    pub params: Vec<Param>,
+
+    /// One or more `DO <intent>` steps. The unit of generation.
+    pub steps: Vec<Step>,
+}
+
+/// `ON <platform> [PREFER <a, b, ...>] [AVOID <c, d, ...>]`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformPragma {
+    /// Lowercase platform identifier: "macos", "linux", "windows", "posix".
+    pub platform: String,
+    /// Things to prefer on this platform (e.g. `bsd-tools`).
+    pub prefer: Vec<String>,
+    /// Things to avoid on this platform (e.g. `systemd-cat`).
+    pub avoid: Vec<String>,
+}
+
+/// `LET <name> = <value>` — an authoring-time parameter.
+///
+/// Substituted into `DO` lines via `{name}` markers at parse time.
+/// Not exposed to the generated shell script as a variable; the LLM is
+/// free to materialize it as a shell variable or inline literal as it sees fit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Param {
+    pub name: String,
+    pub value: String,
+}
+
+/// A single `DO <intent>` step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Step {
+    /// 1-based source line number in the original `.caro` file.
+    pub line: usize,
+
+    /// Intent text after `{name}` substitution (the form fed to the LLM).
+    pub intent: String,
+
+    /// Intent text as written by the human, with `{name}` markers intact.
+    /// Preserved so re-rendering and round-trip diffs are faithful.
+    pub raw_intent: String,
+
+    /// Any `NOTE` lines that immediately preceded this `DO`, in source order.
+    /// These are passed to the LLM as additional guidance for this step.
+    pub notes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Parser errors
+// ---------------------------------------------------------------------------
+
+/// A parse error. Always carries the source line number for editor jump-to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// 1-based line number where the error was detected.
+    pub line: usize,
+    /// Optional 1-based column for finer pointing.
+    pub col: Option<usize>,
+    /// What went wrong.
+    pub kind: ParseErrorKind,
+}
+
+impl ParseError {
+    pub fn new(line: usize, kind: ParseErrorKind) -> Self {
+        Self {
+            line,
+            col: None,
+            kind,
+        }
+    }
+
+    pub fn with_col(mut self, col: usize) -> Self {
+        self.col = Some(col);
+        self
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.col {
+            Some(c) => write!(f, "line {}:{}: {}", self.line, c, self.kind),
+            None => write!(f, "line {}: {}", self.line, self.kind),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseErrorKind {
+    /// First non-comment line was not `TASK <title>`.
+    MissingTaskHeader,
+    /// More than one `TASK` line in the file.
+    DuplicateTask,
+    /// More than one `WHY` line in the file.
+    DuplicateWhy,
+    /// A line started with an unknown keyword.
+    UnknownKeyword(String),
+    /// `LET` line could not be parsed as `LET name = value`.
+    MalformedLet,
+    /// `ON` line could not be parsed as `ON <platform> [PREFER ...] [AVOID ...]`.
+    MalformedOn,
+    /// A `{name}` interpolation in a `DO` line was never closed.
+    UnclosedInterpolation { line: usize },
+    /// A `{name}` referenced a name not defined by any prior `LET`.
+    UndefinedParam(String),
+    /// A `TASK` line had no title.
+    EmptyTaskTitle,
+    /// The file parsed cleanly but had zero `DO` steps.
+    NoSteps,
+}
+
+impl std::fmt::Display for ParseErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingTaskHeader => {
+                write!(f, "expected `TASK <title>` as the first non-comment line")
+            }
+            Self::DuplicateTask => write!(f, "more than one `TASK` line"),
+            Self::DuplicateWhy => write!(f, "more than one `WHY` line"),
+            Self::UnknownKeyword(kw) => write!(f, "unknown keyword `{}`", kw),
+            Self::MalformedLet => {
+                write!(f, "expected `LET <name> = <value>`")
+            }
+            Self::MalformedOn => write!(
+                f,
+                "expected `ON <platform> [PREFER <a,b,...>] [AVOID <c,d,...>]`"
+            ),
+            Self::UnclosedInterpolation { line } => {
+                write!(f, "unclosed `{{...}}` interpolation in DO on line {}", line)
+            }
+            Self::UndefinedParam(name) => write!(
+                f,
+                "DO references `{{{}}}` but no `LET {} = ...` was declared",
+                name, name
+            ),
+            Self::EmptyTaskTitle => write!(f, "TASK line has no title"),
+            Self::NoSteps => write!(f, "task has no `DO` steps"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests for the AST itself (constructors, Display, basic invariants)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_error_display_with_col() {
+        let err = ParseError::new(7, ParseErrorKind::MalformedLet).with_col(12);
+        assert_eq!(err.to_string(), "line 7:12: expected `LET <name> = <value>`");
+    }
+
+    #[test]
+    fn parse_error_display_without_col() {
+        let err = ParseError::new(3, ParseErrorKind::DuplicateTask);
+        assert_eq!(err.to_string(), "line 3: more than one `TASK` line");
+    }
+
+    #[test]
+    fn unknown_keyword_message() {
+        let err = ParseError::new(1, ParseErrorKind::UnknownKeyword("FOO".into()));
+        assert_eq!(err.to_string(), "line 1: unknown keyword `FOO`");
+    }
+
+    #[test]
+    fn task_struct_round_trip_via_serde_json() {
+        let task = Task {
+            source_path: None,
+            title: "Demo".into(),
+            why: Some("for tests".into()),
+            needs: vec!["sudo".into()],
+            platform_pragmas: vec![PlatformPragma {
+                platform: "macos".into(),
+                prefer: vec!["bsd-tools".into()],
+                avoid: vec![],
+            }],
+            params: vec![Param {
+                name: "path".into(),
+                value: "/tmp".into(),
+            }],
+            steps: vec![Step {
+                line: 8,
+                intent: "list /tmp".into(),
+                raw_intent: "list {path}".into(),
+                notes: vec!["be portable".into()],
+            }],
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        let back: Task = serde_json::from_str(&json).unwrap();
+        assert_eq!(task, back);
+    }
+}

--- a/src/caroml/lock.rs
+++ b/src/caroml/lock.rs
@@ -1,0 +1,452 @@
+//! Lock file format (TOML) for CaroML — schema_version 2.
+//!
+//! The lock pairs each `DO` step with one or more **variants** keyed by
+//! platform. Each variant carries the generated command, validations, a
+//! track record, and lineage metadata. A separate `[[history]]` list is
+//! the audit trail.
+//!
+//! Atomic writes use the `.lock.tmp → rename` convention also used by
+//! [`crate::ai::store`].
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// The current supported schema version. Bumping this is a breaking change
+/// to consumers; provide a `caro lock migrate` path before raising it.
+pub const SCHEMA_VERSION: u32 = 2;
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Lock {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub meta: Meta,
+    #[serde(default)]
+    pub task: TaskMeta,
+    /// One entry per `DO` step in the source `.caro` file.
+    #[serde(default)]
+    pub steps: Vec<Step>,
+    /// Append-only generation lineage; ordered oldest-first.
+    #[serde(default)]
+    pub history: Vec<HistoryEntry>,
+}
+
+impl Default for Lock {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            meta: Meta::default(),
+            task: TaskMeta::default(),
+            steps: Vec::new(),
+            history: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-records
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct Meta {
+    /// Caro version that wrote this lock.
+    #[serde(default)]
+    pub caro_version: String,
+    /// Path of the source `.caro` file relative to the project root.
+    #[serde(default)]
+    pub intent_path: String,
+    /// SHA-256 hash of the parsed-and-normalized `.caro` AST.
+    #[serde(default)]
+    pub intent_hash: String,
+    /// Platforms with at least one variant in this lock.
+    #[serde(default)]
+    pub supported_platforms: Vec<String>,
+    /// Wall-clock timestamp of the last full regeneration.
+    #[serde(default)]
+    pub last_full_regen: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct TaskMeta {
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub why: Option<String>,
+    #[serde(default)]
+    pub needs: Vec<String>,
+    /// platform → list of `PREFER` items (e.g. `macos → [bsd-tools]`).
+    #[serde(default)]
+    pub prefers_by_platform: BTreeMap<String, Vec<String>>,
+    /// platform → list of `AVOID` items.
+    #[serde(default)]
+    pub avoids_by_platform: BTreeMap<String, Vec<String>>,
+    /// Resolved `LET` parameter values keyed by name.
+    #[serde(default)]
+    pub params: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Step {
+    /// 1-based source line number in the `.caro` file.
+    pub line: usize,
+    /// Intent text after `LET` substitution.
+    pub intent: String,
+    /// SHA-256 of the normalized step intent (for per-step staleness).
+    pub intent_hash: String,
+    #[serde(default)]
+    pub notes: Vec<String>,
+    #[serde(default)]
+    pub variants: Vec<Variant>,
+}
+
+impl Step {
+    /// The active variant for the given platform, if any.
+    pub fn active_variant(&self, platform: &str) -> Option<&Variant> {
+        self.variants
+            .iter()
+            .find(|v| v.platform == platform && v.active)
+    }
+
+    /// All challenger variants for the given platform (active = false, not retired).
+    pub fn challengers<'a>(
+        &'a self,
+        platform: &'a str,
+    ) -> impl Iterator<Item = &'a Variant> + 'a {
+        self.variants
+            .iter()
+            .filter(move |v| v.platform == platform && !v.active && v.retired_at.is_none())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Variant {
+    /// Platform identifier: "macos" / "linux" / "windows" / "posix".
+    pub platform: String,
+    /// True iff this variant is the chosen one for its platform.
+    /// At most one active per platform per step.
+    pub active: bool,
+    /// Stable identifier for this generation; format `gen_<YYYY-MM-DD>_<plat>_<a|b|...>`.
+    pub generation_id: String,
+    /// The generated shell command for this step.
+    pub command: String,
+    /// Why the LLM chose this command (free-form, used for `caro why`).
+    #[serde(default)]
+    pub reasoning: String,
+    /// Shell variables this command sets (informational; for downstream prompt context).
+    #[serde(default)]
+    pub exports: Vec<String>,
+    /// Shell variables this command reads from prior steps.
+    #[serde(default)]
+    pub imports: Vec<String>,
+    /// "safe" | "moderate" | "high" | "critical".
+    pub risk_level: String,
+    #[serde(default)]
+    pub matched_patterns: Vec<String>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    /// 0.0–1.0 from the backend's confidence score.
+    pub confidence: f32,
+    /// Number of validation-loop iterations needed to settle on this command.
+    #[serde(default = "default_iterations")]
+    pub iterations: u32,
+    #[serde(default)]
+    pub validations: Vec<ValidationEntry>,
+    pub generated_at: DateTime<Utc>,
+    pub model: String,
+    pub backend: String,
+    /// Probed tool versions at generation time (informational for SoftExplore detection).
+    #[serde(default)]
+    pub tool_versions: BTreeMap<String, String>,
+    /// Run history aggregate (project memory).
+    #[serde(default)]
+    pub track_record: TrackRecord,
+    /// If set, this variant has been retired (no longer active or challenger).
+    #[serde(default)]
+    pub retired_at: Option<DateTime<Utc>>,
+}
+
+fn default_iterations() -> u32 {
+    1
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidationEntry {
+    /// "safety" | "platform" | "secrets" | "side_effects" | …
+    pub angle: String,
+    /// "pass" | "warn" | "fail".
+    pub result: String,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct TrackRecord {
+    #[serde(default)]
+    pub runs: u64,
+    #[serde(default)]
+    pub succeeded: u64,
+    #[serde(default)]
+    pub failed: u64,
+    #[serde(default)]
+    pub last_used: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    pub generation_id: String,
+    /// Why this regeneration happened: "intent_hash_mismatch" | "cve_feed_update" | …
+    pub trigger: String,
+    pub caro_version: String,
+    pub model: String,
+    pub backend: String,
+    pub platform: String,
+    pub generated_at: DateTime<Utc>,
+    pub intent_hash: String,
+    #[serde(default)]
+    pub cve_feed_rev: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Read / write
+// ---------------------------------------------------------------------------
+
+impl Lock {
+    /// Parse a lock from a TOML string.
+    pub fn read_str(toml_src: &str) -> Result<Self, LockError> {
+        let lock: Lock = toml::from_str(toml_src).map_err(LockError::Parse)?;
+        if lock.schema_version != SCHEMA_VERSION {
+            return Err(LockError::UnsupportedSchema(lock.schema_version));
+        }
+        Ok(lock)
+    }
+
+    /// Serialize the lock to a TOML string.
+    pub fn write_string(&self) -> Result<String, LockError> {
+        toml::to_string_pretty(self).map_err(LockError::Serialize)
+    }
+
+    /// Read a lock file from disk.
+    pub fn read_path(path: &Path) -> Result<Self, LockError> {
+        let s = std::fs::read_to_string(path).map_err(LockError::Io)?;
+        Self::read_str(&s)
+    }
+
+    /// Write the lock atomically: write to `<path>.tmp`, then rename.
+    pub fn write_path(&self, path: &Path) -> Result<(), LockError> {
+        let s = self.write_string()?;
+        let tmp = path_with_tmp_suffix(path);
+        std::fs::write(&tmp, s).map_err(LockError::Io)?;
+        std::fs::rename(&tmp, path).map_err(LockError::Io)?;
+        Ok(())
+    }
+}
+
+fn path_with_tmp_suffix(path: &Path) -> std::path::PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".tmp");
+    s.into()
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum LockError {
+    Parse(toml::de::Error),
+    Serialize(toml::ser::Error),
+    Io(std::io::Error),
+    UnsupportedSchema(u32),
+}
+
+impl std::fmt::Display for LockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "lock TOML parse error: {}", e),
+            Self::Serialize(e) => write!(f, "lock TOML serialize error: {}", e),
+            Self::Io(e) => write!(f, "lock IO error: {}", e),
+            Self::UnsupportedSchema(v) => write!(
+                f,
+                "lock has schema_version {} but only {} is supported (use `caro lock migrate`)",
+                v, SCHEMA_VERSION
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(e) => Some(e),
+            Self::Serialize(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::UnsupportedSchema(_) => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample_variant() -> Variant {
+        Variant {
+            platform: "macos".into(),
+            active: true,
+            generation_id: "gen_2026-04-26_macos_a".into(),
+            command: "files=$(find /var/log -type f -name '*.log')".into(),
+            reasoning: "Use BSD find with -type f / -name; capture into a shell variable.".into(),
+            exports: vec!["files".into()],
+            imports: Vec::new(),
+            risk_level: "safe".into(),
+            matched_patterns: Vec::new(),
+            warnings: Vec::new(),
+            confidence: 0.94,
+            iterations: 1,
+            validations: vec![ValidationEntry {
+                angle: "safety".into(),
+                result: "pass".into(),
+                note: None,
+            }],
+            generated_at: Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap(),
+            model: "smollm-1.7b".into(),
+            backend: "embedded".into(),
+            tool_versions: {
+                let mut m = BTreeMap::new();
+                m.insert("find".into(), "BSD-stock-macos14".into());
+                m
+            },
+            track_record: TrackRecord {
+                runs: 42,
+                succeeded: 42,
+                failed: 0,
+                last_used: Some(Utc.with_ymd_and_hms(2026, 4, 25, 8, 30, 0).unwrap()),
+            },
+            retired_at: None,
+        }
+    }
+
+    fn sample_lock() -> Lock {
+        Lock {
+            schema_version: SCHEMA_VERSION,
+            meta: Meta {
+                caro_version: "1.4.0".into(),
+                intent_path: "tasks/cleanup-logs.caro".into(),
+                intent_hash: "sha256:a7b3c1".into(),
+                supported_platforms: vec!["macos".into(), "linux".into()],
+                last_full_regen: Some(Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
+            },
+            task: TaskMeta {
+                title: "Clean up old log files".into(),
+                why: Some("Free disk space".into()),
+                needs: vec!["sudo".into()],
+                prefers_by_platform: {
+                    let mut m = BTreeMap::new();
+                    m.insert("macos".into(), vec!["bsd-tools".into()]);
+                    m
+                },
+                avoids_by_platform: BTreeMap::new(),
+                params: {
+                    let mut m = BTreeMap::new();
+                    m.insert("path".into(), "/var/log".into());
+                    m.insert("days".into(), "30".into());
+                    m
+                },
+            },
+            steps: vec![Step {
+                line: 12,
+                intent: "find log files in /var/log".into(),
+                intent_hash: "sha256:step1".into(),
+                notes: vec!["prefer single-pass find".into()],
+                variants: vec![sample_variant()],
+            }],
+            history: vec![HistoryEntry {
+                generation_id: "gen_2026-04-26_macos_a".into(),
+                trigger: "intent_hash_mismatch".into(),
+                caro_version: "1.4.0".into(),
+                model: "smollm-1.7b".into(),
+                backend: "embedded".into(),
+                platform: "macos".into(),
+                generated_at: Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap(),
+                intent_hash: "sha256:a7b3c1".into(),
+                cve_feed_rev: Some("2026-04-26".into()),
+                notes: Some("initial gen".into()),
+            }],
+        }
+    }
+
+    #[test]
+    fn round_trip_via_toml() {
+        let lock = sample_lock();
+        let s = lock.write_string().unwrap();
+        let back = Lock::read_str(&s).unwrap();
+        assert_eq!(lock, back);
+    }
+
+    #[test]
+    fn defaults_compile_and_serialize() {
+        let lock = Lock::default();
+        let s = lock.write_string().unwrap();
+        let back = Lock::read_str(&s).unwrap();
+        assert_eq!(lock, back);
+    }
+
+    #[test]
+    fn rejects_unsupported_schema() {
+        let mut lock = sample_lock();
+        lock.schema_version = 99;
+        let s = lock.write_string().unwrap();
+        match Lock::read_str(&s) {
+            Err(LockError::UnsupportedSchema(99)) => {}
+            other => panic!("expected UnsupportedSchema(99), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn active_variant_lookup() {
+        let lock = sample_lock();
+        let step = &lock.steps[0];
+        assert!(step.active_variant("macos").is_some());
+        assert!(step.active_variant("linux").is_none());
+    }
+
+    #[test]
+    fn challengers_filter() {
+        let mut lock = sample_lock();
+        let mut challenger = sample_variant();
+        challenger.active = false;
+        challenger.generation_id = "gen_2026-04-26_macos_b".into();
+        lock.steps[0].variants.push(challenger);
+        let count = lock.steps[0].challengers("macos").count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn write_path_atomic_rename(/* tmpfs not always available; use tempdir */) {
+        let dir = tempdir_or_skip();
+        let path = dir.path().join("sample.lock");
+        let lock = sample_lock();
+        lock.write_path(&path).unwrap();
+        let back = Lock::read_path(&path).unwrap();
+        assert_eq!(lock, back);
+        // The .tmp file should not remain after a successful rename.
+        let tmp = super::path_with_tmp_suffix(&path);
+        assert!(!tmp.exists());
+    }
+
+    fn tempdir_or_skip() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir creation should succeed")
+    }
+}

--- a/src/caroml/lock.rs
+++ b/src/caroml/lock.rs
@@ -113,10 +113,7 @@ impl Step {
     }
 
     /// All challenger variants for the given platform (active = false, not retired).
-    pub fn challengers<'a>(
-        &'a self,
-        platform: &'a str,
-    ) -> impl Iterator<Item = &'a Variant> + 'a {
+    pub fn challengers<'a>(&'a self, platform: &'a str) -> impl Iterator<Item = &'a Variant> + 'a {
         self.variants
             .iter()
             .filter(move |v| v.platform == platform && !v.active && v.retired_at.is_none())

--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -1,0 +1,64 @@
+//! CaroML — A meta-language for intent-tracked shell tasks.
+//!
+//! CaroML lets a human commit *intent* (a `.caro` file written in a small
+//! line-keyword DSL) and have Caro deterministically (re)generate the
+//! shell script that fulfills it. The lock (`.caro.lock`) records every
+//! generation per platform with a track record so the file evolves with
+//! models, CVE feeds, and accumulated team preference.
+//!
+//! See `docs/caroml/intro.md` for the language reference and
+//! `~/.claude/plans/plan-a-caro-dsl-encapsulated-emerson.md` for the
+//! design plan that drives this module.
+//!
+//! # Layout (v0.1)
+//!
+//! - [`ast`] — parsed `.caro` file representation
+//! - [`parser`] — line-keyword tokenizer; no grammar lib needed
+//! - [`lock`] — TOML serde for the lock format (schema_version 2)
+//!
+//! Subsequent PRs add: discovery, runbook writer, validators, interpreter,
+//! runner, regen evaluator, history, variants, voice, scaffold, skill,
+//! carofile, cve_feed, platform.
+
+pub mod ast;
+pub mod lock;
+pub mod parser;
+
+pub use ast::{ParseError, ParseErrorKind, Param, PlatformPragma, Step, Task};
+pub use lock::{Lock, Step as LockStep, Variant};
+pub use parser::parse;
+
+use std::path::Path;
+
+/// Read a `.caro` file and parse it, returning the [`Task`] on success.
+///
+/// This is the high-level convenience used by `caro check`.
+pub fn check_file(path: &Path) -> Result<Task, CheckError> {
+    let src = std::fs::read_to_string(path).map_err(CheckError::Io)?;
+    parser::parse_with_path(&src, Some(path.to_path_buf())).map_err(CheckError::Parse)
+}
+
+/// Error from [`check_file`] — either I/O or parsing.
+#[derive(Debug)]
+pub enum CheckError {
+    Io(std::io::Error),
+    Parse(ParseError),
+}
+
+impl std::fmt::Display for CheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "{}", e),
+            Self::Parse(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for CheckError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Parse(e) => Some(e),
+        }
+    }
+}

--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -24,7 +24,7 @@ pub mod ast;
 pub mod lock;
 pub mod parser;
 
-pub use ast::{ParseError, ParseErrorKind, Param, PlatformPragma, Step, Task};
+pub use ast::{Param, ParseError, ParseErrorKind, PlatformPragma, Step, Task};
 pub use lock::{Lock, Step as LockStep, Variant};
 pub use parser::parse;
 

--- a/src/caroml/parser.rs
+++ b/src/caroml/parser.rs
@@ -37,6 +37,7 @@ pub fn parse_with_path(src: &str, source_path: Option<PathBuf>) -> Result<Task, 
         if trimmed.is_empty() {
             continue;
         }
+        state.last_line = state.line_no;
 
         let (keyword, rest) = split_keyword(trimmed);
         match keyword {
@@ -65,6 +66,8 @@ pub fn parse_with_path(src: &str, source_path: Option<PathBuf>) -> Result<Task, 
 
 struct ParseState {
     line_no: usize,
+    /// Last non-blank line seen — used as the location for end-of-file errors.
+    last_line: usize,
     source_path: Option<PathBuf>,
     title: Option<String>,
     why: Option<String>,
@@ -79,6 +82,7 @@ impl ParseState {
     fn new(source_path: Option<PathBuf>) -> Self {
         Self {
             line_no: 0,
+            last_line: 0,
             source_path,
             title: None,
             why: None,
@@ -173,11 +177,14 @@ impl ParseState {
     }
 
     fn finish(self) -> Result<Task, ParseError> {
+        // End-of-file errors point at the last non-blank line we saw, falling
+        // back to line 1 for entirely empty / whitespace-only files. Never 0.
+        let eof_line = self.last_line.max(1);
         let title = self
             .title
-            .ok_or_else(|| ParseError::new(0, ParseErrorKind::MissingTaskHeader))?;
+            .ok_or_else(|| ParseError::new(eof_line, ParseErrorKind::MissingTaskHeader))?;
         if self.steps.is_empty() {
-            return Err(ParseError::new(0, ParseErrorKind::NoSteps));
+            return Err(ParseError::new(eof_line, ParseErrorKind::NoSteps));
         }
         Ok(Task {
             source_path: self.source_path,
@@ -246,6 +253,17 @@ fn parse_on_clause(rest: &str) -> Option<PlatformPragma> {
     })
 }
 
+/// Substitute `{name}` placeholders in `raw` with `params` values.
+///
+/// Escape rules:
+/// - `{{` is a literal `{` (lets `awk '{{print $1}}'` survive parsing — see issue
+///   linked from PR review). The matching `}}` is also collapsed to `}` for symmetry.
+/// - `{name}` references a `LET name = value`; substitutes the value.
+/// - `{}` is an error (`EmptyInterpolation`).
+/// - `{name` without closing `}` is `UnclosedInterpolation`.
+///
+/// UTF-8 safe: walks `raw` by char with byte-tracking, never indexes by raw byte
+/// for the literal-copy branch.
 fn substitute_params(
     raw: &str,
     params: &[Param],
@@ -254,10 +272,25 @@ fn substitute_params(
     let mut out = String::with_capacity(raw.len());
     let known: HashSet<&str> = params.iter().map(|p| p.name.as_str()).collect();
 
+    let mut i = 0usize;
     let bytes = raw.as_bytes();
-    let mut i = 0;
+
     while i < bytes.len() {
+        // Literal `{` escape: `{{` → `{`
+        if bytes[i] == b'{' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            out.push('{');
+            i += 2;
+            continue;
+        }
+        // Literal `}` escape: `}}` → `}` (symmetric)
+        if bytes[i] == b'}' && i + 1 < bytes.len() && bytes[i + 1] == b'}' {
+            out.push('}');
+            i += 2;
+            continue;
+        }
+
         if bytes[i] == b'{' {
+            // {name} interpolation
             let close = match bytes[i + 1..].iter().position(|&b| b == b'}') {
                 Some(rel) => i + 1 + rel,
                 None => {
@@ -268,6 +301,9 @@ fn substitute_params(
                 }
             };
             let name = &raw[i + 1..close];
+            if name.is_empty() {
+                return Err(ParseError::new(line_no, ParseErrorKind::EmptyInterpolation));
+            }
             if !known.contains(name) {
                 return Err(ParseError::new(
                     line_no,
@@ -281,10 +317,14 @@ fn substitute_params(
                 .unwrap_or("");
             out.push_str(value);
             i = close + 1;
-        } else {
-            out.push(bytes[i] as char);
-            i += 1;
+            continue;
         }
+
+        // Literal copy — UTF-8 safe: read one char from raw[i..] and advance by its byte length.
+        let c = raw[i..].chars().next().unwrap();
+        let len = c.len_utf8();
+        out.push(c);
+        i += len;
     }
     Ok(out)
 }
@@ -450,6 +490,59 @@ mod tests {
             other => panic!("unexpected error: {:?}", other),
         }
         assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn utf8_in_intent_round_trips_intact() {
+        // Regression: prior implementation truncated non-ASCII codepoints via
+        // `bytes[i] as char`. café / 日本語 / 🌱 must survive verbatim.
+        let src = "TASK Demo\nDO open the café\nDO greet 日本語 🌱\n";
+        let task = must_parse(src);
+        assert_eq!(task.steps[0].intent, "open the café");
+        assert_eq!(task.steps[1].intent, "greet 日本語 🌱");
+    }
+
+    #[test]
+    fn double_brace_escape_yields_literal_brace() {
+        // Lets shell snippets like `awk '{{print $1}}'` survive parsing.
+        let src = "TASK Demo\nDO awk '{{print $1}}' on the file\n";
+        let task = must_parse(src);
+        assert_eq!(task.steps[0].intent, "awk '{print $1}' on the file");
+    }
+
+    #[test]
+    fn empty_interpolation_is_explicit_error() {
+        let src = "TASK Demo\nDO list {}\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::EmptyInterpolation));
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn missing_task_uses_last_seen_line_not_zero() {
+        let src = "REM intro\nWHY because\nNEED sudo\n";
+        let err = parse(src).unwrap_err();
+        // First non-comment, non-blank line is `WHY` on line 2 — that's where
+        // the missing `TASK` requirement bites.
+        assert!(matches!(err.kind, ParseErrorKind::MissingTaskHeader));
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn no_steps_uses_last_seen_line_not_zero() {
+        let src = "TASK Demo\nWHY because\nNEED sudo\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::NoSteps));
+        // `NEED` was the last meaningful line — line 3.
+        assert_eq!(err.line, 3);
+    }
+
+    #[test]
+    fn empty_file_uses_line_one() {
+        let src = "";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::MissingTaskHeader));
+        assert_eq!(err.line, 1);
     }
 
     #[test]

--- a/src/caroml/parser.rs
+++ b/src/caroml/parser.rs
@@ -1,0 +1,501 @@
+//! Line-keyword tokenizer and parser for `.caro` files.
+//!
+//! The grammar is trivial: each non-blank line begins with one of eight
+//! keywords (TASK, WHY, NEED, ON, LET, DO, NOTE, REM). The first non-`REM`
+//! token determines the line kind; the rest of the line is the payload
+//! interpreted per-keyword.
+//!
+//! No grammar library is used — a hand-rolled tokenizer is enough.
+//!
+//! # Error strategy
+//!
+//! v0.1 is **fail-fast**: parsing returns `Err(first_error)` on the first
+//! problem encountered. This keeps the implementation simple and gives
+//! editor jump-to-line behaviour. A future version may switch to an
+//! error-recovery (collect-all) mode for `caro check`; the public API
+//! returns a single `ParseError` today but the type is shaped to allow
+//! a `Vec<ParseError>` variant later without source-breaking changes.
+
+use crate::caroml::ast::{ParseError, ParseErrorKind, Param, PlatformPragma, Step, Task};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+/// Parse a `.caro` source string into a [`Task`].
+///
+/// Returns the first parse error encountered (fail-fast).
+pub fn parse(src: &str) -> Result<Task, ParseError> {
+    parse_with_path(src, None)
+}
+
+/// Parse with an associated source path (for error messages and the `Task.source_path` field).
+pub fn parse_with_path(src: &str, source_path: Option<PathBuf>) -> Result<Task, ParseError> {
+    let mut state = ParseState::new(source_path);
+    for (idx, raw_line) in src.lines().enumerate() {
+        state.line_no = idx + 1;
+        let line = raw_line.trim_end();
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let (keyword, rest) = split_keyword(trimmed);
+        match keyword {
+            "REM" => continue,
+            "TASK" => state.handle_task(rest)?,
+            "WHY" => state.handle_why(rest)?,
+            "NEED" => state.handle_need(rest)?,
+            "ON" => state.handle_on(rest)?,
+            "LET" => state.handle_let(rest)?,
+            "NOTE" => state.handle_note(rest),
+            "DO" => state.handle_do(rest)?,
+            other => {
+                return Err(ParseError::new(
+                    state.line_no,
+                    ParseErrorKind::UnknownKeyword(other.to_string()),
+                ));
+            }
+        }
+    }
+    state.finish()
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+struct ParseState {
+    line_no: usize,
+    source_path: Option<PathBuf>,
+    title: Option<String>,
+    why: Option<String>,
+    needs: Vec<String>,
+    pragmas: Vec<PlatformPragma>,
+    params: Vec<Param>,
+    pending_notes: Vec<String>,
+    steps: Vec<Step>,
+}
+
+impl ParseState {
+    fn new(source_path: Option<PathBuf>) -> Self {
+        Self {
+            line_no: 0,
+            source_path,
+            title: None,
+            why: None,
+            needs: Vec::new(),
+            pragmas: Vec::new(),
+            params: Vec::new(),
+            pending_notes: Vec::new(),
+            steps: Vec::new(),
+        }
+    }
+
+    fn handle_task(&mut self, rest: &str) -> Result<(), ParseError> {
+        if self.title.is_some() {
+            return Err(ParseError::new(self.line_no, ParseErrorKind::DuplicateTask));
+        }
+        let title = rest.trim();
+        if title.is_empty() {
+            return Err(ParseError::new(
+                self.line_no,
+                ParseErrorKind::EmptyTaskTitle,
+            ));
+        }
+        self.title = Some(title.to_string());
+        Ok(())
+    }
+
+    fn handle_why(&mut self, rest: &str) -> Result<(), ParseError> {
+        self.require_task()?;
+        if self.why.is_some() {
+            return Err(ParseError::new(self.line_no, ParseErrorKind::DuplicateWhy));
+        }
+        self.why = Some(rest.trim().to_string());
+        Ok(())
+    }
+
+    fn handle_need(&mut self, rest: &str) -> Result<(), ParseError> {
+        self.require_task()?;
+        let item = rest.trim();
+        if !item.is_empty() {
+            self.needs.push(item.to_string());
+        }
+        Ok(())
+    }
+
+    fn handle_on(&mut self, rest: &str) -> Result<(), ParseError> {
+        self.require_task()?;
+        let parsed = parse_on_clause(rest).ok_or_else(|| {
+            ParseError::new(self.line_no, ParseErrorKind::MalformedOn)
+        })?;
+        self.pragmas.push(parsed);
+        Ok(())
+    }
+
+    fn handle_let(&mut self, rest: &str) -> Result<(), ParseError> {
+        self.require_task()?;
+        let (name, value) = parse_let_clause(rest)
+            .ok_or_else(|| ParseError::new(self.line_no, ParseErrorKind::MalformedLet))?;
+        self.params.push(Param { name, value });
+        Ok(())
+    }
+
+    fn handle_note(&mut self, rest: &str) {
+        let note = rest.trim();
+        if !note.is_empty() {
+            self.pending_notes.push(note.to_string());
+        }
+    }
+
+    fn handle_do(&mut self, rest: &str) -> Result<(), ParseError> {
+        self.require_task()?;
+        let raw_intent = rest.trim().to_string();
+        let intent = substitute_params(&raw_intent, &self.params, self.line_no)?;
+        let notes = std::mem::take(&mut self.pending_notes);
+        self.steps.push(Step {
+            line: self.line_no,
+            intent,
+            raw_intent,
+            notes,
+        });
+        Ok(())
+    }
+
+    fn require_task(&self) -> Result<(), ParseError> {
+        if self.title.is_none() {
+            Err(ParseError::new(
+                self.line_no,
+                ParseErrorKind::MissingTaskHeader,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn finish(self) -> Result<Task, ParseError> {
+        let title = self
+            .title
+            .ok_or_else(|| ParseError::new(0, ParseErrorKind::MissingTaskHeader))?;
+        if self.steps.is_empty() {
+            return Err(ParseError::new(0, ParseErrorKind::NoSteps));
+        }
+        Ok(Task {
+            source_path: self.source_path,
+            title,
+            why: self.why,
+            needs: self.needs,
+            platform_pragmas: self.pragmas,
+            params: self.params,
+            steps: self.steps,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-parsers
+// ---------------------------------------------------------------------------
+
+fn split_keyword(line: &str) -> (&str, &str) {
+    match line.split_once(char::is_whitespace) {
+        Some((kw, rest)) => (kw, rest),
+        None => (line, ""),
+    }
+}
+
+fn parse_let_clause(rest: &str) -> Option<(String, String)> {
+    let (lhs, rhs) = rest.split_once('=')?;
+    let name = lhs.trim();
+    let value = rhs.trim();
+    if name.is_empty() || !is_valid_identifier(name) {
+        return None;
+    }
+    Some((name.to_string(), value.to_string()))
+}
+
+fn parse_on_clause(rest: &str) -> Option<PlatformPragma> {
+    let mut tokens = rest.split_whitespace();
+    let platform = tokens.next()?.to_lowercase();
+    if !is_valid_platform(&platform) {
+        return None;
+    }
+    let mut prefer = Vec::new();
+    let mut avoid = Vec::new();
+    let mut current: Option<&mut Vec<String>> = None;
+    for tok in tokens {
+        match tok.to_uppercase().as_str() {
+            "PREFER" => current = Some(&mut prefer),
+            "AVOID" => current = Some(&mut avoid),
+            _ => {
+                if let Some(target) = current.as_deref_mut() {
+                    for item in tok.split(',') {
+                        let trimmed = item.trim();
+                        if !trimmed.is_empty() {
+                            target.push(trimmed.to_string());
+                        }
+                    }
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(PlatformPragma {
+        platform,
+        prefer,
+        avoid,
+    })
+}
+
+fn substitute_params(
+    raw: &str,
+    params: &[Param],
+    line_no: usize,
+) -> Result<String, ParseError> {
+    let mut out = String::with_capacity(raw.len());
+    let known: HashSet<&str> = params.iter().map(|p| p.name.as_str()).collect();
+
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            let close = match bytes[i + 1..].iter().position(|&b| b == b'}') {
+                Some(rel) => i + 1 + rel,
+                None => {
+                    return Err(ParseError::new(
+                        line_no,
+                        ParseErrorKind::UnclosedInterpolation { line: line_no },
+                    ));
+                }
+            };
+            let name = &raw[i + 1..close];
+            if !known.contains(name) {
+                return Err(ParseError::new(
+                    line_no,
+                    ParseErrorKind::UndefinedParam(name.to_string()),
+                ));
+            }
+            let value = params
+                .iter()
+                .find(|p| p.name == name)
+                .map(|p| p.value.as_str())
+                .unwrap_or("");
+            out.push_str(value);
+            i = close + 1;
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    Ok(out)
+}
+
+fn is_valid_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn is_valid_platform(s: &str) -> bool {
+    matches!(s, "macos" | "linux" | "windows" | "posix")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn must_parse(src: &str) -> Task {
+        parse(src).expect("expected successful parse")
+    }
+
+    #[test]
+    fn parses_minimal_task() {
+        let src = "TASK Hello\nDO say hi\n";
+        let task = must_parse(src);
+        assert_eq!(task.title, "Hello");
+        assert_eq!(task.steps.len(), 1);
+        assert_eq!(task.steps[0].intent, "say hi");
+        assert_eq!(task.steps[0].line, 2);
+    }
+
+    #[test]
+    fn ignores_blank_lines_and_rem() {
+        let src = "\nREM hello\nTASK Hello\n\nREM another comment\nDO say hi\n";
+        let task = must_parse(src);
+        assert_eq!(task.title, "Hello");
+        assert_eq!(task.steps.len(), 1);
+    }
+
+    #[test]
+    fn task_with_why_and_needs() {
+        let src = "TASK Demo\nWHY because\nNEED sudo\nNEED jq\nDO go\n";
+        let task = must_parse(src);
+        assert_eq!(task.why, Some("because".into()));
+        assert_eq!(task.needs, vec!["sudo".to_string(), "jq".into()]);
+    }
+
+    #[test]
+    fn parses_on_with_prefer_and_avoid() {
+        let src =
+            "TASK Demo\nON macos PREFER bsd-tools AVOID gnu-tools, systemd\nDO go\n";
+        let task = must_parse(src);
+        let p = &task.platform_pragmas[0];
+        assert_eq!(p.platform, "macos");
+        assert_eq!(p.prefer, vec!["bsd-tools".to_string()]);
+        assert_eq!(
+            p.avoid,
+            vec!["gnu-tools".to_string(), "systemd".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_on_unknown_platform() {
+        let src = "TASK Demo\nON solaris PREFER bsd-tools\nDO go\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::MalformedOn));
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn substitutes_let_into_intent() {
+        let src = "TASK Demo\nLET path = /tmp\nDO list {path}\n";
+        let task = must_parse(src);
+        assert_eq!(task.steps[0].intent, "list /tmp");
+        assert_eq!(task.steps[0].raw_intent, "list {path}");
+    }
+
+    #[test]
+    fn rejects_undefined_param() {
+        let src = "TASK Demo\nDO list {nope}\n";
+        let err = parse(src).unwrap_err();
+        match err.kind {
+            ParseErrorKind::UndefinedParam(ref n) if n == "nope" => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn rejects_unclosed_interpolation() {
+        let src = "TASK Demo\nLET path = /tmp\nDO list {path\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ParseErrorKind::UnclosedInterpolation { .. }
+        ));
+        assert_eq!(err.line, 3);
+    }
+
+    #[test]
+    fn note_attaches_to_next_do() {
+        let src = "TASK Demo\nNOTE be portable\nNOTE prefer xargs\nDO list /tmp\nDO clean up\n";
+        let task = must_parse(src);
+        assert_eq!(task.steps.len(), 2);
+        assert_eq!(
+            task.steps[0].notes,
+            vec!["be portable".to_string(), "prefer xargs".to_string()]
+        );
+        assert!(task.steps[1].notes.is_empty());
+    }
+
+    #[test]
+    fn duplicate_task_is_error() {
+        let src = "TASK Demo\nTASK Other\nDO go\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::DuplicateTask));
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn duplicate_why_is_error() {
+        let src = "TASK Demo\nWHY because\nWHY also because\nDO go\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::DuplicateWhy));
+        assert_eq!(err.line, 3);
+    }
+
+    #[test]
+    fn missing_task_header_is_error() {
+        let src = "DO go\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::MissingTaskHeader));
+    }
+
+    #[test]
+    fn empty_task_title_is_error() {
+        let src = "TASK   \nDO go\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::EmptyTaskTitle));
+    }
+
+    #[test]
+    fn no_steps_is_error() {
+        let src = "TASK Demo\nWHY because\n";
+        let err = parse(src).unwrap_err();
+        assert!(matches!(err.kind, ParseErrorKind::NoSteps));
+    }
+
+    #[test]
+    fn unknown_keyword_is_error() {
+        let src = "TASK Demo\nFOO bar\nDO go\n";
+        let err = parse(src).unwrap_err();
+        match err.kind {
+            ParseErrorKind::UnknownKeyword(ref kw) if kw == "FOO" => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+        assert_eq!(err.line, 2);
+    }
+
+    #[test]
+    fn full_cleanup_logs_example() {
+        let src = "\
+TASK Clean up old log files
+WHY  Free disk space and rotate; runs weekly via cron
+
+NEED sudo
+ON   macos PREFER bsd-tools
+ON   linux PREFER gnu-tools
+
+LET  path = /var/log
+LET  days = 30
+
+NOTE prefer single-pass find, avoid spawning a subshell per file
+DO   find log files in {path}
+DO   filter to those older than {days} days
+DO   delete each one, asking confirmation per file
+DO   record what was deleted to /tmp/caro-cleanup.log
+";
+        let task = must_parse(src);
+        assert_eq!(task.title, "Clean up old log files");
+        assert_eq!(
+            task.why.as_deref(),
+            Some("Free disk space and rotate; runs weekly via cron")
+        );
+        assert_eq!(task.needs, vec!["sudo".to_string()]);
+        assert_eq!(task.platform_pragmas.len(), 2);
+        assert_eq!(task.params.len(), 2);
+        assert_eq!(task.steps.len(), 4);
+        assert_eq!(
+            task.steps[0].intent,
+            "find log files in /var/log"
+        );
+        assert_eq!(
+            task.steps[0].raw_intent,
+            "find log files in {path}"
+        );
+        assert_eq!(
+            task.steps[0].notes,
+            vec!["prefer single-pass find, avoid spawning a subshell per file".to_string()]
+        );
+        assert_eq!(
+            task.steps[1].intent,
+            "filter to those older than 30 days"
+        );
+    }
+}

--- a/src/caroml/parser.rs
+++ b/src/caroml/parser.rs
@@ -16,7 +16,7 @@
 //! returns a single `ParseError` today but the type is shaped to allow
 //! a `Vec<ParseError>` variant later without source-breaking changes.
 
-use crate::caroml::ast::{ParseError, ParseErrorKind, Param, PlatformPragma, Step, Task};
+use crate::caroml::ast::{Param, ParseError, ParseErrorKind, PlatformPragma, Step, Task};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -129,9 +129,8 @@ impl ParseState {
 
     fn handle_on(&mut self, rest: &str) -> Result<(), ParseError> {
         self.require_task()?;
-        let parsed = parse_on_clause(rest).ok_or_else(|| {
-            ParseError::new(self.line_no, ParseErrorKind::MalformedOn)
-        })?;
+        let parsed = parse_on_clause(rest)
+            .ok_or_else(|| ParseError::new(self.line_no, ParseErrorKind::MalformedOn))?;
         self.pragmas.push(parsed);
         Ok(())
     }
@@ -264,11 +263,7 @@ fn parse_on_clause(rest: &str) -> Option<PlatformPragma> {
 ///
 /// UTF-8 safe: walks `raw` by char with byte-tracking, never indexes by raw byte
 /// for the literal-copy branch.
-fn substitute_params(
-    raw: &str,
-    params: &[Param],
-    line_no: usize,
-) -> Result<String, ParseError> {
+fn substitute_params(raw: &str, params: &[Param], line_no: usize) -> Result<String, ParseError> {
     let mut out = String::with_capacity(raw.len());
     let known: HashSet<&str> = params.iter().map(|p| p.name.as_str()).collect();
 
@@ -382,8 +377,7 @@ mod tests {
 
     #[test]
     fn parses_on_with_prefer_and_avoid() {
-        let src =
-            "TASK Demo\nON macos PREFER bsd-tools AVOID gnu-tools, systemd\nDO go\n";
+        let src = "TASK Demo\nON macos PREFER bsd-tools AVOID gnu-tools, systemd\nDO go\n";
         let task = must_parse(src);
         let p = &task.platform_pragmas[0];
         assert_eq!(p.platform, "macos");
@@ -574,21 +568,12 @@ DO   record what was deleted to /tmp/caro-cleanup.log
         assert_eq!(task.platform_pragmas.len(), 2);
         assert_eq!(task.params.len(), 2);
         assert_eq!(task.steps.len(), 4);
-        assert_eq!(
-            task.steps[0].intent,
-            "find log files in /var/log"
-        );
-        assert_eq!(
-            task.steps[0].raw_intent,
-            "find log files in {path}"
-        );
+        assert_eq!(task.steps[0].intent, "find log files in /var/log");
+        assert_eq!(task.steps[0].raw_intent, "find log files in {path}");
         assert_eq!(
             task.steps[0].notes,
             vec!["prefer single-pass find, avoid spawning a subshell per file".to_string()]
         );
-        assert_eq!(
-            task.steps[1].intent,
-            "filter to those older than 30 days"
-        );
+        assert_eq!(task.steps[1].intent, "filter to those older than 30 days");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ai;
 pub mod assessment;
 pub mod backends;
 pub mod cache;
+pub mod caroml;
 pub mod cli;
 pub mod completion;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,6 +493,14 @@ enum Commands {
         #[arg(long)]
         disable_ai: bool,
     },
+
+    /// Validate a CaroML (`.caro`) task file: parse, lint, report errors with line numbers.
+    ///
+    /// No LLM calls, no execution, no regen. Suitable for editor integration and CI.
+    Check {
+        /// Path to a `.caro` file.
+        file: std::path::PathBuf,
+    },
     // /// Manage telemetry data and settings
     // Telemetry {
     //     #[command(subcommand)]
@@ -2154,6 +2162,26 @@ async fn main() {
                 }
             }
         }
+        Some(Commands::Check { ref file }) => match caro::caroml::check_file(file) {
+            Ok(task) => {
+                println!(
+                    "{}: ok ({} steps, {} pragmas, {} params)",
+                    file.display(),
+                    task.steps.len(),
+                    task.platform_pragmas.len(),
+                    task.params.len()
+                );
+                process::exit(0);
+            }
+            Err(caro::caroml::CheckError::Io(e)) => {
+                eprintln!("{}: {}", file.display(), e);
+                process::exit(1);
+            }
+            Err(caro::caroml::CheckError::Parse(e)) => {
+                eprintln!("{}: {}", file.display(), e);
+                process::exit(1);
+            }
+        },
         Some(Commands::Ai {
             new_session,
             continue_session: _,

--- a/tests/fixtures/caroml/cleanup-logs.caro
+++ b/tests/fixtures/caroml/cleanup-logs.caro
@@ -1,0 +1,18 @@
+REM Test fixture: a well-formed cleanup-logs task.
+REM Used by integration tests for parser, lock, and `caro check`.
+
+TASK Clean up old log files
+WHY  Free disk space and rotate; runs weekly via cron
+
+NEED sudo
+ON   macos PREFER bsd-tools
+ON   linux PREFER gnu-tools
+
+LET  path = /var/log
+LET  days = 30
+
+NOTE prefer single-pass find, avoid spawning a subshell per file
+DO   find log files in {path}
+DO   filter to those older than {days} days
+DO   delete each one, asking confirmation per file
+DO   record what was deleted to /tmp/caro-cleanup.log

--- a/tests/fixtures/caroml/malformed-undefined-param.caro
+++ b/tests/fixtures/caroml/malformed-undefined-param.caro
@@ -1,0 +1,5 @@
+REM Test fixture: a malformed task referencing an undeclared param.
+REM `caro check` should emit a structured error pointing to line 5.
+
+TASK Demo
+DO list {nope}


### PR DESCRIPTION
## Summary

PR 1 of CaroML v0.1 — the **foundational layer** for the CaroML meta-language. Subsequent PRs (parser → discovery → validators → interpreter → runner → memory → orchestration → render/voice/skill → examples → polish) build on this. No LLM integration yet; all-deterministic, all-test surface.

Plan reference: `~/.claude/plans/plan-a-caro-dsl-encapsulated-emerson.md` (private design doc).

### What CaroML is

A line-keyword DSL for **intent-tracked shell tasks**: a `.caro` file describes a task as natural-language `DO` lines plus directives for platform / safety / parameters; Caro generates the runbook per platform, validates from multiple angles, and tracks A/B candidates over time so the *script* evolves with models / CVEs / preferences while the *intent* stays stable. This PR is the parser-only foundation.

### What this PR adds

- **`src/caroml/parser.rs`** — hand-rolled line-keyword tokenizer; eight keywords (`TASK`, `WHY`, `NEED`, `ON`, `LET`, `DO`, `NOTE`, `REM`); fail-fast errors with structured line numbers; `{name}` substitution from `LET`; `PREFER`/`AVOID` clauses on `ON`.
- **`src/caroml/ast.rs`** — `Task` / `PlatformPragma` / `Param` / `Step` types plus `ParseError` with `ParseErrorKind` variants and `Display` impl.
- **`src/caroml/lock.rs`** — `schema_version = 2` lock format: per-platform variants (`[[steps.variants]]`), A/B candidate tracking, `TrackRecord` counters, append-only `[[history]]` lineage. TOML serde with atomic write (`.lock.tmp → rename`).
- **`caro check <file>`** — CLI verb to parse + lint a `.caro` file; exits 0 with a summary (`N steps, M pragmas, K params`) or 1 with a structured `line N: <error>` message.

### Constraints honored

- **No new top-level deps.** All parsing is hand-rolled (≈ 320 LOC). Lock uses existing `toml`, `serde`, `chrono`, `tempfile`.
- **Atomic writes** mirror `src/ai/store.rs`'s `.tmp → rename` convention.
- **Naming hygiene** per the plan: `.caro` file extension, `.caro.lock` for the lock, `Step` (AST) vs `LockStep` (lock alias) at the public API boundary.

### Test plan

- [x] 16 parser unit tests (edge cases, error paths, the full `cleanup-logs` example end-to-end)
- [x] 5 lock unit tests (TOML round-trip, defaults serialize, schema-version mismatch rejection, atomic write/read, retired-variant filter)
- [x] 3 AST tests (`Display` formatting with/without column, serde round-trip)
- [x] 2 fixture files (`tests/fixtures/caroml/cleanup-logs.caro`, `malformed-undefined-param.caro`)
- [x] CLI smoke tested: `caro check tests/fixtures/caroml/cleanup-logs.caro` → exit 0 with summary; `caro check tests/fixtures/caroml/malformed-undefined-param.caro` → exit 1 with `line 5: DO references \`{nope}\` but no \`LET nope = ...\` was declared`
- [x] Full lib test suite: 392 prior + 26 new = **418 tests pass** (1 pre-existing ignored)
- [x] `cargo clippy --lib --no-default-features --features embedded-cpu -- -D warnings` clean

### What's NOT in this PR (deliberate)

- LLM-driven generation (PR 4)
- Runbook export, drift detection (PR 5)
- Validator framework, safety/platform/secrets impls (PR 3)
- Discovery (`caro list`, `caro new`, `caro scaffold`) and Carofile parsing (PR 2)
- Interpreter, RegenEvaluator, per-platform variants (PR 4)
- Project memory, A/B (`caro experiment`/`adopt`) (PR 6)
- Carofile orchestration `caro do` / `caro jobs` (PR 7)
- Markdown render, voice module, Caro skill installer (PR 8)
- Curated `examples/library/` tasks + sample `Carofile` (PR 9)
- Docs at `docs/caroml/` (PR 9)

### Naming the file extensions

This PR locks in the naming choices documented in the plan:

| Artifact | Extension |
|---|---|
| Source intent | `.caro` |
| Lock | `.caro.lock` |
| Per-platform runbook (later PR) | `.<platform>.sh` (`<platform>` ∈ `macos` / `linux` / `windows` / `posix`) |
| Project orchestration (later PR) | `Carofile` (no extension) or `Carofile.caro` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the CaroML v0.1 foundation: a `.caro` parser/AST, a schema v2 `.caro.lock` format, and a `caro check` command for fast, deterministic linting. Adds UTF-8-safe `DO` substitution, literal brace escapes, clearer error locations, and removes a stray `tsc-cache` artifact.

- New Features
  - Hand-rolled `.caro` parser with `TASK/WHY/NEED/ON/LET/NOTE/DO/REM`, `{name}` substitution, and `ON` with `PREFER`/`AVOID`; supports `{{`/`}}` literal braces.
  - AST and structured errors (`Task`, `Step`, `Param`, `PlatformPragma`, `ParseError`).
  - `.caro.lock` schema v2: per-platform variants, A/B tracking, `history`; TOML via `toml`/`serde` with atomic `.tmp → rename`.
  - `caro check <file>`: parses and lints; prints a compact summary or `line N: <error>`.

- Bug Fixes
  - UTF-8-safe `DO` substitution; added `EmptyInterpolation` and guidance to escape with `{{`.
  - End-of-file errors now report the last meaningful line (empty files report line 1).
  - Removed accidentally committed `tsc-cache`.

<sup>Written for commit 858773a19b9e89c8796111bb212db6a4c62a9360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

