### PR TITLE
feat(caroml): PR 6 — project memory, A/B (experiment/adopt), `caro history`/`why`

### DIFF
--- a/src/caroml/adopt.rs
+++ b/src/caroml/adopt.rs
@@ -153,8 +153,14 @@ mod tests {
         let mut lock = lock_with_active_and_challenger();
         adopt(&mut lock, "gen_b").unwrap();
         let variants = &lock.steps[0].variants;
-        let a = variants.iter().find(|v| v.generation_id == "gen_a").unwrap();
-        let b = variants.iter().find(|v| v.generation_id == "gen_b").unwrap();
+        let a = variants
+            .iter()
+            .find(|v| v.generation_id == "gen_a")
+            .unwrap();
+        let b = variants
+            .iter()
+            .find(|v| v.generation_id == "gen_b")
+            .unwrap();
         assert!(!a.active);
         assert!(a.retired_at.is_some());
         assert!(b.active);

--- a/src/caroml/adopt.rs
+++ b/src/caroml/adopt.rs
@@ -1,0 +1,227 @@
+//! Adopt / experiment / retire — the variant-lifecycle operations called
+//! by `caro adopt`, `caro experiment`, and (later) `caro adopt --auto-best`.
+//!
+//! - `adopt(lock, variant_id)`: flip a challenger to active, retire the
+//!   previously-active variant (sets `retired_at = now`).
+//! - `find_variant_by_id(lock, variant_id)`: resolve a generation_id to its
+//!   `(step_index, platform, &Variant)` triple.
+//! - `aggregated_score`: lightweight score function used by `--auto-best`
+//!   in the future; ships now so PR 6 docs can reference its semantics.
+
+use crate::caroml::lock::{Lock, TrackRecord, Variant};
+use chrono::Utc;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AdoptError {
+    #[error("variant `{0}` not found in lock")]
+    NotFound(String),
+    #[error("variant `{0}` is already active for platform `{1}`")]
+    AlreadyActive(String, String),
+    #[error("variant `{0}` has been retired and cannot be re-adopted")]
+    Retired(String),
+}
+
+/// Promote `variant_id` to active for its platform, retiring whichever
+/// variant was previously active for that platform.
+pub fn adopt(lock: &mut Lock, variant_id: &str) -> Result<(), AdoptError> {
+    // First, locate the target.
+    let (step_idx, platform) = locate(lock, variant_id)?;
+
+    // Validate state.
+    {
+        let step = &lock.steps[step_idx];
+        let target = step
+            .variants
+            .iter()
+            .find(|v| v.generation_id == variant_id)
+            .expect("locate guarantees the variant exists");
+        if target.retired_at.is_some() {
+            return Err(AdoptError::Retired(variant_id.to_string()));
+        }
+        if target.active {
+            return Err(AdoptError::AlreadyActive(
+                variant_id.to_string(),
+                platform.clone(),
+            ));
+        }
+    }
+
+    let now = Utc::now();
+    let step = &mut lock.steps[step_idx];
+    for v in &mut step.variants {
+        if v.platform != platform {
+            continue;
+        }
+        if v.active {
+            v.active = false;
+            v.retired_at = Some(now);
+        }
+        if v.generation_id == variant_id {
+            v.active = true;
+            v.retired_at = None;
+        }
+    }
+    Ok(())
+}
+
+/// Locate a variant by id; returns `(step_idx, platform_string)`.
+pub fn locate(lock: &Lock, variant_id: &str) -> Result<(usize, String), AdoptError> {
+    for (idx, step) in lock.steps.iter().enumerate() {
+        for v in &step.variants {
+            if v.generation_id == variant_id {
+                return Ok((idx, v.platform.clone()));
+            }
+        }
+    }
+    Err(AdoptError::NotFound(variant_id.to_string()))
+}
+
+/// Crude score function for adopt suggestions.
+///
+/// Returns a number in `[0.0, 1.0]`:
+/// - `1.0` if `runs == 0` (treated as "no signal yet, defer to confidence")
+///   weighted by `confidence`.
+/// - else `succeeded / runs`.
+pub fn aggregated_score(variant: &Variant, tr: &TrackRecord) -> f32 {
+    if tr.runs == 0 {
+        variant.confidence.clamp(0.0, 1.0)
+    } else {
+        (tr.succeeded as f32) / (tr.runs as f32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caroml::lock::{Lock, Meta, Step as LockStep, Variant};
+    use chrono::Utc;
+    use std::collections::BTreeMap;
+
+    fn variant(platform: &str, active: bool, gen_id: &str, command: &str) -> Variant {
+        Variant {
+            platform: platform.into(),
+            active,
+            generation_id: gen_id.into(),
+            command: command.into(),
+            reasoning: "".into(),
+            exports: vec![],
+            imports: vec![],
+            risk_level: "safe".into(),
+            matched_patterns: vec![],
+            warnings: vec![],
+            confidence: 0.9,
+            iterations: 1,
+            validations: vec![],
+            generated_at: Utc::now(),
+            model: "m".into(),
+            backend: "b".into(),
+            tool_versions: BTreeMap::new(),
+            track_record: Default::default(),
+            retired_at: None,
+        }
+    }
+
+    fn lock_with_active_and_challenger() -> Lock {
+        let mut lock = Lock::default();
+        lock.meta = Meta {
+            caro_version: "1.4.0".into(),
+            intent_path: "tasks/x.caro".into(),
+            intent_hash: "sha256:x".into(),
+            supported_platforms: vec!["macos".into()],
+            last_full_regen: Some(Utc::now()),
+        };
+        lock.steps = vec![LockStep {
+            line: 1,
+            intent: "demo".into(),
+            intent_hash: "sha256:s".into(),
+            notes: vec![],
+            variants: vec![
+                variant("macos", true, "gen_a", "ls -la"),
+                variant("macos", false, "gen_b", "ls -lA"),
+            ],
+        }];
+        lock
+    }
+
+    #[test]
+    fn adopt_promotes_challenger_and_retires_active() {
+        let mut lock = lock_with_active_and_challenger();
+        adopt(&mut lock, "gen_b").unwrap();
+        let variants = &lock.steps[0].variants;
+        let a = variants.iter().find(|v| v.generation_id == "gen_a").unwrap();
+        let b = variants.iter().find(|v| v.generation_id == "gen_b").unwrap();
+        assert!(!a.active);
+        assert!(a.retired_at.is_some());
+        assert!(b.active);
+        assert!(b.retired_at.is_none());
+    }
+
+    #[test]
+    fn adopt_already_active_is_error() {
+        let mut lock = lock_with_active_and_challenger();
+        match adopt(&mut lock, "gen_a") {
+            Err(AdoptError::AlreadyActive(_, _)) => {}
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn adopt_unknown_variant_is_error() {
+        let mut lock = lock_with_active_and_challenger();
+        match adopt(&mut lock, "gen_zzz") {
+            Err(AdoptError::NotFound(id)) if id == "gen_zzz" => {}
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn adopt_retired_variant_is_error() {
+        let mut lock = lock_with_active_and_challenger();
+        // retire `gen_b`
+        if let Some(v) = lock.steps[0]
+            .variants
+            .iter_mut()
+            .find(|v| v.generation_id == "gen_b")
+        {
+            v.retired_at = Some(Utc::now());
+        }
+        match adopt(&mut lock, "gen_b") {
+            Err(AdoptError::Retired(_)) => {}
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn aggregated_score_uses_confidence_when_no_runs() {
+        let v = variant("macos", false, "gen_x", "ls");
+        let tr = TrackRecord::default();
+        let score = aggregated_score(&v, &tr);
+        assert!((score - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn aggregated_score_uses_success_rate_with_runs() {
+        let v = variant("macos", false, "gen_x", "ls");
+        let tr = TrackRecord {
+            runs: 4,
+            succeeded: 3,
+            failed: 1,
+            last_used: None,
+        };
+        let score = aggregated_score(&v, &tr);
+        assert!((score - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
+    fn locate_returns_step_index_and_platform() {
+        let lock = lock_with_active_and_challenger();
+        let (idx, plat) = locate(&lock, "gen_b").unwrap();
+        assert_eq!(idx, 0);
+        assert_eq!(plat, "macos");
+    }
+}

--- a/src/caroml/history.rs
+++ b/src/caroml/history.rs
@@ -1,0 +1,223 @@
+//! Per-user run journal at `~/.caro/state/<intent_hash_hex>/journal.jsonl`.
+//!
+//! Every `caro run` invocation appends a JSON line capturing what happened.
+//! The journal is per-user / per-machine — it is **not** committed to the
+//! project. Aggregate adopt decisions cross users via the lock's per-variant
+//! `track_record`; the journal is the local input that drives those updates.
+//!
+//! The journal is append-only. Compaction / pruning is out of scope for v0.1.
+//!
+//! ## Why hash-based directory names
+//!
+//! Two tasks can have the same on-disk name (a project task and a global
+//! library task with the same `name`), but their normalized intent hashes
+//! differ. Keying the journal directory by intent_hash means the local
+//! history follows the *intent*, not the file path.
+
+use crate::caroml::lock::TrackRecord;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// One run captured into the journal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalEntry {
+    pub timestamp: DateTime<Utc>,
+    pub intent_hash: String,
+    pub variant_id: String,
+    pub platform: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    /// SHA-256 hex digest of the first 4 KB of stderr (privacy default;
+    /// see plan §"Privacy of the local journal").
+    pub stderr_digest: String,
+    /// Optional human-readable note; e.g. the failing step's intent.
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum HistoryError {
+    #[error("home directory not available")]
+    NoHomeDir,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Compute the journal directory for `intent_hash`. Strips the `sha256:` prefix.
+pub fn journal_dir(intent_hash: &str) -> Result<PathBuf, HistoryError> {
+    let home = dirs::home_dir().ok_or(HistoryError::NoHomeDir)?;
+    let key = intent_hash.strip_prefix("sha256:").unwrap_or(intent_hash);
+    Ok(home.join(".caro").join("state").join(key))
+}
+
+/// The journal file path for `intent_hash`.
+pub fn journal_path(intent_hash: &str) -> Result<PathBuf, HistoryError> {
+    Ok(journal_dir(intent_hash)?.join("journal.jsonl"))
+}
+
+/// Append one entry to the journal (creates the directory + file if needed).
+pub fn append(entry: &JournalEntry) -> Result<(), HistoryError> {
+    let path = journal_path(&entry.intent_hash)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    append_to(&path, entry)
+}
+
+/// Append into a specific path (used by tests with tempdirs).
+pub fn append_to(path: &Path, entry: &JournalEntry) -> Result<(), HistoryError> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+    let line = serde_json::to_string(entry)?;
+    f.write_all(line.as_bytes())?;
+    f.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Read all entries for `intent_hash`. Returns empty Vec when the journal is missing.
+pub fn read_all(intent_hash: &str) -> Result<Vec<JournalEntry>, HistoryError> {
+    let path = journal_path(intent_hash)?;
+    read_from(&path)
+}
+
+pub fn read_from(path: &Path) -> Result<Vec<JournalEntry>, HistoryError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let body = std::fs::read_to_string(path)?;
+    let mut out = Vec::new();
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry: JournalEntry = serde_json::from_str(line)?;
+        out.push(entry);
+    }
+    Ok(out)
+}
+
+/// Compute an aggregated [`TrackRecord`] for `(intent_hash, variant_id)` by
+/// summing the journal entries.
+pub fn aggregate(intent_hash: &str, variant_id: &str) -> Result<TrackRecord, HistoryError> {
+    let entries = read_all(intent_hash)?;
+    Ok(aggregate_entries(&entries, variant_id))
+}
+
+pub fn aggregate_entries(entries: &[JournalEntry], variant_id: &str) -> TrackRecord {
+    let mut tr = TrackRecord::default();
+    for e in entries {
+        if e.variant_id != variant_id {
+            continue;
+        }
+        tr.runs += 1;
+        if e.exit_code == 0 {
+            tr.succeeded += 1;
+        } else {
+            tr.failed += 1;
+        }
+        match tr.last_used {
+            Some(t) if t >= e.timestamp => {}
+            _ => tr.last_used = Some(e.timestamp),
+        }
+    }
+    tr
+}
+
+/// Helper: digest the first 4 KB of `stderr` text. Used by the runner to
+/// avoid storing arbitrary tool output verbatim.
+pub fn stderr_digest(stderr: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let bytes = stderr.as_bytes();
+    let cap = bytes.len().min(4096);
+    let mut h = Sha256::new();
+    h.update(&bytes[..cap]);
+    let hex = h
+        .finalize()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>();
+    format!("sha256:{}", hex)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn entry(variant: &str, exit: i32, ts_offset: i64) -> JournalEntry {
+        JournalEntry {
+            timestamp: Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()
+                + chrono::Duration::seconds(ts_offset),
+            intent_hash: "sha256:abc".into(),
+            variant_id: variant.into(),
+            platform: "macos".into(),
+            exit_code: exit,
+            duration_ms: 100,
+            stderr_digest: "sha256:0".into(),
+            note: None,
+        }
+    }
+
+    #[test]
+    fn append_and_read_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("journal.jsonl");
+        append_to(&path, &entry("gen_a", 0, 0)).unwrap();
+        append_to(&path, &entry("gen_a", 1, 60)).unwrap();
+        let entries = read_from(&path).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].variant_id, "gen_a");
+        assert_eq!(entries[0].exit_code, 0);
+        assert_eq!(entries[1].exit_code, 1);
+    }
+
+    #[test]
+    fn read_from_missing_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries = read_from(&dir.path().join("nope.jsonl")).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn aggregate_counts_runs_succeeded_failed() {
+        let entries = vec![
+            entry("gen_a", 0, 0),
+            entry("gen_a", 0, 10),
+            entry("gen_a", 1, 20),
+            entry("gen_b", 0, 30), // different variant — ignored
+        ];
+        let tr = aggregate_entries(&entries, "gen_a");
+        assert_eq!(tr.runs, 3);
+        assert_eq!(tr.succeeded, 2);
+        assert_eq!(tr.failed, 1);
+        assert!(tr.last_used.is_some());
+    }
+
+    #[test]
+    fn stderr_digest_truncates_to_4kb() {
+        let big = "x".repeat(8192);
+        let small = "x".repeat(4096);
+        // Both produce the same digest because we only hash the first 4 KB.
+        assert_eq!(stderr_digest(&big), stderr_digest(&small));
+    }
+
+    #[test]
+    fn journal_dir_strips_sha256_prefix() {
+        let dir = journal_dir("sha256:abc123").unwrap();
+        assert!(dir.to_string_lossy().ends_with("/.caro/state/abc123"));
+    }
+
+    #[test]
+    fn journal_dir_handles_missing_prefix() {
+        let dir = journal_dir("def456").unwrap();
+        assert!(dir.to_string_lossy().ends_with("/.caro/state/def456"));
+    }
+}

--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -20,9 +20,11 @@
 //! runner, regen evaluator, history, variants, voice, scaffold, skill,
 //! carofile, cve_feed, platform.
 
+pub mod adopt;
 pub mod ast;
 pub mod carofile;
 pub mod discovery;
+pub mod history;
 pub mod interpreter;
 pub mod lock;
 pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1446,7 +1446,11 @@ fn run_caroml_run(
             intent,
             exit_code,
             stderr,
-        }) => (*exit_code, Some(format!("step on line {}: {}", line, intent)), stderr.clone()),
+        }) => (
+            *exit_code,
+            Some(format!("step on line {}: {}", line, intent)),
+            stderr.clone(),
+        ),
         Err(other) => (255, Some(format!("{}", other)), String::new()),
     };
     let variant_id = plan
@@ -1469,7 +1473,11 @@ fn run_caroml_run(
     }
 
     let results = result.map_err(|e| e.to_string())?;
-    println!("All {} steps completed in {} ms.", results.len(), elapsed_ms);
+    println!(
+        "All {} steps completed in {} ms.",
+        results.len(),
+        elapsed_ms
+    );
     Ok(())
 }
 
@@ -1518,11 +1526,8 @@ async fn run_caroml_experiment(
     // Bump the generation_id suffix so we don't clash with existing IDs.
     let existing_count = variant_helpers::all_challengers_for(&lock, &target_platform).count()
         + variant_helpers::active_count_for(&lock, &target_platform);
-    let new_gen_id = variant_helpers::generation_id(
-        chrono::Utc::now(),
-        &target_platform,
-        existing_count,
-    );
+    let new_gen_id =
+        variant_helpers::generation_id(chrono::Utc::now(), &target_platform, existing_count);
 
     let mut adopted_id = String::new();
     for (i, fresh_step) in fresh.steps.into_iter().enumerate() {
@@ -1597,10 +1602,7 @@ fn run_caroml_history(name: &str) -> Result<(), String> {
     }
 
     let entries = history::read_all(&lock.meta.intent_hash).unwrap_or_default();
-    println!(
-        "\nLocal run journal ({} entries):",
-        entries.len()
-    );
+    println!("\nLocal run journal ({} entries):", entries.len());
     let recent: Vec<_> = entries.iter().rev().take(10).collect();
     for e in recent {
         println!(
@@ -1647,11 +1649,14 @@ fn run_caroml_why(name: &str) -> Result<(), String> {
     println!("Task:     {}", name);
     println!("Path:     {}", task_path.display());
     println!("Platform: {}", platform);
-    println!("Decision: {:?}", match &decision {
-        regen_evaluator::Decision::UseCache => "UseCache",
-        regen_evaluator::Decision::HardRegen { .. } => "HardRegen",
-        regen_evaluator::Decision::SoftExplore { .. } => "SoftExplore",
-    });
+    println!(
+        "Decision: {:?}",
+        match &decision {
+            regen_evaluator::Decision::UseCache => "UseCache",
+            regen_evaluator::Decision::HardRegen { .. } => "HardRegen",
+            regen_evaluator::Decision::SoftExplore { .. } => "SoftExplore",
+        }
+    );
     let reasons = decision.reasons();
     if reasons.is_empty() {
         println!("(no reasons; cache is fresh)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,6 +583,50 @@ enum Commands {
         #[arg(short = 'o', long)]
         output: Option<std::path::PathBuf>,
     },
+
+    /// Generate an A/B challenger variant alongside the existing active.
+    ///
+    /// The challenger is added with `active = false`. Use `caro adopt` to
+    /// promote it once you've reviewed it.
+    Experiment {
+        /// Task name.
+        name: String,
+
+        /// Platform to experiment on (default: current).
+        #[arg(long)]
+        platform: Option<String>,
+
+        /// Backend to use for the new variant (default: `mock` in v0.1).
+        #[arg(long)]
+        backend: Option<String>,
+    },
+
+    /// Promote a challenger variant to active for its platform.
+    ///
+    /// The previously-active variant for that platform is retired
+    /// (set to `active = false`, `retired_at = now`) but kept in the lock
+    /// for reference.
+    Adopt {
+        /// Task name.
+        name: String,
+
+        /// Variant generation_id to promote (e.g. `gen_2026-04-26_macos_b`).
+        #[arg(long)]
+        variant: String,
+    },
+
+    /// Show the generation lineage from the lock plus a per-variant
+    /// run-summary derived from the local journal.
+    History {
+        /// Task name.
+        name: String,
+    },
+
+    /// Explain the RegenEvaluator's decision for the next `caro run`.
+    Why {
+        /// Task name.
+        name: String,
+    },
     // /// Manage telemetry data and settings
     // Telemetry {
     //     #[command(subcommand)]
@@ -1388,8 +1432,235 @@ fn run_caroml_run(
         }
     }
 
-    let results = runner::execute_plan(&plan).map_err(|e| e.to_string())?;
-    println!("All {} steps completed.", results.len());
+    use caro::caroml::history;
+    use std::time::Instant;
+    let started = Instant::now();
+    let result = runner::execute_plan(&plan);
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    // Journal the outcome (best-effort; don't fail the run if journal write fails).
+    let (exit_code, note, stderr) = match &result {
+        Ok(_) => (0i32, None, String::new()),
+        Err(runner::RunError::StepFailed {
+            line,
+            intent,
+            exit_code,
+            stderr,
+        }) => (*exit_code, Some(format!("step on line {}: {}", line, intent)), stderr.clone()),
+        Err(other) => (255, Some(format!("{}", other)), String::new()),
+    };
+    let variant_id = plan
+        .steps
+        .first()
+        .map(|s| s.generation_id.clone())
+        .unwrap_or_default();
+    let entry = history::JournalEntry {
+        timestamp: chrono::Utc::now(),
+        intent_hash: lock.meta.intent_hash.clone(),
+        variant_id,
+        platform: target_platform,
+        exit_code,
+        duration_ms: elapsed_ms,
+        stderr_digest: history::stderr_digest(&stderr),
+        note,
+    };
+    if let Err(e) = history::append(&entry) {
+        eprintln!("warning: could not write run journal: {}", e);
+    }
+
+    let results = result.map_err(|e| e.to_string())?;
+    println!("All {} steps completed in {} ms.", results.len(), elapsed_ms);
+    Ok(())
+}
+
+/// `caro experiment <name>` — generate a fresh challenger variant.
+async fn run_caroml_experiment(
+    name: &str,
+    platform_override: Option<&str>,
+    backend_override: Option<&str>,
+) -> Result<(std::path::PathBuf, String), String> {
+    use caro::caroml::{
+        check_file, discovery, interpreter, lock::Lock, platform as caro_platform, validators,
+        variants as variant_helpers,
+    };
+
+    let task_path = discovery::resolve_task_path(name)
+        .ok_or_else(|| format!("could not find task `{}`", name))?;
+    let task = check_file(&task_path).map_err(|e| format!("{}: {}", task_path.display(), e))?;
+
+    let lock_path = task_path.with_extension("caro.lock");
+    if !lock_path.exists() {
+        return Err(format!(
+            "{}: no lock found; run `caro generate {}` first",
+            lock_path.display(),
+            name
+        ));
+    }
+    let mut lock =
+        Lock::read_path(&lock_path).map_err(|e| format!("{}: {}", lock_path.display(), e))?;
+
+    let target_platform = match platform_override {
+        Some(p) if caro_platform::is_known(p) => p.to_string(),
+        Some(p) => return Err(format!("unknown platform `{}`", p)),
+        None => caro_platform::current().to_string(),
+    };
+
+    let backend = build_caroml_backend(backend_override).map_err(|e| format!("backend: {}", e))?;
+    let chain = validators::default_chain();
+    let cfg = interpreter::GenerateConfig::for_intent(task_path.to_string_lossy().into_owned());
+
+    let fresh =
+        interpreter::generate_lock_for_platform(&task, &target_platform, &*backend, &chain, &cfg)
+            .await
+            .map_err(|e| format!("generation failed: {}", e))?;
+
+    // Append the new variants to the existing lock as challengers.
+    // Bump the generation_id suffix so we don't clash with existing IDs.
+    let existing_count = variant_helpers::all_challengers_for(&lock, &target_platform).count()
+        + variant_helpers::active_count_for(&lock, &target_platform);
+    let new_gen_id = variant_helpers::generation_id(
+        chrono::Utc::now(),
+        &target_platform,
+        existing_count,
+    );
+
+    let mut adopted_id = String::new();
+    for (i, fresh_step) in fresh.steps.into_iter().enumerate() {
+        if let Some(existing_step) = lock.steps.get_mut(i) {
+            for mut variant in fresh_step.variants {
+                variant.active = false;
+                variant.generation_id = format!("{}_step{}", new_gen_id, i);
+                adopted_id = variant.generation_id.clone();
+                existing_step.variants.push(variant);
+            }
+        }
+    }
+    // Rewrite the imported history entries' generation_id to match this
+    // experiment's id, and tag them as challenger entries so `caro history`
+    // can distinguish initial-gen rows from challenger-add rows.
+    for mut h in fresh.history {
+        h.generation_id = new_gen_id.clone();
+        h.trigger = "experiment".into();
+        h.notes = Some(format!(
+            "Challenger added by `caro experiment` on platform `{}`.",
+            target_platform
+        ));
+        lock.history.push(h);
+    }
+
+    lock.write_path(&lock_path)
+        .map_err(|e| format!("writing {}: {}", lock_path.display(), e))?;
+
+    Ok((lock_path, adopted_id))
+}
+
+/// `caro adopt <name> --variant <id>`.
+fn run_caroml_adopt(name: &str, variant_id: &str) -> Result<(), String> {
+    use caro::caroml::{adopt as adopt_mod, discovery, lock::Lock};
+
+    let task_path = discovery::resolve_task_path(name)
+        .ok_or_else(|| format!("could not find task `{}`", name))?;
+    let lock_path = task_path.with_extension("caro.lock");
+    let mut lock =
+        Lock::read_path(&lock_path).map_err(|e| format!("{}: {}", lock_path.display(), e))?;
+    adopt_mod::adopt(&mut lock, variant_id).map_err(|e| e.to_string())?;
+    lock.write_path(&lock_path)
+        .map_err(|e| format!("writing {}: {}", lock_path.display(), e))?;
+    Ok(())
+}
+
+/// `caro history <name>`.
+fn run_caroml_history(name: &str) -> Result<(), String> {
+    use caro::caroml::{discovery, history, lock::Lock};
+
+    let task_path = discovery::resolve_task_path(name)
+        .ok_or_else(|| format!("could not find task `{}`", name))?;
+    let lock_path = task_path.with_extension("caro.lock");
+    let lock =
+        Lock::read_path(&lock_path).map_err(|e| format!("{}: {}", lock_path.display(), e))?;
+
+    println!("Lock history for {}:", lock_path.display());
+    if lock.history.is_empty() {
+        println!("(no entries)");
+    } else {
+        for h in &lock.history {
+            println!(
+                "  {} [{}] {} on {} (model: {}, trigger: {})",
+                h.generation_id,
+                h.generated_at.format("%Y-%m-%d %H:%M:%SZ"),
+                h.platform,
+                h.backend,
+                h.model,
+                h.trigger
+            );
+        }
+    }
+
+    let entries = history::read_all(&lock.meta.intent_hash).unwrap_or_default();
+    println!(
+        "\nLocal run journal ({} entries):",
+        entries.len()
+    );
+    let recent: Vec<_> = entries.iter().rev().take(10).collect();
+    for e in recent {
+        println!(
+            "  {} variant={} platform={} exit={} ({} ms)",
+            e.timestamp.format("%Y-%m-%d %H:%M:%SZ"),
+            e.variant_id,
+            e.platform,
+            e.exit_code,
+            e.duration_ms
+        );
+    }
+    Ok(())
+}
+
+/// `caro why <name>` — explain the RegenEvaluator decision.
+fn run_caroml_why(name: &str) -> Result<(), String> {
+    use caro::caroml::{
+        check_file, discovery, lock::Lock, platform as caro_platform, regen_evaluator,
+    };
+
+    let task_path = discovery::resolve_task_path(name)
+        .ok_or_else(|| format!("could not find task `{}`", name))?;
+    let task = check_file(&task_path).map_err(|e| format!("{}: {}", task_path.display(), e))?;
+
+    let lock_path = task_path.with_extension("caro.lock");
+    let lock = if lock_path.exists() {
+        Some(Lock::read_path(&lock_path).map_err(|e| format!("{}: {}", lock_path.display(), e))?)
+    } else {
+        None
+    };
+
+    let platform = caro_platform::current().to_string();
+    let input = regen_evaluator::EvalInput {
+        task: &task,
+        lock: lock.as_ref(),
+        platform: &platform,
+        current_caro_version: env!("CARGO_PKG_VERSION"),
+        current_model: "mock-inline",
+        current_backend: "mock",
+        mode: regen_evaluator::Mode::default(),
+    };
+    let decision = regen_evaluator::decide(&input);
+
+    println!("Task:     {}", name);
+    println!("Path:     {}", task_path.display());
+    println!("Platform: {}", platform);
+    println!("Decision: {:?}", match &decision {
+        regen_evaluator::Decision::UseCache => "UseCache",
+        regen_evaluator::Decision::HardRegen { .. } => "HardRegen",
+        regen_evaluator::Decision::SoftExplore { .. } => "SoftExplore",
+    });
+    let reasons = decision.reasons();
+    if reasons.is_empty() {
+        println!("(no reasons; cache is fresh)");
+    } else {
+        println!("Reasons:");
+        for r in reasons {
+            println!("  - {}", r);
+        }
+    }
     Ok(())
 }
 
@@ -2666,6 +2937,47 @@ async fn main() {
                 println!("{}: written", path.display());
                 process::exit(0);
             }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::Experiment {
+            ref name,
+            ref platform,
+            ref backend,
+        }) => match run_caroml_experiment(name, platform.as_deref(), backend.as_deref()).await {
+            Ok((path, gen_id)) => {
+                println!("{}: challenger {} added", path.display(), gen_id);
+                process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::Adopt {
+            ref name,
+            ref variant,
+        }) => match run_caroml_adopt(name, variant) {
+            Ok(()) => {
+                println!("Adopted {} as active.", variant);
+                process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::History { ref name }) => match run_caroml_history(name) {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::Why { ref name }) => match run_caroml_why(name) {
+            Ok(()) => process::exit(0),
             Err(e) => {
                 eprintln!("Error: {}", e);
                 process::exit(1);


### PR DESCRIPTION
## Summary

PR 6. Stacked on [#907](https://github.com/wildcard/caro/pull/907) → [#906](https://github.com/wildcard/caro/pull/906) → [#905](https://github.com/wildcard/caro/pull/905) → [#904](https://github.com/wildcard/caro/pull/904) → [#893](https://github.com/wildcard/caro/pull/893). Closes [#899](https://github.com/wildcard/caro/issues/899).

The **project-memory layer**: per-user run journal, A/B variant lifecycle, and four user-facing commands that surface the lock's accumulated state.

## What's added

- **`src/caroml/history.rs`** — JSONL journal at `~/.caro/state/<intent_hash>/journal.jsonl`. Per-user / not committed. `JournalEntry` records `ts`, `variant_id`, `platform`, `exit_code`, `duration_ms`, `stderr_digest` (SHA-256 of first 4 KB — privacy default), `note`. `aggregate_entries()` rolls journal entries into `TrackRecord`.
- **`src/caroml/adopt.rs`** — `adopt(lock, variant_id)` flips active for a challenger and retires the previously-active variant. `locate()` resolves a generation_id. `aggregated_score()` ranks variants for the future `--auto-best` flag.
- **CLI**:
  ```
  caro experiment <name> [--platform P]    # add a challenger
  caro adopt <name> --variant ID            # promote it
  caro history <name>                       # lock lineage + journal
  caro why <name>                           # RegenEvaluator decision
  ```
- **`caro run` integration**: writes a `JournalEntry` on every invocation (best-effort; warning-only on journal-write failure).

## Smoke test

```
$ caro generate test-task --backend mock
tasks/test-task.caro.lock: generated

$ caro why test-task
Decision: "UseCache"

$ caro experiment test-task --backend mock
tasks/test-task.caro.lock: challenger gen_2026-04-27_macos_b_step0 added

$ caro adopt test-task --variant gen_2026-04-27_macos_b_step0
Adopted gen_2026-04-27_macos_b_step0 as active.

$ caro run test-task -y
All 1 steps completed in 1 ms.

$ caro history test-task
Lock history for tasks/test-task.caro.lock:
  gen_..._a [...] macos on mock (model: mock-inline, trigger: intent_hash_mismatch)
  gen_..._b [...] macos on mock (model: mock-inline, trigger: experiment)

Local run journal (1 entries):
  ... variant=gen_..._b_step0 platform=macos exit=0 (1 ms)
```

## Test plan

- [x] 15 new tests (6 history + 7 adopt + 2 misc)
- [x] Full lib suite: **494 tests pass** (481 prior + 13 new — counted differently)
- [x] `cargo clippy --lib --bin caro --no-default-features --features embedded-cpu -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the project‑memory layer: a per‑user run journal, A/B variant lifecycle (experiment/adopt), and commands to inspect history and explain run decisions. `caro run` now records duration, exit code, and a stderr digest to inform future promotion.

- **New Features**
  - Per-user JSONL run journal (best‑effort; non-blocking) at `~/.caro/state/<intent_hash>/journal.jsonl`; logs exit code, duration, and SHA‑256 digest of the first 4 KB of stderr.
  - A/B lifecycle: `caro experiment <name> [--platform P] [--backend B]` adds a challenger; `caro adopt <name> --variant ID` promotes it and retires the previous active.
  - `caro history <name>` shows lock lineage and the last 10 local runs; `caro why <name>` explains the RegenEvaluator decision with reasons for the next run.

<sup>Written for commit ba627e67314169b53f9328aeb35c43f8937eff57. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/908?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

