### PR TITLE
feat(caroml): PR 8 — Markdown render, voice (pager codes), skill installer

### DIFF
--- a/.claude/skills/caro-scaffold/README.md
+++ b/.claude/skills/caro-scaffold/README.md
@@ -1,0 +1,32 @@
+# caro-scaffold
+
+A Claude Code / Cursor skill that helps users scaffold CaroML task files
+(`.caro`) from natural-language descriptions.
+
+## Install
+
+In any skill-aware coder agent:
+
+```sh
+caro skill install   # copies into ~/.claude/skills/caro-scaffold/
+```
+
+Or copy the `SKILL.md` file manually into your local skills directory.
+
+## Use
+
+Trigger by asking the agent:
+
+- "Make a CaroML task that ..."
+- "Scaffold a runbook for ..."
+- "Create a .caro for ..."
+- `/caro new <name>`
+
+The skill will ask 1–3 clarifying questions, then write the file (or call
+`caro new <name> "<description>"` if Caro is on PATH).
+
+## See also
+
+- CaroML language: `docs/caroml/grammar.md` (in the caro repo)
+- Caro CLI: `caro --help`
+- Companion skill: `caro-shell` (shell-command inference)

--- a/.claude/skills/caro-scaffold/SKILL.md
+++ b/.claude/skills/caro-scaffold/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: caro-scaffold
+description: Scaffold a new CaroML task file (.caro) from a natural-language description. Use this when the user wants to create a repeatable shell task that Caro will validate, generate, and maintain over time. Triggers on requests like "make a CaroML task that...", "scaffold a runbook for...", "create a .caro file for...", or invocations of `/caro new <name>`.
+---
+
+# CaroML Task Scaffolding
+
+This skill helps you create a new `.caro` file (a CaroML task) and an
+accompanying lock + runbook by walking through the user's intent in a
+small number of focused steps.
+
+## When to invoke
+
+The user is asking for a **repeatable shell task** that they'd otherwise
+script by hand and gradually drift away from. Examples:
+
+- "Make a CaroML task that cleans up old log files weekly"
+- "Scaffold a runbook to deploy the API to staging"
+- "Create a .caro for the nightly snapshot job"
+
+Caro's value proposition is that the *intent* (the what) stays stable
+while the *generated script* can evolve — across model upgrades, new CVE
+patterns, platform changes, or learned team preferences. The eight-keyword
+DSL (TASK / WHY / NEED / ON / LET / DO / NOTE / REM) is meant to feel like
+your first programming language: line-oriented, minimal syntax, BASIC-like.
+
+## Workflow
+
+1. **Clarify the intent.** Ask 1–3 short questions:
+   - What's the one-line title? (becomes `TASK`)
+   - Why does this task exist? When does it run? (becomes `WHY`)
+   - Does it need sudo / network / a specific tool? (becomes `NEED`)
+   - Target platforms? macOS, Linux, both? (becomes `ON`)
+
+2. **Sketch the steps.** Each `DO` line is one natural-language intent.
+   Keep them short and imperative. Order matters — later steps may use
+   earlier results.
+
+3. **Run `caro new <name> "<description>"`** if the user is in a shell
+   with caro installed. Otherwise, write the file content yourself
+   following the format below.
+
+4. **Show the user the resulting `.caro`** before generating. Let them
+   refine before committing.
+
+5. **Run `caro check`, then `caro generate <name> --backend mock`** for
+   a dry-run; show the resulting commands. If anything looks off,
+   refine the intent (not the output).
+
+6. **For real generation**, point the user at `caro generate` with their
+   configured backend; for now `mock` is the only one wired through.
+
+## File format reference
+
+```
+REM Optional comments anywhere; ignored at runtime
+TASK <one-line title>
+WHY  <reason; when does this run?>
+
+NEED <prerequisite>      # zero or more
+ON   <platform> [PREFER <a, b>] [AVOID <c, d>]    # zero or more
+
+LET  <name> = <value>     # zero or more; use {name} in DO lines
+
+NOTE <hint to the LLM>    # attaches to the next DO line
+DO   <natural-language intent>
+DO   <next intent>
+```
+
+Recognized platforms: `macos`, `linux`, `windows`, `posix`.
+
+## Example session
+
+```
+USER: Make a CaroML task that deletes log files older than 30 days,
+      with confirmation per file.
+
+ASSISTANT: A few quick questions:
+  1. Title for the task? (e.g., "Clean up old log files")
+  2. Where do the logs live? (`/var/log` is the conventional spot)
+  3. Target platforms? Both macOS and Linux?
+
+USER: Yes, both. /var/log is fine. Title is "Cleanup logs".
+
+ASSISTANT: Drafting tasks/cleanup-logs.caro:
+
+  TASK Cleanup logs
+  WHY  Free disk space; runs weekly via cron
+
+  NEED sudo
+  ON   macos PREFER bsd-tools
+  ON   linux PREFER gnu-tools
+
+  LET  path = /var/log
+  LET  days = 30
+
+  DO   find log files in {path}
+  DO   filter to those older than {days} days
+  DO   delete each, asking confirmation per file
+  DO   record what was deleted to /tmp/caro-cleanup.log
+
+Want me to commit this as-is, or refine anything first?
+```
+
+## Don'ts
+
+- Don't over-constrain — leave the LLM room to choose a sensible idiom.
+  `DO find all .log files older than 30 days and delete them` is fine;
+  `DO run "find /var/log -mtime +30 -delete"` defeats the point.
+- Don't put shell flags in the intent — that's the lock's job.
+- Don't ship `.sh` runbooks as the primary deliverable. The committed
+  artifact is the `.caro` + `.caro.lock`; runbooks are derived.
+
+## Triggers
+
+This skill should activate when the user says any of:
+- "make a CaroML task"
+- "scaffold a runbook"
+- "create a .caro for ..."
+- "/caro new"
+- "I want a repeatable shell task"

--- a/src/caroml/mod.rs
+++ b/src/caroml/mod.rs
@@ -31,10 +31,13 @@ pub mod lock;
 pub mod parser;
 pub mod platform;
 pub mod regen_evaluator;
+pub mod render;
 pub mod runbook;
 pub mod runner;
+pub mod skill;
 pub mod validators;
 pub mod variants;
+pub mod voice;
 
 pub use ast::{Param, ParseError, ParseErrorKind, PlatformPragma, Step, Task};
 pub use lock::{Lock, Step as LockStep, Variant};

--- a/src/caroml/render.rs
+++ b/src/caroml/render.rs
@@ -1,0 +1,191 @@
+//! Markdown renderer — `caro render <name>` produces a documentation-grade
+//! `.md` from a `.caro` task file.
+//!
+//! v0.1 is **forward-only**: `.caro` → Markdown. v0.2 may add reverse parsing
+//! so a renderable `.md` round-trips back to a `.caro`.
+
+use crate::caroml::ast::Task;
+
+/// Render a parsed [`Task`] as Markdown.
+///
+/// Layout:
+///
+/// ```markdown
+/// # <TASK title>
+///
+/// > <WHY...>
+///
+/// **Requires:** sudo, jq
+///
+/// > **macos:** prefers `bsd-tools`
+/// > **linux:** prefers `gnu-tools`
+///
+/// **Parameters:**
+/// - `path` = `/var/log`
+/// - `days` = `30`
+///
+/// 1. find log files in /var/log
+///    <small>note: prefer single-pass find</small>
+/// 2. delete files older than 30 days
+/// 3. ...
+/// ```
+pub fn render_markdown(task: &Task) -> String {
+    let mut s = String::new();
+
+    s.push_str(&format!("# {}\n\n", task.title));
+
+    if let Some(why) = &task.why {
+        s.push_str(&format!("> {}\n\n", why));
+    }
+
+    if !task.needs.is_empty() {
+        s.push_str(&format!("**Requires:** {}\n\n", task.needs.join(", ")));
+    }
+
+    if !task.platform_pragmas.is_empty() {
+        for p in &task.platform_pragmas {
+            s.push_str(&format!("> **{}:**", p.platform));
+            if !p.prefer.is_empty() {
+                s.push_str(&format!(
+                    " prefers {}",
+                    p.prefer
+                        .iter()
+                        .map(|x| format!("`{}`", x))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if !p.avoid.is_empty() {
+                s.push_str(&format!(
+                    " · avoids {}",
+                    p.avoid
+                        .iter()
+                        .map(|x| format!("`{}`", x))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            s.push('\n');
+        }
+        s.push('\n');
+    }
+
+    if !task.params.is_empty() {
+        s.push_str("**Parameters:**\n\n");
+        for p in &task.params {
+            s.push_str(&format!("- `{}` = `{}`\n", p.name, p.value));
+        }
+        s.push('\n');
+    }
+
+    s.push_str("**Steps:**\n\n");
+    for (i, step) in task.steps.iter().enumerate() {
+        s.push_str(&format!("{}. {}\n", i + 1, step.intent));
+        for note in &step.notes {
+            s.push_str(&format!("   <small>note: {}</small>\n", note));
+        }
+    }
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caroml::ast::{Param, PlatformPragma, Step, Task};
+
+    fn full_task() -> Task {
+        Task {
+            source_path: None,
+            title: "Clean up old log files".into(),
+            why: Some("Free disk space, runs weekly via cron".into()),
+            needs: vec!["sudo".into(), "jq".into()],
+            platform_pragmas: vec![
+                PlatformPragma {
+                    platform: "macos".into(),
+                    prefer: vec!["bsd-tools".into()],
+                    avoid: vec![],
+                },
+                PlatformPragma {
+                    platform: "linux".into(),
+                    prefer: vec!["gnu-tools".into()],
+                    avoid: vec![],
+                },
+            ],
+            params: vec![
+                Param {
+                    name: "path".into(),
+                    value: "/var/log".into(),
+                },
+                Param {
+                    name: "days".into(),
+                    value: "30".into(),
+                },
+            ],
+            steps: vec![
+                Step {
+                    line: 12,
+                    intent: "find log files in /var/log".into(),
+                    raw_intent: "find log files in {path}".into(),
+                    notes: vec!["prefer single-pass find".into()],
+                },
+                Step {
+                    line: 13,
+                    intent: "delete files older than 30 days".into(),
+                    raw_intent: "delete files older than {days} days".into(),
+                    notes: vec![],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn markdown_includes_title_as_h1() {
+        let md = render_markdown(&full_task());
+        assert!(md.starts_with("# Clean up old log files\n"));
+    }
+
+    #[test]
+    fn markdown_includes_why_as_blockquote() {
+        let md = render_markdown(&full_task());
+        assert!(md.contains("> Free disk space, runs weekly via cron"));
+    }
+
+    #[test]
+    fn markdown_lists_needs() {
+        let md = render_markdown(&full_task());
+        assert!(md.contains("**Requires:** sudo, jq"));
+    }
+
+    #[test]
+    fn markdown_renders_per_platform_pragmas() {
+        let md = render_markdown(&full_task());
+        assert!(md.contains("> **macos:**"));
+        assert!(md.contains("`bsd-tools`"));
+        assert!(md.contains("> **linux:**"));
+        assert!(md.contains("`gnu-tools`"));
+    }
+
+    #[test]
+    fn markdown_renders_steps_as_numbered_list_with_notes() {
+        let md = render_markdown(&full_task());
+        assert!(md.contains("1. find log files in /var/log"));
+        assert!(md.contains("<small>note: prefer single-pass find</small>"));
+        assert!(md.contains("2. delete files older than 30 days"));
+    }
+
+    #[test]
+    fn empty_optional_fields_are_omitted() {
+        let mut task = full_task();
+        task.why = None;
+        task.needs = vec![];
+        task.platform_pragmas = vec![];
+        task.params = vec![];
+        task.steps[0].notes = vec![];
+        let md = render_markdown(&task);
+        assert!(!md.contains("**Requires:**"));
+        assert!(!md.contains("**Parameters:**"));
+        assert!(!md.contains("> **macos:**"));
+        assert!(!md.contains("<small>"));
+    }
+}

--- a/src/caroml/skill.rs
+++ b/src/caroml/skill.rs
@@ -73,11 +73,7 @@ mod tests {
     fn make_skill_source(root: &Path) -> PathBuf {
         let dir = root.join("source/.claude/skills/caro-scaffold");
         std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("SKILL.md"),
-            "---\nname: caro-scaffold\n---\nbody",
-        )
-        .unwrap();
+        std::fs::write(dir.join("SKILL.md"), "---\nname: caro-scaffold\n---\nbody").unwrap();
         std::fs::write(dir.join("README.md"), "# caro-scaffold\n").unwrap();
         dir
     }

--- a/src/caroml/skill.rs
+++ b/src/caroml/skill.rs
@@ -1,0 +1,137 @@
+//! Caro skill installer — copies the bundled `caro-scaffold` skill into the
+//! local skill-aware coder agent's directory (default `~/.claude/skills/`).
+//!
+//! The bundled skill source lives under `.claude/skills/caro-scaffold/` in
+//! this repo and is read at install-time. v0.1 ships the skill files as
+//! committed text under `.claude/skills/`; v0.2 may embed them via
+//! `include_str!` for static binaries.
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const SKILL_NAME: &str = "caro-scaffold";
+
+/// Source files that make up the skill (relative to the project root's `.claude/skills/caro-scaffold/`).
+const SKILL_FILES: &[&str] = &["SKILL.md", "README.md"];
+
+#[derive(Debug, Error)]
+pub enum SkillError {
+    #[error("home directory not available")]
+    NoHomeDir,
+    #[error("skill source not found at {0}")]
+    SourceMissing(PathBuf),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// The default install destination: `<home>/.claude/skills/caro-scaffold/`.
+pub fn default_install_dir() -> Result<PathBuf, SkillError> {
+    let home = dirs::home_dir().ok_or(SkillError::NoHomeDir)?;
+    Ok(home.join(".claude").join("skills").join(SKILL_NAME))
+}
+
+/// Where the skill source ships in this repo.
+pub fn bundled_source_dir() -> PathBuf {
+    PathBuf::from(".claude").join("skills").join(SKILL_NAME)
+}
+
+/// Install the skill: copy each file in [`SKILL_FILES`] from `source_dir`
+/// to `dest_dir`. Returns the final `dest_dir`.
+pub fn install(source_dir: &Path, dest_dir: &Path) -> Result<PathBuf, SkillError> {
+    if !source_dir.exists() {
+        return Err(SkillError::SourceMissing(source_dir.to_path_buf()));
+    }
+    std::fs::create_dir_all(dest_dir)?;
+    for filename in SKILL_FILES {
+        let src = source_dir.join(filename);
+        if !src.exists() {
+            // Skip optional files; SKILL.md is required, README.md is best-effort.
+            if *filename == "SKILL.md" {
+                return Err(SkillError::SourceMissing(src));
+            }
+            continue;
+        }
+        let dst = dest_dir.join(filename);
+        std::fs::copy(&src, &dst)?;
+    }
+    Ok(dest_dir.to_path_buf())
+}
+
+/// Uninstall: remove `dest_dir` recursively. No-op if missing.
+pub fn uninstall(dest_dir: &Path) -> Result<bool, SkillError> {
+    if !dest_dir.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_dir_all(dest_dir)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_skill_source(root: &Path) -> PathBuf {
+        let dir = root.join("source/.claude/skills/caro-scaffold");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: caro-scaffold\n---\nbody",
+        )
+        .unwrap();
+        std::fs::write(dir.join("README.md"), "# caro-scaffold\n").unwrap();
+        dir
+    }
+
+    #[test]
+    fn install_copies_skill_md_and_readme() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = make_skill_source(temp.path());
+        let dest = temp.path().join("dest/skills/caro-scaffold");
+        install(&source, &dest).unwrap();
+        assert!(dest.join("SKILL.md").exists());
+        assert!(dest.join("README.md").exists());
+        let body = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(body.contains("name: caro-scaffold"));
+    }
+
+    #[test]
+    fn install_errors_when_source_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let dest = temp.path().join("dest");
+        match install(&temp.path().join("nope"), &dest) {
+            Err(SkillError::SourceMissing(_)) => {}
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn uninstall_removes_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = make_skill_source(temp.path());
+        let dest = temp.path().join("dest");
+        install(&source, &dest).unwrap();
+        assert!(dest.exists());
+        assert!(uninstall(&dest).unwrap());
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn uninstall_missing_returns_false() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = uninstall(&temp.path().join("never-existed")).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn install_skips_missing_optional_readme() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("src");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("SKILL.md"), "---\nname: x\n---").unwrap();
+        // No README — should still succeed.
+        let dest = temp.path().join("dest");
+        install(&source, &dest).unwrap();
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("README.md").exists());
+    }
+}

--- a/src/caroml/voice.rs
+++ b/src/caroml/voice.rs
@@ -1,0 +1,152 @@
+//! Caro's voice — pager-era / teletype codes used as decorative epilogue
+//! lines on success messages.
+//!
+//! The five canonical codes (anchored on the user's design intent):
+//!
+//! | Code | Meaning                            | When |
+//! |------|------------------------------------|------|
+//! | 143  | "I love you" (1-4-3 letters)       | After a long successful run, or first-time success on a new platform |
+//! | 371  | "I love you too"                    | After accepting an adopt suggestion |
+//! | 607  | "I miss you"                        | After `caro upgrade` regenerates a stale variant |
+//! | 42   | The Hitchhiker's Guide answer       | After multi-iteration validation loops converge |
+//! | 111111 | Binary all-ones; "all green"      | After all JOBs in a Carofile complete green |
+//!
+//! Always opt-out, never opt-in. Callers gate output on `eggs_enabled()`.
+
+/// One of the five canonical voice codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Code {
+    Love143,
+    LoveBack371,
+    Miss607,
+    Hitchhiker42,
+    AllOnes,
+}
+
+impl Code {
+    /// The decorative number rendered to the terminal.
+    pub fn rendered(self) -> &'static str {
+        match self {
+            Self::Love143 => "143",
+            Self::LoveBack371 => "371",
+            Self::Miss607 => "607",
+            Self::Hitchhiker42 => "42",
+            Self::AllOnes => "111111",
+        }
+    }
+
+    /// Human-readable meaning (used in `caro --help-eggs` output, v0.2).
+    pub fn meaning(self) -> &'static str {
+        match self {
+            Self::Love143 => "I love you (1-4-3 letters)",
+            Self::LoveBack371 => "I love you too",
+            Self::Miss607 => "I miss you",
+            Self::Hitchhiker42 => "The answer to life, the universe, and everything",
+            Self::AllOnes => "Binary all-ones — all green",
+        }
+    }
+}
+
+/// Pick a code appropriate for the situation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Occasion {
+    /// Successful execution.
+    SuccessfulRun,
+    /// `caro adopt` accepted.
+    Adopted,
+    /// `caro upgrade` produced a fresh lock for a stale variant.
+    UpgradedFromStale,
+    /// Multi-iteration validation loop converged on a clean command.
+    LoopConverged,
+    /// All JOBs in a Carofile completed green.
+    AllJobsGreen,
+}
+
+impl Occasion {
+    pub fn code(self) -> Code {
+        match self {
+            Self::SuccessfulRun => Code::Love143,
+            Self::Adopted => Code::LoveBack371,
+            Self::UpgradedFromStale => Code::Miss607,
+            Self::LoopConverged => Code::Hitchhiker42,
+            Self::AllJobsGreen => Code::AllOnes,
+        }
+    }
+}
+
+/// Render an epilogue line for `occasion`. Returns an empty string when
+/// `eggs` is false.
+///
+/// The output format is `"  <code>"` (two spaces of leading padding) so
+/// callers can append to a status line cleanly.
+pub fn epilogue(occasion: Occasion, eggs: bool) -> String {
+    if !eggs {
+        return String::new();
+    }
+    format!("  {}", occasion.code().rendered())
+}
+
+/// Read the `--no-eggs` policy. Reads from the env var `CARO_NO_EGGS` (any
+/// non-empty value disables) and falls back to the per-call argument.
+///
+/// Order of precedence: env > arg.
+pub fn eggs_enabled(arg_no_eggs: bool) -> bool {
+    if std::env::var("CARO_NO_EGGS")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    !arg_no_eggs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_code_renders_distinctly() {
+        let codes = [
+            Code::Love143.rendered(),
+            Code::LoveBack371.rendered(),
+            Code::Miss607.rendered(),
+            Code::Hitchhiker42.rendered(),
+            Code::AllOnes.rendered(),
+        ];
+        let unique: std::collections::HashSet<_> = codes.iter().collect();
+        assert_eq!(unique.len(), 5);
+    }
+
+    #[test]
+    fn occasions_map_to_canonical_codes() {
+        assert_eq!(Occasion::SuccessfulRun.code(), Code::Love143);
+        assert_eq!(Occasion::Adopted.code(), Code::LoveBack371);
+        assert_eq!(Occasion::UpgradedFromStale.code(), Code::Miss607);
+        assert_eq!(Occasion::LoopConverged.code(), Code::Hitchhiker42);
+        assert_eq!(Occasion::AllJobsGreen.code(), Code::AllOnes);
+    }
+
+    #[test]
+    fn epilogue_empty_when_eggs_disabled() {
+        assert_eq!(epilogue(Occasion::SuccessfulRun, false), "");
+    }
+
+    #[test]
+    fn epilogue_has_padding_and_code_when_enabled() {
+        let s = epilogue(Occasion::SuccessfulRun, true);
+        assert_eq!(s, "  143");
+    }
+
+    #[test]
+    fn meanings_are_non_empty() {
+        for c in [
+            Code::Love143,
+            Code::LoveBack371,
+            Code::Miss607,
+            Code::Hitchhiker42,
+            Code::AllOnes,
+        ] {
+            assert!(!c.meaning().is_empty());
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1737,10 +1737,7 @@ fn run_caroml_history(name: &str) -> Result<(), String> {
 }
 
 /// `caro render <name>` — write Markdown docs from a `.caro` task.
-fn run_caroml_render(
-    name: &str,
-    output: Option<&std::path::Path>,
-) -> Result<(), String> {
+fn run_caroml_render(name: &str, output: Option<&std::path::Path>) -> Result<(), String> {
     use caro::caroml::{check_file, discovery, render};
 
     let path = discovery::resolve_task_path(name)
@@ -3227,15 +3224,16 @@ async fn main() {
                 process::exit(1);
             }
         },
-        Some(Commands::Render { ref name, ref output }) => {
-            match run_caroml_render(name, output.as_deref()) {
-                Ok(()) => process::exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    process::exit(1);
-                }
+        Some(Commands::Render {
+            ref name,
+            ref output,
+        }) => match run_caroml_render(name, output.as_deref()) {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
             }
-        }
+        },
         Some(Commands::Skill { ref command }) => match run_caroml_skill(command) {
             Ok(()) => process::exit(0),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,15 @@ enum KnowledgeCommands {
     },
 }
 
+/// `caro skill` subcommands.
+#[derive(Parser, Clone)]
+enum SkillSubcommand {
+    /// Install the bundled `caro-scaffold` skill into `~/.claude/skills/`.
+    Install,
+    /// Remove the installed `caro-scaffold` skill.
+    Uninstall,
+}
+
 /// Subcommands for caro
 #[derive(Parser, Clone)]
 enum Commands {
@@ -641,6 +650,22 @@ enum Commands {
         /// Print the resolved dispatch plan and exit.
         #[arg(long)]
         dry_run: bool,
+    },
+
+    /// Render a CaroML task as Markdown documentation.
+    Render {
+        /// Task name.
+        name: String,
+
+        /// Output path. If unset, prints to stdout.
+        #[arg(short = 'o', long)]
+        output: Option<std::path::PathBuf>,
+    },
+
+    /// Manage Caro's bundled coder-agent skill.
+    Skill {
+        #[command(subcommand)]
+        command: SkillSubcommand,
     },
     // /// Manage telemetry data and settings
     // Telemetry {
@@ -1709,6 +1734,57 @@ fn run_caroml_history(name: &str) -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+/// `caro render <name>` — write Markdown docs from a `.caro` task.
+fn run_caroml_render(
+    name: &str,
+    output: Option<&std::path::Path>,
+) -> Result<(), String> {
+    use caro::caroml::{check_file, discovery, render};
+
+    let path = discovery::resolve_task_path(name)
+        .ok_or_else(|| format!("could not find task `{}`", name))?;
+    let task = check_file(&path).map_err(|e| format!("{}: {}", path.display(), e))?;
+    let md = render::render_markdown(&task);
+    match output {
+        Some(out) => {
+            if let Some(parent) = out.parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| format!("creating {}: {}", parent.display(), e))?;
+                }
+            }
+            std::fs::write(out, md).map_err(|e| format!("writing {}: {}", out.display(), e))?;
+            println!("{}: rendered", out.display());
+        }
+        None => print!("{}", md),
+    }
+    Ok(())
+}
+
+/// `caro skill install|uninstall` — manage the bundled coder-agent skill.
+fn run_caroml_skill(command: &SkillSubcommand) -> Result<(), String> {
+    use caro::caroml::skill;
+
+    let dest = skill::default_install_dir().map_err(|e| e.to_string())?;
+    match command {
+        SkillSubcommand::Install => {
+            let source = skill::bundled_source_dir();
+            let installed = skill::install(&source, &dest).map_err(|e| e.to_string())?;
+            println!("Installed `caro-scaffold` skill to {}", installed.display());
+            Ok(())
+        }
+        SkillSubcommand::Uninstall => {
+            let removed = skill::uninstall(&dest).map_err(|e| e.to_string())?;
+            if removed {
+                println!("Removed {}", dest.display());
+            } else {
+                println!("No skill installed at {}", dest.display());
+            }
+            Ok(())
+        }
+    }
 }
 
 /// `caro do <name>` — Carofile JOB / external-alias / native-alias / fallback.
@@ -3145,6 +3221,22 @@ async fn main() {
             }
         },
         Some(Commands::Do { ref name, dry_run }) => match run_caroml_do(name, dry_run) {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Some(Commands::Render { ref name, ref output }) => {
+            match run_caroml_render(name, output.as_deref()) {
+                Ok(()) => process::exit(0),
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Some(Commands::Skill { ref command }) => match run_caroml_skill(command) {
             Ok(()) => process::exit(0),
             Err(e) => {
                 eprintln!("Error: {}", e);


### PR DESCRIPTION
## Summary

PR 8. Stacked on the chain through [#909](https://github.com/wildcard/caro/pull/909). Closes [#901](https://github.com/wildcard/caro/issues/901).

The polish-and-distribution PR. Three new modules + the bundled coder-agent skill artifact + three new CLI verbs.

## What's added

- **`src/caroml/render.rs`** — `render_markdown(task)` produces documentation-grade `.md` from a parsed Task. Title → H1, WHY → blockquote, NEED → "Requires:" line, ON → per-platform blockquotes, params → list, DOs → numbered list with `<small>note:</small>` annotations.
- **`src/caroml/voice.rs`** — pager-era codes `143 / 371 / 607 / 42 / 111111` keyed off `Occasion::{SuccessfulRun, Adopted, UpgradedFromStale, LoopConverged, AllJobsGreen}`. `epilogue(occasion, eggs)` returns `"  <code>"` or empty. `CARO_NO_EGGS` env var is the project-wide opt-out switch.
- **`src/caroml/skill.rs`** — `install(source, dest)` copies the bundled `caro-scaffold` skill (`SKILL.md` + `README.md`) into `~/.claude/skills/caro-scaffold/` (default destination resolved via `default_install_dir()`).
- **`.claude/skills/caro-scaffold/`** — the bundled skill artifact: SKILL.md frontmatter documents trigger phrases ("make a CaroML task that ...") and the workflow (clarify intent → sketch DOs → run `caro new ...` → `caro check` → `caro generate`).
- **CLI**:
  ```
  caro render <name> [-o PATH]    # write Markdown doc
  caro skill install               # copy skill into ~/.claude/skills/
  caro skill uninstall             # remove it
  ```

## Smoke test

```
$ caro render test | head -8
# <one-line title for this task>

> <why this task exists; runs when?>

**Steps:**

1. <first thing to do>
2. <second thing to do>

$ HOME=/tmp/skill-home caro skill install
Installed `caro-scaffold` skill to /tmp/skill-home/.claude/skills/caro-scaffold
```

## Test plan

- [x] 16 new tests (6 render + 5 voice + 5 skill)
- [x] Full lib suite: **516 tests pass** (500 prior + 16 new)
- [x] `cargo clippy --lib --bin caro --no-default-features --features embedded-cpu -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Markdown rendering for CaroML tasks, a small “voice” epilogue using pager codes, and a bundled `caro-scaffold` skill with an installer. Exposes `caro render` and `caro skill install|uninstall` to make docs and distribution easier.

- New Features
  - Markdown renderer: `render_markdown(task)` writes `.md` from `.caro` (H1 title, WHY blockquote, “Requires:” line, per-platform blockquotes with prefer/avoid, params list, numbered DOs with `<small>note</small>`). Forward-only in v0.1.
  - Voice epilogue: pager codes `143/371/607/42/111111` via `epilogue(occasion, eggs)`; opt out with `CARO_NO_EGGS`.
  - Skill installer: `install(source, dest)` copies bundled `caro-scaffold` (`SKILL.md` required; `README.md` optional) into `~/.claude/skills/caro-scaffold/`; `uninstall` removes it.
  - CLI: `caro render <name> [-o PATH]`, `caro skill install`, `caro skill uninstall`.

<sup>Written for commit 547d5728a144e6d5c160da0eeacc45fd903b8c3d. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/911?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

