### PR TITLE
chore(caroml): PR 10 — CHANGELOG entry + README banner for v0.1 preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CaroML preview** — a meta-language for intent-tracked shell tasks. A
+  `.caro` file describes a task as a sequence of natural-language `DO` lines
+  in an eight-keyword line-keyword DSL (TASK / WHY / NEED / ON / LET / DO /
+  NOTE / REM). Caro generates a per-platform `.caro.lock` (schema_version=2)
+  with active variants, A/B candidates, validation outcomes, and a
+  history-trail; an on-disk `.<platform>.sh` runbook can be regenerated
+  from the lock and `bash`-executed without Caro installed. New CLI verbs:
+  `caro check / generate / run / export / list / new / jobs / do /
+  experiment / adopt / history / why / render / skill install`. Carofile
+  orchestration (`caro do <job>`) lets a single project file index native
+  CaroML tasks alongside external commands. The bundled `caro-scaffold`
+  Claude-Code-style skill (under `.claude/skills/caro-scaffold/`) is
+  installable via `caro skill install`. Multi-angle validator chain
+  (safety + platform + secrets + side_effects) drives a per-step repair
+  loop. Project memory: per-user run journal at
+  `~/.caro/state/<intent_hash>/journal.jsonl`, A/B challenger lifecycle
+  via `caro experiment` / `caro adopt`. CaroML preview ships behind the
+  same `cargo install caro` path; comprehensive E2E test
+  (`tests/caroml_e2e.rs`) exercises all 16 phases of the pipeline.
+  ([#893](https://github.com/wildcard/caro/pull/893),
+   [#904](https://github.com/wildcard/caro/pull/904),
+   [#905](https://github.com/wildcard/caro/pull/905),
+   [#906](https://github.com/wildcard/caro/pull/906),
+   [#907](https://github.com/wildcard/caro/pull/907),
+   [#908](https://github.com/wildcard/caro/pull/908),
+   [#909](https://github.com/wildcard/caro/pull/909),
+   [#911](https://github.com/wildcard/caro/pull/911),
+   [#912](https://github.com/wildcard/caro/pull/912),
+   [#913](https://github.com/wildcard/caro/pull/913))
+- **CaroML voice** — pager-era epilogue codes (143/371/607/42/111111) on
+  success messages, opt-out via `CARO_NO_EGGS`. Documented at
+  `docs/caroml/voice.md`.
+- **CaroML examples library** at `examples/library/system/` plus a sample
+  `Carofile`. Walk-through documentation under `docs/caroml/`.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > ✨ **Now Generally Available!** - Published on crates.io with all core features working. Visit [caro.sh](https://caro.sh) for more info.
 
+> 🆕 **CaroML preview** — Caro now interprets `.caro` task files: an eight-keyword line-keyword DSL that lets you commit *intent* and have Caro generate the script. Per-platform variants, A/B challengers, runbook drift detection, and the bundled `caro-scaffold` skill for any skill-aware coder agent. See [`docs/caroml/intro.md`](docs/caroml/intro.md) and [`examples/library/system/`](examples/library/system/).
+
 **caro** (formerly **cmdai**) converts natural language descriptions into safe POSIX shell commands using local LLMs. Built with Rust for blazing-fast performance, single-binary distribution, and safety-first design with intelligent platform detection.
 
 ```bash


### PR DESCRIPTION
## Summary

PR 10 — the polish PR. **No code; pure docs.** Documents the CaroML preview surface that PRs 1–9 + 11 shipped.

Closes [#903](https://github.com/wildcard/caro/issues/903). Stacked on the chain through [#913](https://github.com/wildcard/caro/pull/913).

## What's added

- **CHANGELOG.md** — thorough Unreleased / Added entry citing every PR ([#893](https://github.com/wildcard/caro/pull/893) → [#913](https://github.com/wildcard/caro/pull/913)), summarizing the end-user surface (CLI verbs, file types, voice opt-out), and noting `tests/caroml_e2e.rs` as the capstone E2E.
- **README.md** — one-paragraph blockquote banner under the existing GA notice pointing readers at `docs/caroml/intro.md` and the examples library.

## What's NOT in this PR

- No version bump; CaroML ships as a preview within the existing 1.x line.
- The 6-file release alignment (`Cargo.toml` / `Cargo.lock` / `ROADMAP.md` / install scripts) applies only when a maintainer actually cuts v1.4.0. This PR deliberately doesn't touch the version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CaroML v0.1 preview docs: a thorough Unreleased/Added entry in `CHANGELOG.md` covering the `.caro` DSL, new CLI verbs (incl. `skill install`), `.caro.lock` + runbook flow, Carofile orchestration, A/B experiment/adopt, the validator chain, and voice codes with opt‑out via `CARO_NO_EGGS` (see `docs/caroml/voice.md`). Adds a short README banner linking to `docs/caroml/intro.md` and `examples/library/system/`, noting per‑platform variants, runbook drift checks, and the bundled `caro-scaffold` skill; no version bump—preview ships under 1.x.

<sup>Written for commit b7c567b73caae809a76e53358c04728e51db42b2. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/914?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

