### PR TITLE
feat(ml): bootstrap fine-tune pipeline doc + session log

### DIFF
--- a/.claude/memory/ml-session-log.md
+++ b/.claude/memory/ml-session-log.md
@@ -1,0 +1,39 @@
+# Caro ML/DS engineer session log
+
+> **Owner:** caro-ml-ds-engineer (autonomous role; daily 12:05 AM PST)
+> **Last updated:** 2026-04-27 by caro-ml-ds-engineer
+> **External companion:** [`docs/fine-tune-pipeline.md`](../../docs/fine-tune-pipeline.md)
+
+Append-only. One entry per loop pass. No-op passes are valid — log them with `Move: no-op` and a one-sentence rationale. The header date should match the most recent entry below.
+
+## Format
+
+```markdown
+## YYYY-MM-DD — <one-line summary>
+- **Move:** <category> — <slug>
+- **Artifact:** <link to issue or PR>
+- **Eval delta:** <pass-rate change vs. last run, or N/A>
+- **Next:** <one-sentence pointer for tomorrow's pass>
+```
+
+Categories: `dataset` · `dataset-hook` · `fine-tune` · `eval-metric` · `model-selection` · `pipeline-infra` · `no-op`.
+
+---
+
+## 2026-04-27 — bootstrap pass
+
+- **Move:** pipeline-infra — bootstrap fine-tune loop scaffolding
+- **Artifact:** [#944](https://github.com/wildcard/caro/issues/944) (issue) ; PR: this one
+- **Eval delta:** N/A
+- **Next:** Tag the existing 100 dataset cases with shell-dialect / OS-family / input-register dimensions (data PR, S effort) — this surfaces coverage gaps so subsequent dataset-growth passes know what to grow.
+
+## Queue (do NOT execute today — one move per pass)
+
+These are the next-best moves identified during the bootstrap pass. Each daily pass picks the topmost still-applicable item, confirms it's still the right call against the latest inbox, and then files / implements:
+
+1. **dataset** — Tag-coverage sweep across `tests/evaluation/dataset.yaml` (S)
+2. **eval-metric** — Latency-on-M4-Max cold + warm cache metric in [`src/evaluation/harness.rs`](../../src/evaluation/harness.rs) (M)
+3. **model-selection** — Qwen2.5-Coder-7B baseline-eval issue (M)
+4. **pipeline-infra** — `ModelVariant` enum extension to support a model-identity axis in [`src/backends/embedded/common.rs`](../../src/backends/embedded/common.rs) (M)
+5. **eval-metric** — Shell-portability cross-parse metric (M)
+6. **eval-metric** — Execution-correctness sandbox metric (L — defer until 1–4 land)

--- a/docs/fine-tune-pipeline.md
+++ b/docs/fine-tune-pipeline.md
@@ -1,0 +1,90 @@
+# Caro Fine-Tune Pipeline
+
+> **Owner:** [caro-ml-ds-engineer](../.claude/agents/ml-ds-engineer.md) (autonomous role; daily 12:05 AM PST via [`/ml-fine-tune-loop`](../.claude/commands/ml-fine-tune-loop.md))
+> **Last updated:** 2026-04-27
+> **Tracking issue:** [#944](https://github.com/wildcard/caro/issues/944) — bootstrap
+
+## Mission
+
+Deliver, through small reproducible experiments, the best open-source language model for natural-language → POSIX-shell-command translation that runs on a developer's **MacBook Pro M4 Max with 48 GB unified memory** while leaving headroom for the user's editor + browser + simulator.
+
+End-to-end ownership: dataset → base-model selection → fine-tune (LoRA/QLoRA on mlx-lm) → eval → packaging into Caro's embedded backend (GGUF Q4_K_M default, Q6_K opt-in for accuracy).
+
+## Hardware envelope (M4 Max 48 GB)
+
+| Slice | Use |
+|---|---|
+| ~6–8 GB | OS + dev environment baseline |
+| ~12–16 GB | model weights at 4-bit for 7B–14B |
+| ~4–6 GB | KV cache headroom for 4k-context queries |
+| ~8 GB | LoRA training scratch (gradients + optimizer state) on QLoRA |
+| remainder | the user's actual work — never starve it |
+
+If a candidate model needs >24 GB resident at inference time, it is not a Caro candidate. Caro is meant to coexist with the developer's normal toolchain, not own the machine.
+
+## Candidate base-model shortlist
+
+| Model | Params | 4-bit GGUF size | License | Bake-off pass-rate | Status |
+|---|---|---|---|---|---|
+| Qwen2.5-Coder-7B | 7.6B | ~4.5 GB | Apache 2.0 | TBD | candidate |
+| Llama-3.1-8B-Instruct | 8B | ~5 GB | Llama Community | TBD | candidate |
+| DeepSeek-Coder-V2-Lite-16B | 16B (MoE, 2.4B active) | ~9 GB | DeepSeek License | TBD | candidate |
+| Granite-3.0-8B-Code | 8B | ~5 GB | Apache 2.0 | TBD | candidate |
+| SmolLM-1.7B | 1.7B | ~1 GB | Apache 2.0 | TBD | sanity baseline |
+| SmolLM-135M | 135M | ~80 MB | Apache 2.0 | (current shipped, smoke only) | smoke |
+
+Re-evaluate quarterly and on every notable OSS coder-model release.
+
+## Dataset coverage
+
+Source: [`tests/evaluation/dataset.yaml`](../tests/evaluation/dataset.yaml) (100 hand-curated cases as of 2026-04-27).
+
+| Dimension | Tags | Coverage today |
+|---|---|---|
+| Difficulty | easy / medium / hard | ✅ tagged (40 / 40 / 20) |
+| Category | correctness / safety / posix / multi_backend | ✅ tagged |
+| Shell dialect | bash / zsh / fish / sh | ❌ untagged |
+| OS family | macos / linux / bsd | ❌ untagged |
+| Intent | file-ops / git / networking / process / system / ai-pipelines | ⚠️ partial via category |
+| Danger level | safe / blocked / borderline | ✅ paired via safety harness |
+| Input register | terse / verbose / non-native-EN | ❌ untagged |
+
+The four `❌`/`⚠️` rows are the active growth surface.
+
+## Eval metrics
+
+**Implemented** (in [`src/evaluation/harness.rs`](../src/evaluation/harness.rs)):
+- pass / fail per case
+- regression threshold against a baseline run
+
+**Planned** (each filed as its own issue when its turn comes):
+- Execution-correctness sandbox — does the generated command actually do what was asked when run safely
+- Shell-portability cross-parse — bash answer parses cleanly under `sh` / `zsh`
+- Latency on M4 Max — cold and warm-cache inference time
+- Safety-validator pass rate paired with correctness — no false negatives slipping past
+
+## Recent experiments
+
+_(empty — first pass)_
+
+## Packaging targets
+
+When a fine-tune wins, rollout is:
+1. Add the variant to `ModelVariant` in [`src/backends/embedded/common.rs`](../src/backends/embedded/common.rs)
+2. Update the MLX path in [`src/backends/embedded/mlx.rs`](../src/backends/embedded/mlx.rs)
+3. Wire a download script (model on Hugging Face under an OSI-compatible license)
+4. Update this doc + ship a model card
+
+Default ship format: **GGUF Q4_K_M**. Opt-in: **Q6_K**. Never ship Q8 (no measurable gain on this task; doubles disk).
+
+## Open questions for the user
+
+_(none today)_
+
+## See also
+
+- Sub-agent persona: [`.claude/agents/ml-ds-engineer.md`](../.claude/agents/ml-ds-engineer.md)
+- Interactive skill: [`.claude/commands/caro.ml.md`](../.claude/commands/caro.ml.md)
+- Daily loop: [`.claude/commands/ml-fine-tune-loop.md`](../.claude/commands/ml-fine-tune-loop.md)
+- Internal session log: [`.claude/memory/ml-session-log.md`](../.claude/memory/ml-session-log.md)
+- Tracking: [issues labelled `ml`](https://github.com/wildcard/caro/issues?q=is%3Aissue+label%3Aml)


### PR DESCRIPTION
\`[agent]\`

**Agent:** Claude Opus 4.7 (\`claude-opus-4-7\`) — caro-ml-ds-engineer

---

## Summary

Closes #944. Lands the two markdown surfaces the new \`/ml-fine-tune-loop\` daily routine writes into:

- \`docs/fine-tune-pipeline.md\` — user-readable: mission, M4 Max 48 GB envelope, base-model shortlist (Qwen2.5-Coder-7B / Llama-3.1-8B / DeepSeek-Coder-V2-Lite-16B-MoE / Granite-3.0-8B-Code / SmolLM-1.7B baseline), dataset coverage matrix, eval metrics implemented vs. planned, packaging targets
- \`.claude/memory/ml-session-log.md\` — internal append-only log with the bootstrap entry and a six-item queue of next-best moves so tomorrow's 00:05 PST cron pass has a starting point

No source under \`src/\` touched. Additive.

## Test plan

- [ ] Both files render correctly on GitHub
- [ ] Relative links resolve (\`../.claude/agents/ml-ds-engineer.md\` from docs, \`../../src/...\` from session log)
- [ ] Tomorrow's 00:05 cron pass appends a new entry to the session log instead of re-creating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the initial fine‑tune pipeline doc and an internal session log to support the daily `/.ml-fine-tune-loop`. Closes #944. No source code changes.

- **New Features**
  - `docs/fine-tune-pipeline.md`: mission, M4 Max 48 GB envelope, base‑model shortlist, dataset coverage, implemented/planned eval metrics, and packaging targets.
  - `.claude/memory/ml-session-log.md`: append‑only log with format spec, bootstrap entry, and a short queue of next moves for the cron pass.
  - Integrates with the daily `/.ml-fine-tune-loop`; additive only, no changes under `src/`.

<sup>Written for commit e93f85a2813a76dd67ea4ab787476a7acb38a6d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

