### PR TITLE
feat(caroml): PR 7 — Carofile orchestration (`caro do`) + stack-wide review fixes

### DIFF
--- a/src/caroml/adopt.rs
+++ b/src/caroml/adopt.rs
@@ -123,6 +123,7 @@ mod tests {
             tool_versions: BTreeMap::new(),
             track_record: Default::default(),
             retired_at: None,
+            runbook_hash: String::new(),
         }
     }
 

--- a/src/caroml/interpreter.rs
+++ b/src/caroml/interpreter.rs
@@ -215,11 +215,10 @@ async fn generate_step(
         };
         let outcomes = run_all(validators, &validator_ctx).await;
 
-        if !should_repair(&outcomes) || iter >= cfg.max_iterations.saturating_sub(1) {
-            break (generated, outcomes, iter + 1);
-        }
+        // Must-pass failures (e.g. safety) ALWAYS short-circuit, even on the
+        // last allowed iteration — otherwise a max-iter exhaustion would
+        // silently land the bad command in the lock with risk_level=high.
         if let Some(angle) = fatal_angle(validators, &outcomes) {
-            // must-pass failed: don't loop forever, surface the failure.
             if angle == "safety" {
                 return Err(GenerateError::SafetyBlocked {
                     step_line: step.line,
@@ -230,6 +229,10 @@ async fn generate_step(
                         .unwrap_or_else(|| "blocked by safety validator".to_string()),
                 });
             }
+        }
+
+        if !should_repair(&outcomes) || iter >= cfg.max_iterations.saturating_sub(1) {
+            break (generated, outcomes, iter + 1);
         }
 
         prior_failures = outcomes
@@ -324,6 +327,7 @@ fn build_variant(
         tool_versions: BTreeMap::new(),
         track_record: Default::default(),
         retired_at: None,
+            runbook_hash: String::new(),
     }
 }
 

--- a/src/caroml/interpreter.rs
+++ b/src/caroml/interpreter.rs
@@ -327,7 +327,7 @@ fn build_variant(
         tool_versions: BTreeMap::new(),
         track_record: Default::default(),
         retired_at: None,
-            runbook_hash: String::new(),
+        runbook_hash: String::new(),
     }
 }
 

--- a/src/caroml/jobs.rs
+++ b/src/caroml/jobs.rs
@@ -1,0 +1,277 @@
+//! `caro do` resolver + JOB runner.
+//!
+//! Resolves a name (typed by the user as `caro do <name>`) into one of:
+//!
+//! - **Job**: a `JOB <name>` declared in the project's Carofile — runs the
+//!   sequence of `RUN <alias>` lines, dispatching each via `dispatch_alias`.
+//! - **External alias**: a `USE "<command>" AS <name>` registers `<name>` as
+//!   a shell-command alias; `dispatch_alias` runs the command directly.
+//! - **Native task alias**: a `USE <path-to-.caro> AS <name>` aliases a
+//!   CaroML task; `dispatch_alias` runs it via `caro run`.
+//! - **Fallback**: if none of the above match, treat `<name>` as a bare task
+//!   name and run via `caro run <name>` (this is the no-Carofile path).
+//!
+//! All execution goes through the existing `CommandExecutor` so the safety
+//! validator can scan the resolved command (per the plan: "the safety
+//! pipeline still runs on the resolved command").
+
+use crate::caroml::carofile::{Carofile, UseDecl, UseTarget};
+use crate::caroml::lock::Lock;
+use crate::caroml::runner::{self, RunError};
+use crate::execution::{CommandExecutor, ExecutionResult, ExecutorError};
+use crate::models::ShellType;
+use std::path::Path;
+use thiserror::Error;
+
+/// What `caro do <name>` resolved to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Run a JOB declared in the Carofile.
+    Job { name: String, runs: Vec<String> },
+    /// Run an external command alias (e.g. `npm test`).
+    ExternalAlias { alias: String, command: String },
+    /// Run a native task — caller dispatches to `caro run <task>`.
+    NativeAlias { alias: String, task_path: std::path::PathBuf },
+    /// No Carofile match — treat as a bare task name.
+    BareTask { name: String },
+}
+
+#[derive(Debug, Error)]
+pub enum DoError {
+    #[error("executor: {0}")]
+    Executor(#[from] ExecutorError),
+    #[error("alias `{alias}` resolved to a JOB but JOBs cannot be re-aliased")]
+    InvalidAliasing { alias: String },
+    #[error("step run error: {0}")]
+    StepRun(#[from] RunError),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Resolve `name` against an optional Carofile. Returns the matched variant.
+pub fn resolve(name: &str, carofile: Option<&Carofile>) -> Resolution {
+    if let Some(cf) = carofile {
+        if let Some(job) = cf.jobs.iter().find(|j| j.name == name) {
+            return Resolution::Job {
+                name: job.name.clone(),
+                runs: job.runs.clone(),
+            };
+        }
+        if let Some(use_decl) = cf.uses.iter().find(|u| u.alias == name) {
+            return resolution_for_use(use_decl);
+        }
+    }
+    Resolution::BareTask {
+        name: name.to_string(),
+    }
+}
+
+fn resolution_for_use(use_decl: &UseDecl) -> Resolution {
+    match &use_decl.target {
+        UseTarget::ExternalCommand(cmd) => Resolution::ExternalAlias {
+            alias: use_decl.alias.clone(),
+            command: cmd.clone(),
+        },
+        UseTarget::NativeTask(path) => Resolution::NativeAlias {
+            alias: use_decl.alias.clone(),
+            task_path: path.clone(),
+        },
+    }
+}
+
+/// Render the dispatch plan for `caro do --dry-run` — no execution.
+pub fn render_plan(name: &str, resolution: &Resolution, carofile: Option<&Carofile>) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("caro do {} →\n", name));
+    match resolution {
+        Resolution::Job { name, runs } => {
+            s.push_str(&format!("  JOB {} ({} runs):\n", name, runs.len()));
+            for (i, alias) in runs.iter().enumerate() {
+                let nested = carofile
+                    .and_then(|cf| cf.uses.iter().find(|u| u.alias == *alias))
+                    .map(resolution_for_use)
+                    .unwrap_or(Resolution::BareTask {
+                        name: alias.clone(),
+                    });
+                s.push_str(&format!("    {}. {}", i + 1, render_inline(&nested)));
+                s.push('\n');
+            }
+        }
+        other => {
+            s.push_str(&format!("  {}\n", render_inline(other)));
+        }
+    }
+    s
+}
+
+fn render_inline(r: &Resolution) -> String {
+    match r {
+        Resolution::Job { name, .. } => format!("JOB {}", name),
+        Resolution::ExternalAlias { alias, command } => {
+            format!("alias `{}` → `{}`", alias, command)
+        }
+        Resolution::NativeAlias { alias, task_path } => {
+            format!("alias `{}` → caro run {}", alias, task_path.display())
+        }
+        Resolution::BareTask { name } => format!("caro run {}", name),
+    }
+}
+
+/// Dispatch one resolved alias. For a Job, recursively iterates its runs.
+/// For external commands, executes via `CommandExecutor`. For native
+/// aliases / bare tasks, calls `task_runner` (caller-supplied — keeps this
+/// module free of CLI / I/O choice).
+pub fn dispatch<F>(
+    name: &str,
+    carofile: Option<&Carofile>,
+    mut task_runner: F,
+) -> Result<Vec<ExecutionResult>, DoError>
+where
+    F: FnMut(&str, Option<&Path>) -> Result<Vec<ExecutionResult>, DoError>,
+{
+    let resolution = resolve(name, carofile);
+    match resolution {
+        Resolution::Job { runs, .. } => {
+            let mut all_results = Vec::new();
+            for alias in &runs {
+                let nested = match carofile.and_then(|cf| cf.uses.iter().find(|u| u.alias == *alias))
+                {
+                    Some(use_decl) => resolution_for_use(use_decl),
+                    None => Resolution::BareTask {
+                        name: alias.clone(),
+                    },
+                };
+                let mut step_results = dispatch_resolution(&nested, &mut task_runner)?;
+                all_results.append(&mut step_results);
+            }
+            Ok(all_results)
+        }
+        other => dispatch_resolution(&other, &mut task_runner),
+    }
+}
+
+fn dispatch_resolution<F>(
+    resolution: &Resolution,
+    task_runner: &mut F,
+) -> Result<Vec<ExecutionResult>, DoError>
+where
+    F: FnMut(&str, Option<&Path>) -> Result<Vec<ExecutionResult>, DoError>,
+{
+    match resolution {
+        Resolution::Job { name, .. } => Err(DoError::InvalidAliasing { alias: name.clone() }),
+        Resolution::ExternalAlias { command, .. } => {
+            let exec = CommandExecutor::new(ShellType::Bash);
+            let result = exec.execute(command)?;
+            if result.exit_code != 0 {
+                return Err(DoError::Other(format!(
+                    "external alias exited {}: {}\nstderr: {}",
+                    result.exit_code, command, result.stderr
+                )));
+            }
+            Ok(vec![result])
+        }
+        Resolution::NativeAlias { alias, task_path } => task_runner(alias, Some(task_path)),
+        Resolution::BareTask { name } => task_runner(name, None),
+    }
+}
+
+/// Convenience runner used by `caro do <bare-task>`: load the task's lock
+/// and execute it on `platform`. The lock must already exist.
+pub fn run_native_task(
+    task_path: &Path,
+    platform: &str,
+) -> Result<Vec<ExecutionResult>, DoError> {
+    let lock_path = task_path.with_extension("caro.lock");
+    let lock = Lock::read_path(&lock_path).map_err(|e| DoError::Other(e.to_string()))?;
+    let plan = runner::plan_run(&lock, platform).map_err(DoError::StepRun)?;
+    runner::execute_plan(&plan).map_err(DoError::StepRun)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caroml::carofile::{parse, Carofile};
+
+    fn cf(src: &str) -> Carofile {
+        parse(src).expect("parse")
+    }
+
+    #[test]
+    fn resolve_finds_job() {
+        let c = cf("\
+TASK demo
+USE \"npm test\" AS test
+JOB ci
+  RUN test
+");
+        match resolve("ci", Some(&c)) {
+            Resolution::Job { name, runs } => {
+                assert_eq!(name, "ci");
+                assert_eq!(runs, vec!["test".to_string()]);
+            }
+            other => panic!("expected Job, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_finds_external_alias() {
+        let c = cf("TASK demo\nUSE \"npm test\" AS test\n");
+        match resolve("test", Some(&c)) {
+            Resolution::ExternalAlias { alias, command } => {
+                assert_eq!(alias, "test");
+                assert_eq!(command, "npm test");
+            }
+            other => panic!("expected ExternalAlias, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_finds_native_alias() {
+        let c = cf("TASK demo\nUSE tasks/cleanup-logs.caro AS cleanup-logs\n");
+        match resolve("cleanup-logs", Some(&c)) {
+            Resolution::NativeAlias { alias, task_path } => {
+                assert_eq!(alias, "cleanup-logs");
+                assert_eq!(task_path.to_string_lossy(), "tasks/cleanup-logs.caro");
+            }
+            other => panic!("expected NativeAlias, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_falls_back_to_bare_task() {
+        let c = cf("TASK demo\n");
+        match resolve("nonexistent", Some(&c)) {
+            Resolution::BareTask { name } => assert_eq!(name, "nonexistent"),
+            other => panic!("expected BareTask, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_without_carofile_returns_bare_task() {
+        match resolve("anything", None) {
+            Resolution::BareTask { name } => assert_eq!(name, "anything"),
+            other => panic!("expected BareTask, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn render_plan_job_lists_each_run() {
+        let c = cf("\
+TASK demo
+USE \"npm test\" AS test
+USE \"make build\" AS build
+JOB ci
+  RUN test
+  RUN build
+");
+        let resolution = resolve("ci", Some(&c));
+        let rendered = render_plan("ci", &resolution, Some(&c));
+        assert!(rendered.contains("JOB ci (2 runs)"));
+        assert!(rendered.contains("npm test"));
+        assert!(rendered.contains("make build"));
+    }
+}

--- a/src/caroml/jobs.rs
+++ b/src/caroml/jobs.rs
@@ -31,7 +31,10 @@ pub enum Resolution {
     /// Run an external command alias (e.g. `npm test`).
     ExternalAlias { alias: String, command: String },
     /// Run a native task — caller dispatches to `caro run <task>`.
-    NativeAlias { alias: String, task_path: std::path::PathBuf },
+    NativeAlias {
+        alias: String,
+        task_path: std::path::PathBuf,
+    },
     /// No Carofile match — treat as a bare task name.
     BareTask { name: String },
 }
@@ -134,13 +137,13 @@ where
         Resolution::Job { runs, .. } => {
             let mut all_results = Vec::new();
             for alias in &runs {
-                let nested = match carofile.and_then(|cf| cf.uses.iter().find(|u| u.alias == *alias))
-                {
-                    Some(use_decl) => resolution_for_use(use_decl),
-                    None => Resolution::BareTask {
-                        name: alias.clone(),
-                    },
-                };
+                let nested =
+                    match carofile.and_then(|cf| cf.uses.iter().find(|u| u.alias == *alias)) {
+                        Some(use_decl) => resolution_for_use(use_decl),
+                        None => Resolution::BareTask {
+                            name: alias.clone(),
+                        },
+                    };
                 let mut step_results = dispatch_resolution(&nested, &mut task_runner)?;
                 all_results.append(&mut step_results);
             }
@@ -158,7 +161,9 @@ where
     F: FnMut(&str, Option<&Path>) -> Result<Vec<ExecutionResult>, DoError>,
 {
     match resolution {
-        Resolution::Job { name, .. } => Err(DoError::InvalidAliasing { alias: name.clone() }),
+        Resolution::Job { name, .. } => Err(DoError::InvalidAliasing {
+            alias: name.clone(),
+        }),
         Resolution::ExternalAlias { command, .. } => {
             let exec = CommandExecutor::new(ShellType::Bash);
             let result = exec.execute(command)?;
@@ -177,10 +182,7 @@ where
 
 /// Convenience runner used by `caro do <bare-task>`: load the task's lock
 /// and execute it on `platform`. The lock must already exist.
-pub fn run_native_task(
-    task_path: &Path,
-    platform: &str,
-) -> Result<Vec<ExecutionResult>, DoError> {
+pub fn run_native_task(task_path: &Path, platform: &str) -> Result<Vec<ExecutionResult>, DoError> {
     let lock_path = task_path.with_extension("caro.lock");
     let lock = Lock::read_path(&lock_path).map_err(|e| DoError::Other(e.to_string()))?;
     let plan = runner::plan_run(&lock, platform).map_err(DoError::StepRun)?;

--- a/src/caroml/lock.rs
+++ b/src/caroml/lock.rs
@@ -165,6 +165,11 @@ pub struct Variant {
     /// If set, this variant has been retired (no longer active or challenger).
     #[serde(default)]
     pub retired_at: Option<DateTime<Utc>>,
+    /// Body-hash of the runbook that was last exported from this variant.
+    /// `caro run` compares this against the on-disk runbook to detect drift.
+    /// Empty when the runbook has never been exported.
+    #[serde(default)]
+    pub runbook_hash: String,
 }
 
 fn default_iterations() -> u32 {
@@ -332,6 +337,7 @@ mod tests {
                 last_used: Some(Utc.with_ymd_and_hms(2026, 4, 25, 8, 30, 0).unwrap()),
             },
             retired_at: None,
+            runbook_hash: String::new(),
         }
     }
 

--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -26,6 +26,7 @@ pub mod carofile;
 pub mod discovery;
 pub mod history;
 pub mod interpreter;
+pub mod jobs;
 pub mod lock;
 pub mod parser;
 pub mod platform;

--- a/src/caroml/regen_evaluator.rs
+++ b/src/caroml/regen_evaluator.rs
@@ -291,6 +291,7 @@ mod tests {
                 tool_versions: BTreeMap::new(),
                 track_record: Default::default(),
                 retired_at: None,
+            runbook_hash: String::new(),
             }],
         }];
         lock

--- a/src/caroml/regen_evaluator.rs
+++ b/src/caroml/regen_evaluator.rs
@@ -291,7 +291,7 @@ mod tests {
                 tool_versions: BTreeMap::new(),
                 track_record: Default::default(),
                 retired_at: None,
-            runbook_hash: String::new(),
+                runbook_hash: String::new(),
             }],
         }];
         lock

--- a/src/caroml/runbook.rs
+++ b/src/caroml/runbook.rs
@@ -219,6 +219,7 @@ mod tests {
             tool_versions: BTreeMap::new(),
             track_record: Default::default(),
             retired_at: None,
+            runbook_hash: String::new(),
         }
     }
 

--- a/src/caroml/runner.rs
+++ b/src/caroml/runner.rs
@@ -172,6 +172,7 @@ mod tests {
             tool_versions: BTreeMap::new(),
             track_record: Default::default(),
             retired_at: None,
+            runbook_hash: String::new(),
         }
     }
 

--- a/src/caroml/variants.rs
+++ b/src/caroml/variants.rs
@@ -107,6 +107,7 @@ mod tests {
             tool_versions: BTreeMap::new(),
             track_record: Default::default(),
             retired_at: None,
+            runbook_hash: String::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,6 +627,21 @@ enum Commands {
         /// Task name.
         name: String,
     },
+
+    /// Run a Carofile JOB, an external-alias, or a bare task.
+    ///
+    /// Resolution order:
+    /// 1. JOB matching `<name>` in `./Carofile` / `./Carofile.caro`
+    /// 2. USE alias matching `<name>` (external command or native task)
+    /// 3. Fallback: `caro run <name>` (treats `<name>` as a bare task name)
+    Do {
+        /// Job, alias, or task name.
+        name: String,
+
+        /// Print the resolved dispatch plan and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
     // /// Manage telemetry data and settings
     // Telemetry {
     //     #[command(subcommand)]
@@ -1614,6 +1629,48 @@ fn run_caroml_history(name: &str) -> Result<(), String> {
             e.duration_ms
         );
     }
+    Ok(())
+}
+
+/// `caro do <name>` — Carofile JOB / external-alias / native-alias / fallback.
+fn run_caroml_do(name: &str, dry_run: bool) -> Result<(), String> {
+    use caro::caroml::{
+        carofile, discovery, jobs, platform as caro_platform,
+    };
+
+    // Try to load the Carofile (optional).
+    let carofile_path = discovery::find_carofile();
+    let carofile = if let Some(path) = carofile_path.as_ref() {
+        let src = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        Some(
+            carofile::parse_with_path(&src, Some(path.clone()))
+                .map_err(|e| format!("{}: {}", path.display(), e))?,
+        )
+    } else {
+        None
+    };
+
+    let resolution = jobs::resolve(name, carofile.as_ref());
+    print!("{}", jobs::render_plan(name, &resolution, carofile.as_ref()));
+
+    if dry_run {
+        return Ok(());
+    }
+
+    let platform = caro_platform::current().to_string();
+    let results = jobs::dispatch(name, carofile.as_ref(), |alias_or_name, task_path_opt| {
+        // Native task or bare-task: load the lock and execute it.
+        let task_path = match task_path_opt {
+            Some(p) => p.to_path_buf(),
+            None => discovery::resolve_task_path(alias_or_name).ok_or_else(|| {
+                jobs::DoError::Other(format!("could not find task `{}`", alias_or_name))
+            })?,
+        };
+        jobs::run_native_task(&task_path, &platform)
+    })
+    .map_err(|e| e.to_string())?;
+
+    println!("Completed {} step(s) in caro do {}.", results.len(), name);
     Ok(())
 }
 
@@ -2982,6 +3039,13 @@ async fn main() {
             }
         },
         Some(Commands::Why { ref name }) => match run_caroml_why(name) {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::Do { ref name, dry_run }) => match run_caroml_do(name, dry_run) {
             Ok(()) => process::exit(0),
             Err(e) => {
                 eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1398,6 +1398,38 @@ fn build_caroml_backend(
     }
 }
 
+/// Status of the on-disk runbook relative to the lock's stamped hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunbookStatus {
+    Missing,
+    Clean,
+    Drift,
+    NoStamp,
+}
+
+fn runbook_status_for_active(
+    lock: &caro::caroml::lock::Lock,
+    platform: &str,
+    runbook_path: &std::path::Path,
+) -> RunbookStatus {
+    if !runbook_path.exists() {
+        return RunbookStatus::Missing;
+    }
+    let stamp = lock
+        .steps
+        .iter()
+        .find_map(|s| s.active_variant(platform).map(|v| v.runbook_hash.clone()))
+        .unwrap_or_default();
+    if stamp.is_empty() {
+        return RunbookStatus::NoStamp;
+    }
+    match caro::caroml::runbook::read_and_hash(runbook_path) {
+        Ok(actual) if actual == stamp => RunbookStatus::Clean,
+        Ok(_) => RunbookStatus::Drift,
+        Err(_) => RunbookStatus::Missing,
+    }
+}
+
 /// Run `caro run <name>` — read lock, build plan, confirm, execute.
 fn run_caroml_run(
     name: &str,
@@ -1430,7 +1462,38 @@ fn run_caroml_run(
     let plan = runner::plan_run(&lock, &target_platform)
         .map_err(|e| format!("{}: {}", lock_path.display(), e))?;
 
+    // Runbook-first execution: if the per-platform `.sh` runbook exists and
+    // is hash-clean, prefer running it directly (matches what a non-Caro
+    // user would `bash`). Falls back to step-by-step otherwise.
+    use caro::caroml::runbook;
+    let runbook_path = runbook::runbook_path(&task_path, &target_platform);
+    let runbook_status = runbook_status_for_active(&lock, &target_platform, &runbook_path);
+
     println!("{}", runner::render_plan(&plan));
+    match &runbook_status {
+        RunbookStatus::Missing => {
+            println!("(no runbook on disk; will execute step-by-step from the lock)")
+        }
+        RunbookStatus::Clean => {
+            println!("(runbook clean — will run `bash {}`)", runbook_path.display())
+        }
+        RunbookStatus::Drift => {
+            eprintln!(
+                "warning: {} has been edited since `caro export` last ran.\n\
+                 Step-by-step execution from the lock will be used instead.\n\
+                 Run `caro export {}` to refresh the runbook from the lock.",
+                runbook_path.display(),
+                name
+            );
+        }
+        RunbookStatus::NoStamp => {
+            eprintln!(
+                "note: lock has no runbook_hash stamp yet. Run `caro export {}` after\n\
+                 successful runs to enable drift detection.",
+                name
+            );
+        }
+    }
 
     if dry_run {
         return Ok(());
@@ -1450,7 +1513,20 @@ fn run_caroml_run(
     use caro::caroml::history;
     use std::time::Instant;
     let started = Instant::now();
-    let result = runner::execute_plan(&plan);
+    // Prefer runbook execution when it's hash-clean; fall back to per-step.
+    let result = match runbook_status {
+        RunbookStatus::Clean => match runner::execute_runbook(&runbook_path) {
+            Ok(0) => Ok(vec![]),
+            Ok(other) => Err(runner::RunError::StepFailed {
+                line: 0,
+                intent: format!("bash {}", runbook_path.display()),
+                exit_code: other,
+                stderr: String::new(),
+            }),
+            Err(e) => Err(e),
+        },
+        _ => runner::execute_plan(&plan),
+    };
     let elapsed_ms = started.elapsed().as_millis() as u64;
 
     // Journal the outcome (best-effort; don't fail the run if journal write fails).
@@ -1753,19 +1829,38 @@ fn run_caroml_export(
         None => caro_platform::current().to_string(),
     };
 
-    if let Some(out) = output {
-        let body = runbook::build_runbook(&lock, &platform).map_err(|e| e.to_string())?;
+    let body = runbook::build_runbook(&lock, &platform).map_err(|e| e.to_string())?;
+    let body_hash = runbook::compute_runbook_hash(&body);
+
+    let path = if let Some(out) = output {
         if let Some(parent) = out.parent() {
             if !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent)
                     .map_err(|e| format!("creating {}: {}", parent.display(), e))?;
             }
         }
-        std::fs::write(out, body).map_err(|e| format!("writing {}: {}", out.display(), e))?;
-        Ok(out.to_path_buf())
+        std::fs::write(out, &body).map_err(|e| format!("writing {}: {}", out.display(), e))?;
+        out.to_path_buf()
     } else {
-        runbook::write_runbook(&lock, &platform, &task_path).map_err(|e| e.to_string())
+        runbook::write_runbook(&lock, &platform, &task_path).map_err(|e| e.to_string())?
+    };
+
+    // Stamp the runbook_hash onto every active variant for this platform.
+    // This is what `caro run` later compares against the on-disk runbook to
+    // detect manual edits.
+    let mut updated = lock;
+    for step in updated.steps.iter_mut() {
+        for v in step.variants.iter_mut() {
+            if v.active && v.platform == platform {
+                v.runbook_hash = body_hash.clone();
+            }
+        }
     }
+    updated
+        .write_path(&lock_path)
+        .map_err(|e| format!("updating {}: {}", lock_path.display(), e))?;
+
+    Ok(path)
 }
 
 /// Inline echo-style deterministic backend for `caro generate --backend mock`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1475,7 +1475,10 @@ fn run_caroml_run(
             println!("(no runbook on disk; will execute step-by-step from the lock)")
         }
         RunbookStatus::Clean => {
-            println!("(runbook clean — will run `bash {}`)", runbook_path.display())
+            println!(
+                "(runbook clean — will run `bash {}`)",
+                runbook_path.display()
+            )
         }
         RunbookStatus::Drift => {
             eprintln!(
@@ -1710,9 +1713,7 @@ fn run_caroml_history(name: &str) -> Result<(), String> {
 
 /// `caro do <name>` — Carofile JOB / external-alias / native-alias / fallback.
 fn run_caroml_do(name: &str, dry_run: bool) -> Result<(), String> {
-    use caro::caroml::{
-        carofile, discovery, jobs, platform as caro_platform,
-    };
+    use caro::caroml::{carofile, discovery, jobs, platform as caro_platform};
 
     // Try to load the Carofile (optional).
     let carofile_path = discovery::find_carofile();
@@ -1727,7 +1728,10 @@ fn run_caroml_do(name: &str, dry_run: bool) -> Result<(), String> {
     };
 
     let resolution = jobs::resolve(name, carofile.as_ref());
-    print!("{}", jobs::render_plan(name, &resolution, carofile.as_ref()));
+    print!(
+        "{}",
+        jobs::render_plan(name, &resolution, carofile.as_ref())
+    );
 
     if dry_run {
         return Ok(());


### PR DESCRIPTION
## Summary

PR 7 of CaroML v0.1. Stacked on the full chain: [#908](https://github.com/wildcard/caro/pull/908) → [#907](https://github.com/wildcard/caro/pull/907) → [#906](https://github.com/wildcard/caro/pull/906) → [#905](https://github.com/wildcard/caro/pull/905) → [#904](https://github.com/wildcard/caro/pull/904) → [#893](https://github.com/wildcard/caro/pull/893). Closes [#900](https://github.com/wildcard/caro/issues/900).

Two commits: (1) the PR-7 feature itself — Carofile orchestration via `caro do` — and (2) stack-wide review fixes for the three blockers raised on PR 5/6 (now applied at the head of the stack so the next PR builds on a healthy base).

## Commit 1: Carofile orchestration

- **`src/caroml/jobs.rs`** — `Resolution { Job, ExternalAlias, NativeAlias, BareTask }`. `resolve(name, carofile)` does the lookup, `dispatch(name, carofile, task_runner)` executes (caller-supplied `task_runner` keeps the module CLI-free). Six unit tests covering each Resolution variant.
- **CLI**: `caro do <name> [--dry-run]`. JOB matches → run all RUN aliases sequentially. External alias → run via `CommandExecutor`. Native alias / bare-task fallback → load lock and execute. `--dry-run` prints the resolved dispatch plan.
- Smoke: `caro do ci` runs three RUN aliases (two native tasks + one external `true`), all green.

## Commit 2: Stack-wide review fixes (B1 / B2 / B3)

| Block | Where | Fix |
|---|---|---|
| **B1** runbook-first execution | #907 | `caro run` now checks the on-disk runbook before step-by-step. When clean, runs `bash <runbook>`; falls back when missing / drifted / unstamped. |
| **B2** drift detection wired | #907 | New `runbook_hash` field on `Variant`. `caro export` stamps it; `caro run` compares and reports one of four `RunbookStatus` states. |
| **B3** safety must-pass on last iter | #906 | `interpreter.rs` reorders `fatal_angle` check before the iter break, so a max-iterations safety Fail surfaces as `GenerateError::SafetyBlocked` rather than landing silently. |

**Drift smoke**:
```
caro run t --dry-run     → "no runbook on disk; ..."
caro export t            → runbook + hash stamp
caro run t --dry-run     → "(runbook clean — will run `bash tasks/t.macos.sh`)"
echo '# edit' >> tasks/t.macos.sh
caro run t --dry-run     → "warning: ... has been edited since `caro export` last ran..."
```

## Test plan

- [x] 6 new tests for `jobs.rs`
- [x] Full lib suite: **500 tests pass** (no regressions)
- [x] `cargo clippy --lib --bin caro --no-default-features --features embedded-cpu -- -D warnings` clean
- [x] All 4 RunbookStatus paths smoke-tested

## v0.2 tracking-issue candidates

- SafetyAngle config integration (currently hard-codes Moderate)
- Move `ScriptedBackend` / `InlineMockBackend` out of inline `#[cfg(test)]`
- Wire real backends (embedded / ollama / vllm) into `caro generate`
- Prompt-context budget probe before sending to small LLMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Carofile orchestration with `caro do` to run jobs and aliases from one command. Also fixes runbook-first execution, runbook drift detection, and safety-check ordering for more reliable runs.

- **New Features**
  - `caro do <name> [--dry-run]`: resolves a `JOB`, an external alias, a native task alias, or falls back to a bare task. Runs `RUN` aliases sequentially; `--dry-run` prints the dispatch plan.
  - Resolver in `caroml::jobs` with `resolve`/`render_plan`/`dispatch`; external aliases run via `CommandExecutor` so safety still applies; native/bare tasks execute through the existing runner.

- **Bug Fixes**
  - Runbook-first: `caro run` prefers a clean on-disk runbook; falls back when missing, drifted, or unstamped. `Variant` adds `runbook_hash`; `caro export` stamps it; `caro run` reports status and warns on drift.
  - Safety must-pass: interpreter checks `fatal_angle` before the loop exits, so max-iteration safety failures surface as `SafetyBlocked`.

<sup>Written for commit d562ec9d80f4089395718b9dcd268a5407833856. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/909?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

