### PR TITLE
feat(caroml): PR 3 — validator framework + safety/platform/secrets/side_effects

### DIFF
--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -25,6 +25,7 @@ pub mod carofile;
 pub mod discovery;
 pub mod lock;
 pub mod parser;
+pub mod validators;
 
 pub use ast::{Param, ParseError, ParseErrorKind, PlatformPragma, Step, Task};
 pub use lock::{Lock, Step as LockStep, Variant};

--- a/src/caroml/validators/mod.rs
+++ b/src/caroml/validators/mod.rs
@@ -1,0 +1,246 @@
+//! Multi-angle validator framework.
+//!
+//! Per-step generation in the CaroML interpreter (PR 4) runs the generated
+//! command through a stack of [`Validator`]s, each focused on a different
+//! "angle" — safety, platform compatibility, secrets exposure, side-effect
+//! surfacing, and so on. Validators run in parallel for a single step
+//! (they're independent and side-effect-free); their outcomes drive both
+//! the lock's per-step `validations` field and the repair-hint feedback
+//! that's fed into the next LLM iteration if any validator fails.
+//!
+//! # v0.1 angles (this PR)
+//!
+//! - [`safety::SafetyAngle`] — wraps the existing 52+ pattern + CVE matcher
+//! - [`platform::PlatformAngle`] — BSD-vs-GNU flag heuristics from `CapabilityProfile`
+//! - [`secrets::SecretsAngle`] — regex scan for hard-coded credentials
+//! - [`side_effects::SideEffectsAngle`] — warn-only stub flagging sudo/network/destructive ops
+//!
+//! v0.2 will add `idempotency`, `reversibility`, `resource_impact`, and the
+//! external-validator hook (path to a binary that reads JSON on stdin / writes JSON on stdout).
+
+use async_trait::async_trait;
+
+pub mod platform;
+pub mod safety;
+pub mod secrets;
+pub mod side_effects;
+
+pub use platform::PlatformAngle;
+pub use safety::SafetyAngle;
+pub use secrets::SecretsAngle;
+pub use side_effects::SideEffectsAngle;
+
+// ---------------------------------------------------------------------------
+// Trait + types
+// ---------------------------------------------------------------------------
+
+/// Inputs needed by a validator. Borrowed for cheap parallel dispatch.
+pub struct ValidatorContext<'a> {
+    /// The shell command being validated.
+    pub command: &'a str,
+    /// The natural-language intent that produced this command (for repair hints).
+    pub intent: &'a str,
+    /// Title of the parent task (for context in error messages).
+    pub task_title: &'a str,
+    /// Target platform: `"macos"` / `"linux"` / `"windows"` / `"posix"`.
+    pub platform: &'a str,
+    /// True iff the task explicitly declared `NEED sudo` (lets `side_effects`
+    /// not flag sudo as a finding when it was opted into).
+    pub sudo_declared: bool,
+    /// Optional capability profile (drives the `platform` validator's heuristics).
+    pub capability_profile: Option<&'a crate::prompts::CapabilityProfile>,
+}
+
+/// One validator's verdict for a single command.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationOutcome {
+    pub angle: String,
+    pub result: Verdict,
+    /// Free-form note for human display (`caro why` / `caro check` output).
+    pub note: Option<String>,
+    /// Hint fed back into the next LLM iteration if `result` is `Fail` or `Warn`.
+    pub repair_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl ValidationOutcome {
+    pub fn pass(angle: &'static str) -> Self {
+        Self {
+            angle: angle.to_string(),
+            result: Verdict::Pass,
+            note: None,
+            repair_hint: None,
+        }
+    }
+
+    pub fn warn(angle: &'static str, note: impl Into<String>) -> Self {
+        Self {
+            angle: angle.to_string(),
+            result: Verdict::Warn,
+            note: Some(note.into()),
+            repair_hint: None,
+        }
+    }
+
+    pub fn fail(
+        angle: &'static str,
+        note: impl Into<String>,
+        repair: impl Into<String>,
+    ) -> Self {
+        Self {
+            angle: angle.to_string(),
+            result: Verdict::Fail,
+            note: Some(note.into()),
+            repair_hint: Some(repair.into()),
+        }
+    }
+}
+
+/// A validator focuses on one "angle" of correctness.
+#[async_trait]
+pub trait Validator: Send + Sync {
+    /// Stable string identifier (`"safety"` / `"platform"` / …).
+    fn angle(&self) -> &'static str;
+
+    /// Whether a `Fail` from this validator should block the loop entirely
+    /// (rather than just trigger a repair iteration). Default `false`.
+    /// `safety` is the only `must_pass = true` validator in v0.1.
+    fn must_pass(&self) -> bool {
+        false
+    }
+
+    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome;
+}
+
+/// Run every validator in `chain` against `ctx` concurrently and collect
+/// the outcomes in chain order.
+pub async fn run_all(
+    chain: &[Box<dyn Validator>],
+    ctx: &ValidatorContext<'_>,
+) -> Vec<ValidationOutcome> {
+    use futures::future::join_all;
+    let futures = chain.iter().map(|v| v.validate(ctx));
+    join_all(futures).await
+}
+
+/// True iff every outcome in `outcomes` is `Pass` (warnings count as not-passing for the loop).
+pub fn all_pass(outcomes: &[ValidationOutcome]) -> bool {
+    outcomes.iter().all(|o| o.result == Verdict::Pass)
+}
+
+/// Whether the loop should give up entirely — i.e. any `must_pass` validator
+/// returned `Fail`. Returns the first such outcome's angle for diagnostics.
+pub fn fatal_angle(
+    chain: &[Box<dyn Validator>],
+    outcomes: &[ValidationOutcome],
+) -> Option<String> {
+    chain
+        .iter()
+        .zip(outcomes.iter())
+        .find(|(v, o)| v.must_pass() && o.result == Verdict::Fail)
+        .map(|(_, o)| o.angle.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Default v0.1 validator chain
+// ---------------------------------------------------------------------------
+
+/// Build the default v0.1 chain: `safety` (must-pass) → `platform` → `secrets` → `side_effects`.
+pub fn default_chain() -> Vec<Box<dyn Validator>> {
+    vec![
+        Box::new(SafetyAngle::default()),
+        Box::new(PlatformAngle),
+        Box::new(SecretsAngle),
+        Box::new(SideEffectsAngle),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_for<'a>(command: &'a str) -> ValidatorContext<'a> {
+        ValidatorContext {
+            command,
+            intent: "test intent",
+            task_title: "test task",
+            platform: "macos",
+            sudo_declared: false,
+            capability_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn default_chain_runs_all_four_angles() {
+        let chain = default_chain();
+        assert_eq!(chain.len(), 4);
+        let angles: Vec<&str> = chain.iter().map(|v| v.angle()).collect();
+        assert_eq!(angles, vec!["safety", "platform", "secrets", "side_effects"]);
+    }
+
+    #[tokio::test]
+    async fn run_all_returns_outcomes_in_chain_order() {
+        let chain = default_chain();
+        let ctx = ctx_for("ls -la");
+        let outcomes = run_all(&chain, &ctx).await;
+        assert_eq!(outcomes.len(), 4);
+        assert_eq!(outcomes[0].angle, "safety");
+        assert_eq!(outcomes[1].angle, "platform");
+        assert_eq!(outcomes[2].angle, "secrets");
+        assert_eq!(outcomes[3].angle, "side_effects");
+    }
+
+    #[tokio::test]
+    async fn all_pass_is_true_when_outcomes_all_pass() {
+        let outcomes = vec![
+            ValidationOutcome::pass("safety"),
+            ValidationOutcome::pass("platform"),
+        ];
+        assert!(all_pass(&outcomes));
+    }
+
+    #[tokio::test]
+    async fn all_pass_is_false_when_any_warn() {
+        let outcomes = vec![
+            ValidationOutcome::pass("safety"),
+            ValidationOutcome::warn("platform", "BSD detected, GNU flag used"),
+        ];
+        assert!(!all_pass(&outcomes));
+    }
+
+    #[tokio::test]
+    async fn fatal_angle_identifies_must_pass_failure() {
+        let chain: Vec<Box<dyn Validator>> = vec![
+            Box::new(SafetyAngle::default()), // must_pass = true
+            Box::new(SideEffectsAngle),
+        ];
+        let outcomes = vec![
+            ValidationOutcome::fail("safety", "blocked", "use a less destructive approach"),
+            ValidationOutcome::pass("side_effects"),
+        ];
+        assert_eq!(fatal_angle(&chain, &outcomes), Some("safety".to_string()));
+    }
+
+    #[tokio::test]
+    async fn fatal_angle_ignores_non_must_pass_failure() {
+        let chain: Vec<Box<dyn Validator>> = vec![
+            Box::new(SafetyAngle::default()),
+            Box::new(SideEffectsAngle),
+        ];
+        let outcomes = vec![
+            ValidationOutcome::pass("safety"),
+            ValidationOutcome::fail("side_effects", "writes /etc", "scope to /tmp"),
+        ];
+        assert_eq!(fatal_angle(&chain, &outcomes), None);
+    }
+}

--- a/src/caroml/validators/mod.rs
+++ b/src/caroml/validators/mod.rs
@@ -88,11 +88,7 @@ impl ValidationOutcome {
         }
     }
 
-    pub fn fail(
-        angle: &'static str,
-        note: impl Into<String>,
-        repair: impl Into<String>,
-    ) -> Self {
+    pub fn fail(angle: &'static str, note: impl Into<String>, repair: impl Into<String>) -> Self {
         Self {
             angle: angle.to_string(),
             result: Verdict::Fail,
@@ -136,10 +132,7 @@ pub fn all_pass(outcomes: &[ValidationOutcome]) -> bool {
 
 /// Whether the loop should give up entirely — i.e. any `must_pass` validator
 /// returned `Fail`. Returns the first such outcome's angle for diagnostics.
-pub fn fatal_angle(
-    chain: &[Box<dyn Validator>],
-    outcomes: &[ValidationOutcome],
-) -> Option<String> {
+pub fn fatal_angle(chain: &[Box<dyn Validator>], outcomes: &[ValidationOutcome]) -> Option<String> {
     chain
         .iter()
         .zip(outcomes.iter())
@@ -185,7 +178,10 @@ mod tests {
         let chain = default_chain();
         assert_eq!(chain.len(), 4);
         let angles: Vec<&str> = chain.iter().map(|v| v.angle()).collect();
-        assert_eq!(angles, vec!["safety", "platform", "secrets", "side_effects"]);
+        assert_eq!(
+            angles,
+            vec!["safety", "platform", "secrets", "side_effects"]
+        );
     }
 
     #[tokio::test]
@@ -233,10 +229,8 @@ mod tests {
 
     #[tokio::test]
     async fn fatal_angle_ignores_non_must_pass_failure() {
-        let chain: Vec<Box<dyn Validator>> = vec![
-            Box::new(SafetyAngle::default()),
-            Box::new(SideEffectsAngle),
-        ];
+        let chain: Vec<Box<dyn Validator>> =
+            vec![Box::new(SafetyAngle::default()), Box::new(SideEffectsAngle)];
         let outcomes = vec![
             ValidationOutcome::pass("safety"),
             ValidationOutcome::fail("side_effects", "writes /etc", "scope to /tmp"),

--- a/src/caroml/validators/platform.rs
+++ b/src/caroml/validators/platform.rs
@@ -34,11 +34,8 @@ impl Validator for PlatformAngle {
         // Macro-only shortcut: quick checks with no profile required.
         for (pattern, message, hint, restricted_to) in BUILTIN_HEURISTICS {
             if cmd.contains(*pattern) && platforms_match(restricted_to, ctx.platform) {
-                return ValidationOutcome::warn(
-                    "platform",
-                    format!("{} (`{}`)", message, pattern),
-                )
-                .with_hint(*hint);
+                return ValidationOutcome::warn("platform", format!("{} (`{}`)", message, pattern))
+                    .with_hint(*hint);
             }
         }
 
@@ -94,7 +91,12 @@ impl OutcomeExt for ValidationOutcome {
 }
 
 /// Tuple: (pattern, human-readable message, repair hint, platforms to flag on).
-type Heuristic = (&'static str, &'static str, &'static str, &'static [&'static str]);
+type Heuristic = (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static [&'static str],
+);
 
 const BUILTIN_HEURISTICS: &[Heuristic] = &[
     (

--- a/src/caroml/validators/platform.rs
+++ b/src/caroml/validators/platform.rs
@@ -1,0 +1,200 @@
+//! Platform angle — heuristic checks for BSD vs GNU tool flags.
+//!
+//! v0.1 ships a small built-in heuristic table (no full POSIX coverage —
+//! that's PR's beyond v1.0 territory). The goal is to flag the most common
+//! cross-platform footguns: GNU-only flags on macOS, BSD-only flags on Linux,
+//! and shell-specific bashisms in `/bin/sh` contexts.
+//!
+//! When a [`CapabilityProfile`] is attached to the [`ValidatorContext`] this
+//! validator uses it for higher-confidence detection (e.g. probing the host's
+//! `find -printf` support). Without a profile, it falls back to the platform
+//! string and a static feature table.
+
+use async_trait::async_trait;
+
+use crate::caroml::validators::{ValidationOutcome, Validator, ValidatorContext, Verdict};
+
+pub struct PlatformAngle;
+
+impl Default for PlatformAngle {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Validator for PlatformAngle {
+    fn angle(&self) -> &'static str {
+        "platform"
+    }
+
+    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome {
+        let cmd = ctx.command;
+
+        // Macro-only shortcut: quick checks with no profile required.
+        for (pattern, message, hint, restricted_to) in BUILTIN_HEURISTICS {
+            if cmd.contains(*pattern) && platforms_match(restricted_to, ctx.platform) {
+                return ValidationOutcome::warn(
+                    "platform",
+                    format!("{} (`{}`)", message, pattern),
+                )
+                .with_hint(*hint);
+            }
+        }
+
+        // Capability-profile-driven checks (only when a profile is provided).
+        if let Some(profile) = ctx.capability_profile {
+            if cmd.contains("find ") && cmd.contains("-printf") && !profile.find_printf {
+                return ValidationOutcome::fail(
+                    "platform",
+                    format!(
+                        "`find -printf` is not available on this host ({})",
+                        ctx.platform
+                    ),
+                    "use `find ... -exec stat ...` or `find ... | xargs stat ...` instead of -printf",
+                );
+            }
+            if cmd.contains("sed -i ''") && profile.sed_inplace_gnu {
+                return ValidationOutcome::warn(
+                    "platform",
+                    "GNU sed expects `-i` without an empty argument; \
+                     `sed -i ''` is BSD/macOS syntax",
+                )
+                .with_hint("on Linux/GNU, use `sed -i` (no quoted empty string)");
+            }
+            if cmd.contains("sed -i\n") || cmd.contains("sed -i ") && !profile.sed_inplace_gnu {
+                // BSD sed needs an explicit suffix arg, even if empty.
+                if !cmd.contains("sed -i ''") && !cmd.contains("sed -i.") {
+                    return ValidationOutcome::warn(
+                        "platform",
+                        "BSD/macOS `sed -i` requires an explicit backup-suffix argument",
+                    )
+                    .with_hint("on macOS, use `sed -i ''` (empty suffix) or `sed -i.bak`");
+                }
+            }
+        }
+
+        ValidationOutcome::pass("platform")
+    }
+}
+
+/// Tiny extension to [`ValidationOutcome`] for builder-style hint attachment.
+trait OutcomeExt {
+    fn with_hint(self, hint: impl Into<String>) -> Self;
+}
+
+impl OutcomeExt for ValidationOutcome {
+    fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.repair_hint = Some(hint.into());
+        if self.result == Verdict::Pass {
+            self.result = Verdict::Warn;
+        }
+        self
+    }
+}
+
+/// Tuple: (pattern, human-readable message, repair hint, platforms to flag on).
+type Heuristic = (&'static str, &'static str, &'static str, &'static [&'static str]);
+
+const BUILTIN_HEURISTICS: &[Heuristic] = &[
+    (
+        "stat -c",
+        "`stat -c` is GNU-only and not available in BSD",
+        "use `stat -f` on macOS/BSD; or branch on `$OSTYPE`",
+        &["macos"],
+    ),
+    (
+        "stat -f",
+        "`stat -f` is BSD/macOS-only and not available in GNU coreutils",
+        "use `stat -c` on Linux; or branch on `$OSTYPE`",
+        &["linux"],
+    ),
+    (
+        "readlink -f",
+        "`readlink -f` is GNU-only on older macOS; install coreutils or use `realpath`",
+        "use `realpath` (or `python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' \"$path\"`)",
+        &["macos"],
+    ),
+    (
+        "useradd ",
+        "`useradd` is Linux-only; macOS uses `dscl`",
+        "branch on `$OSTYPE`; on macOS use `sudo dscl . -create /Users/<name>` etc.",
+        &["macos"],
+    ),
+    (
+        "apt ",
+        "`apt` is Debian/Ubuntu-only",
+        "use `brew` on macOS; `dnf`/`yum` on RHEL-family Linux",
+        &["macos", "windows"],
+    ),
+    (
+        "brew ",
+        "`brew` is macOS / Linux-with-Homebrew only",
+        "use the platform's native package manager (`apt`, `dnf`, `winget`, ...)",
+        &["windows"],
+    ),
+];
+
+fn platforms_match(restricted_to: &[&str], current: &str) -> bool {
+    restricted_to.contains(&current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(command: &'a str, platform: &'a str) -> ValidatorContext<'a> {
+        ValidatorContext {
+            command,
+            intent: "test",
+            task_title: "test",
+            platform,
+            sudo_declared: false,
+            capability_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn passes_clean_command() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("ls -la /tmp", "macos")).await;
+        assert_eq!(outcome.result, Verdict::Pass);
+    }
+
+    #[tokio::test]
+    async fn flags_stat_dash_c_on_macos() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("stat -c '%n' /tmp/foo", "macos")).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        assert!(outcome.note.unwrap().contains("GNU-only"));
+    }
+
+    #[tokio::test]
+    async fn flags_stat_dash_f_on_linux() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("stat -f '%N' /tmp/foo", "linux")).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+
+    #[tokio::test]
+    async fn allows_apt_on_linux() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("apt install jq", "linux")).await;
+        assert_eq!(outcome.result, Verdict::Pass);
+    }
+
+    #[tokio::test]
+    async fn flags_apt_on_macos() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("apt install jq", "macos")).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        assert!(outcome.repair_hint.is_some());
+    }
+
+    #[tokio::test]
+    async fn flags_brew_on_windows() {
+        let v = PlatformAngle;
+        let outcome = v.validate(&ctx("brew install jq", "windows")).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+}

--- a/src/caroml/validators/safety.rs
+++ b/src/caroml/validators/safety.rs
@@ -1,0 +1,147 @@
+//! Safety angle — wraps the existing 52+ pattern + CVE matcher
+//! ([`crate::safety::SafetyValidator`]).
+//!
+//! `must_pass = true`: a `Fail` from this validator stops the generation loop
+//! (no further repair iterations). The other v0.1 angles are advisory and
+//! merely trigger another iteration with their `repair_hint` fed back.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::caroml::validators::{ValidationOutcome, Validator, ValidatorContext, Verdict};
+use crate::models::{RiskLevel, ShellType};
+use crate::safety::{SafetyConfig, SafetyValidator};
+
+pub struct SafetyAngle {
+    inner: Arc<SafetyValidator>,
+    /// Map a CaroML `platform` field to a `ShellType` for the wrapped validator.
+    /// macOS / Linux / POSIX → Bash; Windows → PowerShell.
+    fallback_shell: ShellType,
+}
+
+impl Default for SafetyAngle {
+    fn default() -> Self {
+        let inner = SafetyValidator::new(SafetyConfig::moderate())
+            .expect("default SafetyConfig::moderate must produce a valid SafetyValidator");
+        Self {
+            inner: Arc::new(inner),
+            fallback_shell: ShellType::Bash,
+        }
+    }
+}
+
+impl SafetyAngle {
+    pub fn new(inner: Arc<SafetyValidator>) -> Self {
+        Self {
+            inner,
+            fallback_shell: ShellType::Bash,
+        }
+    }
+
+    fn shell_for(&self, platform: &str) -> ShellType {
+        match platform {
+            "windows" => ShellType::PowerShell,
+            _ => self.fallback_shell,
+        }
+    }
+}
+
+#[async_trait]
+impl Validator for SafetyAngle {
+    fn angle(&self) -> &'static str {
+        "safety"
+    }
+
+    fn must_pass(&self) -> bool {
+        true
+    }
+
+    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome {
+        let shell = self.shell_for(ctx.platform);
+        let result = match self.inner.validate_command(ctx.command, shell).await {
+            Ok(r) => r,
+            Err(e) => {
+                return ValidationOutcome::fail(
+                    "safety",
+                    format!("validator error: {}", e),
+                    "the safety validator could not run; this should not happen",
+                )
+            }
+        };
+
+        if !result.allowed {
+            return ValidationOutcome::fail(
+                "safety",
+                format!(
+                    "{} (risk: {:?}, matched: {})",
+                    result.explanation,
+                    result.risk_level,
+                    result.matched_patterns.join(", "),
+                ),
+                "rewrite the command without the dangerous pattern; \
+                 prefer a least-privilege approach (read-only, scoped paths, \
+                 explicit confirmations)",
+            );
+        }
+
+        match result.risk_level {
+            RiskLevel::Safe => ValidationOutcome::pass("safety"),
+            RiskLevel::Moderate => {
+                let warnings = if result.warnings.is_empty() {
+                    "moderate risk".to_string()
+                } else {
+                    result.warnings.join("; ")
+                };
+                ValidationOutcome {
+                    angle: "safety".to_string(),
+                    result: Verdict::Pass, // moderate is allowed, surface as note
+                    note: Some(warnings),
+                    repair_hint: None,
+                }
+            }
+            RiskLevel::High | RiskLevel::Critical => ValidationOutcome::fail(
+                "safety",
+                format!("risk={:?}: {}", result.risk_level, result.explanation),
+                "downgrade the action — narrower scope, dry-run mode, or a safer tool",
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(command: &'a str) -> ValidatorContext<'a> {
+        ValidatorContext {
+            command,
+            intent: "test",
+            task_title: "test",
+            platform: "macos",
+            sudo_declared: false,
+            capability_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn safe_command_passes() {
+        let v = SafetyAngle::default();
+        let outcome = v.validate(&ctx("ls -la")).await;
+        assert_eq!(outcome.angle, "safety");
+        assert_eq!(outcome.result, Verdict::Pass);
+    }
+
+    #[tokio::test]
+    async fn dangerous_command_fails_with_repair_hint() {
+        let v = SafetyAngle::default();
+        let outcome = v.validate(&ctx("rm -rf /")).await;
+        assert_eq!(outcome.result, Verdict::Fail);
+        assert!(outcome.repair_hint.is_some());
+        assert!(outcome.note.is_some());
+    }
+
+    #[tokio::test]
+    async fn safety_angle_must_pass() {
+        assert!(SafetyAngle::default().must_pass());
+    }
+}

--- a/src/caroml/validators/secrets.rs
+++ b/src/caroml/validators/secrets.rs
@@ -1,0 +1,147 @@
+//! Secrets angle — regex scan for hard-coded credentials in commands.
+//!
+//! Runs a tiny set of high-precision patterns. v0.1 is intentionally
+//! conservative: false-positives are worse than misses since this is a
+//! warn-only gate (it doesn't block generation, just flags for human review).
+//!
+//! The plan defers stdout secret scanning to v0.2 (it requires the runtime
+//! journal to be feeding back, which arrives in PR 6).
+
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::caroml::validators::{ValidationOutcome, Validator, ValidatorContext, Verdict};
+
+pub struct SecretsAngle;
+
+impl Default for SecretsAngle {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Validator for SecretsAngle {
+    fn angle(&self) -> &'static str {
+        "secrets"
+    }
+
+    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome {
+        for (kind, pattern) in PATTERNS.iter() {
+            if pattern.is_match(ctx.command) {
+                return ValidationOutcome {
+                    angle: "secrets".to_string(),
+                    result: Verdict::Warn,
+                    note: Some(format!("possible {} in command", kind)),
+                    repair_hint: Some(format!(
+                        "move the {} into an env var or a credential file; \
+                         reference it via $VAR rather than hard-coding",
+                        kind
+                    )),
+                };
+            }
+        }
+        ValidationOutcome::pass("secrets")
+    }
+}
+
+/// (Human-readable kind, regex). Keep tight — high precision over high recall.
+static PATTERNS: Lazy<Vec<(&'static str, Regex)>> = Lazy::new(|| {
+    vec![
+        (
+            "AWS access key",
+            Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+        ),
+        (
+            "GitHub personal access token",
+            Regex::new(r"\bghp_[A-Za-z0-9]{36}\b").unwrap(),
+        ),
+        (
+            "GitHub fine-grained token",
+            Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{82}\b").unwrap(),
+        ),
+        (
+            "Slack token",
+            Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b").unwrap(),
+        ),
+        (
+            "Stripe live key",
+            Regex::new(r"\bsk_live_[A-Za-z0-9]{24,}\b").unwrap(),
+        ),
+        (
+            "OpenAI API key",
+            Regex::new(r"\bsk-[A-Za-z0-9]{20,}T3BlbkFJ[A-Za-z0-9]{20,}\b").unwrap(),
+        ),
+        (
+            "private key block",
+            Regex::new(r"-----BEGIN ([A-Z ]+)PRIVATE KEY-----").unwrap(),
+        ),
+        (
+            "URL with embedded credentials",
+            Regex::new(r"https?://[^/\s:@]+:[^/\s:@]+@").unwrap(),
+        ),
+    ]
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(command: &'a str) -> ValidatorContext<'a> {
+        ValidatorContext {
+            command,
+            intent: "test",
+            task_title: "test",
+            platform: "linux",
+            sudo_declared: false,
+            capability_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn benign_command_passes() {
+        let v = SecretsAngle;
+        let outcome = v.validate(&ctx("curl https://example.com")).await;
+        assert_eq!(outcome.result, Verdict::Pass);
+    }
+
+    #[tokio::test]
+    async fn aws_access_key_warns() {
+        let v = SecretsAngle;
+        let outcome = v
+            .validate(&ctx("export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        assert!(outcome.note.unwrap().contains("AWS"));
+    }
+
+    #[tokio::test]
+    async fn github_classic_token_warns() {
+        let v = SecretsAngle;
+        let outcome = v
+            .validate(&ctx(
+                "git push https://x-access-token:ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789@github.com/foo/bar.git",
+            ))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+
+    #[tokio::test]
+    async fn url_with_basic_auth_warns() {
+        let v = SecretsAngle;
+        let outcome = v
+            .validate(&ctx("curl https://admin:secret@example.com/api"))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+
+    #[tokio::test]
+    async fn private_key_block_warns() {
+        let v = SecretsAngle;
+        let outcome = v
+            .validate(&ctx("echo '-----BEGIN OPENSSH PRIVATE KEY-----' > k"))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+}

--- a/src/caroml/validators/secrets.rs
+++ b/src/caroml/validators/secrets.rs
@@ -49,10 +49,7 @@ impl Validator for SecretsAngle {
 /// (Human-readable kind, regex). Keep tight — high precision over high recall.
 static PATTERNS: Lazy<Vec<(&'static str, Regex)>> = Lazy::new(|| {
     vec![
-        (
-            "AWS access key",
-            Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
-        ),
+        ("AWS access key", Regex::new(r"AKIA[0-9A-Z]{16}").unwrap()),
         (
             "GitHub personal access token",
             Regex::new(r"\bghp_[A-Za-z0-9]{36}\b").unwrap(),

--- a/src/caroml/validators/side_effects.rs
+++ b/src/caroml/validators/side_effects.rs
@@ -1,0 +1,216 @@
+//! Side-effects angle — surfaces network, filesystem, and privilege effects.
+//!
+//! v0.1 is **warn-only**: this validator never blocks generation. It emits
+//! informational notes that get surfaced via `caro why` and stored verbatim
+//! in the lock's per-step `validations` array. v0.2 may add `must_pass`
+//! gates for declared but unrequested side effects (e.g. a network call when
+//! the task didn't `NEED network`).
+
+use async_trait::async_trait;
+
+use crate::caroml::validators::{ValidationOutcome, Validator, ValidatorContext, Verdict};
+
+pub struct SideEffectsAngle;
+
+impl Default for SideEffectsAngle {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Validator for SideEffectsAngle {
+    fn angle(&self) -> &'static str {
+        "side_effects"
+    }
+
+    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome {
+        let cmd = ctx.command;
+        let mut notes: Vec<String> = Vec::new();
+
+        if has_sudo(cmd) {
+            if !ctx.sudo_declared {
+                notes.push(
+                    "uses sudo; consider `NEED sudo` in the .caro to make this explicit".into(),
+                );
+            } else {
+                notes.push("uses sudo (declared via NEED)".into());
+            }
+        }
+
+        if has_network(cmd) {
+            notes.push("makes network calls (curl/wget/ssh/scp/rsync over network)".into());
+        }
+
+        if has_destructive_fs(cmd) {
+            notes.push("filesystem destructive: rm/rmdir/mv/truncate".into());
+        }
+
+        if has_systemwide_write(cmd) {
+            notes.push(
+                "writes outside the user's home — paths under /etc, /var, /usr, /opt, /System"
+                    .into(),
+            );
+        }
+
+        if notes.is_empty() {
+            return ValidationOutcome::pass("side_effects");
+        }
+
+        ValidationOutcome {
+            angle: "side_effects".to_string(),
+            result: Verdict::Warn,
+            note: Some(notes.join("; ")),
+            repair_hint: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Heuristics
+// ---------------------------------------------------------------------------
+
+fn has_sudo(cmd: &str) -> bool {
+    contains_word(cmd, "sudo") || contains_word(cmd, "doas")
+}
+
+fn has_network(cmd: &str) -> bool {
+    [
+        "curl ",
+        "wget ",
+        "scp ",
+        "rsync ",
+        "ssh ",
+        "git push",
+        "git pull",
+        "git clone",
+        "git fetch",
+        "nc ",
+        "ncat ",
+        "telnet ",
+        "openssl s_client",
+    ]
+    .iter()
+    .any(|p| cmd.contains(p))
+}
+
+fn has_destructive_fs(cmd: &str) -> bool {
+    contains_word(cmd, "rm")
+        || contains_word(cmd, "rmdir")
+        || contains_word(cmd, "truncate")
+        || contains_word(cmd, "mv")
+        || contains_word(cmd, "shred")
+        || contains_word(cmd, "dd")
+}
+
+fn has_systemwide_write(cmd: &str) -> bool {
+    [
+        " /etc/", "> /etc/", " /var/", "> /var/", " /usr/", "> /usr/", " /opt/", "> /opt/",
+        " /System/", "> /System/",
+    ]
+    .iter()
+    .any(|p| cmd.contains(p))
+}
+
+/// Word-boundary contains: matches the bare token surrounded by whitespace, line
+/// start/end, or simple punctuation (`;`, `&`, `|`, `(`, `)`).
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let nbytes = needle.as_bytes();
+    let mut i = 0;
+    while i + nbytes.len() <= bytes.len() {
+        if &bytes[i..i + nbytes.len()] == nbytes {
+            let before_ok = i == 0 || is_boundary(bytes[i - 1]);
+            let after = i + nbytes.len();
+            let after_ok = after == bytes.len() || is_boundary(bytes[after]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_boundary(b: u8) -> bool {
+    matches!(
+        b,
+        b' ' | b'\t' | b'\n' | b';' | b'&' | b'|' | b'(' | b')' | b'`'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(command: &'a str, sudo_declared: bool) -> ValidatorContext<'a> {
+        ValidatorContext {
+            command,
+            intent: "test",
+            task_title: "test",
+            platform: "linux",
+            sudo_declared,
+            capability_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_only_command_passes() {
+        let v = SideEffectsAngle;
+        let outcome = v.validate(&ctx("ls -la /tmp", false)).await;
+        assert_eq!(outcome.result, Verdict::Pass);
+    }
+
+    #[tokio::test]
+    async fn sudo_without_declaration_warns_with_specific_note() {
+        let v = SideEffectsAngle;
+        let outcome = v.validate(&ctx("sudo apt update", false)).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        let note = outcome.note.unwrap();
+        assert!(note.contains("NEED sudo"));
+    }
+
+    #[tokio::test]
+    async fn declared_sudo_warns_but_acknowledges() {
+        let v = SideEffectsAngle;
+        let outcome = v.validate(&ctx("sudo apt update", true)).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        let note = outcome.note.unwrap();
+        assert!(note.contains("declared via NEED"));
+    }
+
+    #[tokio::test]
+    async fn network_command_warns() {
+        let v = SideEffectsAngle;
+        let outcome = v
+            .validate(&ctx("curl https://example.com -o file.txt", false))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+        assert!(outcome.note.unwrap().contains("network"));
+    }
+
+    #[tokio::test]
+    async fn rm_warns_as_destructive() {
+        let v = SideEffectsAngle;
+        let outcome = v.validate(&ctx("rm /tmp/foo", false)).await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+
+    #[tokio::test]
+    async fn write_to_etc_warns() {
+        let v = SideEffectsAngle;
+        let outcome = v
+            .validate(&ctx("echo 'hello' > /etc/motd", false))
+            .await;
+        assert_eq!(outcome.result, Verdict::Warn);
+    }
+
+    #[tokio::test]
+    async fn word_boundary_does_not_match_substring() {
+        // "drum" should not match the word "rm"
+        assert!(!contains_word("a drum kit", "rm"));
+        // "rm" as a word should match
+        assert!(contains_word("rm /tmp/foo", "rm"));
+        assert!(contains_word("foo && rm bar", "rm"));
+    }
+}

--- a/src/caroml/validators/side_effects.rs
+++ b/src/caroml/validators/side_effects.rs
@@ -105,8 +105,16 @@ fn has_destructive_fs(cmd: &str) -> bool {
 
 fn has_systemwide_write(cmd: &str) -> bool {
     [
-        " /etc/", "> /etc/", " /var/", "> /var/", " /usr/", "> /usr/", " /opt/", "> /opt/",
-        " /System/", "> /System/",
+        " /etc/",
+        "> /etc/",
+        " /var/",
+        "> /var/",
+        " /usr/",
+        "> /usr/",
+        " /opt/",
+        "> /opt/",
+        " /System/",
+        "> /System/",
     ]
     .iter()
     .any(|p| cmd.contains(p))
@@ -199,9 +207,7 @@ mod tests {
     #[tokio::test]
     async fn write_to_etc_warns() {
         let v = SideEffectsAngle;
-        let outcome = v
-            .validate(&ctx("echo 'hello' > /etc/motd", false))
-            .await;
+        let outcome = v.validate(&ctx("echo 'hello' > /etc/motd", false)).await;
         assert_eq!(outcome.result, Verdict::Warn);
     }
 


### PR DESCRIPTION
## Summary

PR 3 of the CaroML v0.1 series. **Stacked on top of [#904](https://github.com/wildcard/caro/pull/904)** (which is stacked on [#893](https://github.com/wildcard/caro/pull/893)). Closes [#896](https://github.com/wildcard/caro/issues/896).

Pure infrastructure — adds the multi-angle validator framework that the PR-4 interpreter will drive per generation iteration. Trait + four built-in validators + a default chain. **No CLI changes; no LLM integration; no new top-level dependencies.**

> **Stacking note:** review `gh pr diff <this-PR>` only; `git diff` against `main` includes PR 1 + 2 + 3 commits. Once #893 and #904 land, this auto-rebases to PR-3-only.

## What's added

### `Validator` trait + framework (`src/caroml/validators/mod.rs`)

```rust
#[async_trait]
pub trait Validator: Send + Sync {
    fn angle(&self) -> &'static str;       // "safety" | "platform" | ...
    fn must_pass(&self) -> bool { false }  // safety overrides to true
    async fn validate(&self, ctx: &ValidatorContext<'_>) -> ValidationOutcome;
}
```

- `ValidatorContext<'a>` borrows `command`, `intent`, `task_title`, `platform`, `sudo_declared`, optional `capability_profile`
- `ValidationOutcome { angle, result, note, repair_hint }` — `repair_hint` feeds back into the next LLM iteration on Fail
- `Verdict::{Pass, Warn, Fail}`
- `run_all` runs the chain in parallel via `futures::future::join_all`
- `default_chain()` returns the v0.1 chain: `safety → platform → secrets → side_effects`
- `fatal_angle()` helper for the must-pass guard

### Four built-in validators

| Angle | Source | Behaviour |
|---|---|---|
| `safety` | wraps `SafetyValidator::new(SafetyConfig::moderate())` | `must_pass = true`. Maps risk levels to verdicts; emits repair hint on Fail. |
| `platform` | heuristic table + optional `CapabilityProfile` | Flags BSD-vs-GNU footguns (`stat -c` on macOS, `apt` on macOS, `brew` on Windows, etc.); higher-confidence with profile (`find -printf`, `sed -i ''`). |
| `secrets` | high-precision regex scan | AWS access keys, GitHub classic + fine-grained PATs, Slack tokens, Stripe live keys, OpenAI keys, PEM private-key blocks, basic-auth URLs. Warn-only. |
| `side_effects` | structural heuristics | sudo / network / destructive-fs / system-wide-write surfacing, with `ctx.sudo_declared` softening. Warn-only. Word-boundary scanner so `drum` doesn't false-match `rm`. |

## Test plan

- [x] 27 new validator tests (5 framework + 3 safety + 6 platform + 5 secrets + 7 side_effects + 1 word-boundary helper)
- [x] Full lib suite: **446 tests pass** (419 prior + 27 new)
- [x] `cargo clippy --lib --bin caro --no-default-features --features embedded-cpu -- -D warnings` clean

## Out of scope

| Concern | Tracked in |
|---|---|
| `idempotency` / `reversibility` / `resource_impact` validators | v0.2 |
| External-validator hook (binary-as-validator)                    | v1.0 |
| Integration into the per-step generation loop                    | [#897](https://github.com/wildcard/caro/issues/897) (PR 4) |
| Stdout secret scanning (warn on credentials in command output)   | v0.2 (after PR 6 lands the runtime journal) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi‑angle validator framework for CaroML with four built‑in checks to guide command generation and surface risks. No CLI changes and no new top‑level dependencies.

- **New Features**
  - Async `Validator` trait with `angle`, `must_pass`, `validate(ctx)`; `ValidatorContext`; `ValidationOutcome` with `Verdict` and `repair_hint`.
  - Parallel `run_all`; `default_chain()` order `safety → platform → secrets → side_effects`; helpers `all_pass()` and `fatal_angle()`.
  - Safety: wraps `SafetyValidator::new(SafetyConfig::moderate())`; `must_pass = true`; `High`/`Critical` → Fail with repair hint; `Moderate` → Pass with note.
  - Platform: BSD vs GNU heuristics (`stat -c`/`-f`, `readlink -f`, `useradd`, `apt`, `brew`); `CapabilityProfile` checks for `find -printf` and `sed -i` shape; warn‑only.
  - Secrets: tight regex scan (AWS keys, GitHub PATs, Slack, Stripe live, OpenAI, PEM blocks, basic‑auth URLs); warn‑only.
  - Side‑effects: flags sudo, network, destructive‑fs, and system‑wide writes; respects `sudo_declared`; warn‑only.

<sup>Written for commit 502325733d06b05f97ef834318eb214d689ff5ec. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/905?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

