### PR TITLE
feat(website): ingest v2.1 pixel icon pack + Glyph wrapper

### DIFF
--- a/website/public/icons/brain.svg
+++ b/website/public/icons/brain.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" shape-rendering="crispEdges" aria-hidden="true">
+  <g fill="currentColor">
+    <path d="M5 2h6v1H5zM3 3h2v1H3zM11 3h2v1h-2zM2 4h1v1H2zM13 4h1v1h-1zM2 5h1v6H2zM13 5h1v6h-1zM3 11h1v1H3zM12 11h1v1h-1zM4 12h1v1H4zM11 12h1v1h-1zM5 13h6v1H5z"/>
+    <path d="M8 4h1v8H8z"/>
+    <path d="M5 6h2v1H5zM4 7h2v1H4zM5 8h2v1H5zM4 9h2v1H4zM5 10h2v1H5z"/>
+    <path d="M9 6h2v1H9zM10 7h2v1h-2zM9 8h2v1H9zM10 9h2v1h-2zM9 10h2v1H9z"/>
+  </g>
+</svg>

--- a/website/public/icons/home.svg
+++ b/website/public/icons/home.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M7 1h2v1H7zM6 2h4v1H6zM5 3h6v1H5zM4 4h8v1H4zM3 5h10v1H3zM2 6h12v1H2z"/>
+  <path d="M3 7h2v8H3zM11 7h2v8h-2zM5 14h6v1H5z"/>
+  <path d="M7 10h2v5H7z"/>
+  <path d="M5 8h2v2H5z"/>
+</svg>

--- a/website/public/icons/kyaro-mark.svg
+++ b/website/public/icons/kyaro-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" shape-rendering="crispEdges" aria-hidden="true">
+  <path fill="currentColor" fill-rule="evenodd" d="M2 2 h2 v2 h1 v-1 h6 v1 h1 v-2 h2 v3 h1 v6 h-1 v2 h-1 v1 h-1 v1 h-6 v-1 h-1 v-1 h-1 v-2 h-1 v-6 h1 z M5 7 h1 v2 h-1 z M10 7 h1 v2 h-1 z M7 10 h2 v1 h-2 z"/>
+</svg>

--- a/website/public/icons/lightning.svg
+++ b/website/public/icons/lightning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M8 1h3v1H8zM6 2h4v1H6zM5 3h4v1H5zM4 4h4v1H4zM3 5h4v2H3zM5 7h4v1H5zM4 8h4v1H4zM3 9h4v1H3zM2 10h4v1H2zM1 11h3v1H1zM5 8h3v1H5z"/>
+  <path d="M2 12h2v1H2zM3 13h1v1H3z"/>
+</svg>

--- a/website/public/icons/location.svg
+++ b/website/public/icons/location.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M6 1h4v1H6zM4 2h2v1H4zM10 2h2v1h-2zM3 3h1v6H3zM12 3h1v6h-1zM4 9h2v1H4zM10 9h2v1h-2zM5 10h2v1H5zM9 10h2v1H9zM6 11h2v1H6zM8 11h2v1H8zM7 12h2v1H7zM7 13h2v1H7zM7 14h2v1H7z"/>
+  <path d="M7 4h2v1H7zM6 5h4v2H6zM7 7h2v1H7z"/>
+</svg>

--- a/website/public/icons/rocket.svg
+++ b/website/public/icons/rocket.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M8 1h1v1H8zM7 2h3v1H7zM6 3h5v1H6zM6 4h2v3H6zM10 4h2v3h-2zM8 4h2v6H8zM5 7h2v3H5zM11 7h2v3h-2z"/>
+  <path d="M7 5h3v2H7z" fill="none"/>
+  <path d="M7 11h1v1H7zM10 11h1v1h-1zM8 12h2v1H8zM7 13h1v1H7zM10 13h1v1h-1zM8 14h2v1H8z"/>
+</svg>

--- a/website/public/icons/shield.svg
+++ b/website/public/icons/shield.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M3 2h10v1H3zM2 3h1v6H2zM13 3h1v6h-1zM3 9h1v2H3zM12 9h1v2h-1zM4 11h1v2H4zM11 11h1v2h-1zM5 13h2v1H5zM9 13h2v1H9zM7 14h2v1H7z"/>
+  <path d="M10 5h2v1h-2zM9 6h2v1H9zM8 7h2v1H8zM7 8h2v1H7zM5 8h1v1H5zM6 9h2v1H6z"/>
+</svg>

--- a/website/public/icons/teams.svg
+++ b/website/public/icons/teams.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M2 3h3v1H2zM1 4h1v2H1zM5 4h1v2H5zM2 6h3v1H2z"/>
+  <path d="M1 8h5v1H1zM0 9h7v4H0z"/>
+  <path d="M11 3h3v1h-3zM10 4h1v2h-1zM14 4h1v2h-1zM11 6h3v1h-3z"/>
+  <path d="M10 8h5v1h-5zM9 9h7v4H9z"/>
+  <path d="M7 9h2v4H7z" fill="none"/>
+</svg>

--- a/website/public/icons/tools.svg
+++ b/website/public/icons/tools.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+  <path d="M2 1h3v1H2zM1 2h2v2H1zM4 2h1v1H4zM2 4h2v1H2zM3 5h2v1H3zM4 6h2v1H4zM5 7h2v1H5zM6 8h2v1H6zM7 9h2v1H7zM8 10h2v1H8zM9 11h2v1H9zM10 12h2v2h-2zM11 14h3v1h-3z"/>
+  <path d="M11 1h3v1h-3zM12 2h2v2h-2zM10 3h1v1h-1zM10 4h2v1h-2zM9 5h2v1H9zM8 6h2v1H8zM7 7h2v1H7zM6 8h2v1H6zM5 9h2v1H5zM4 10h2v1H4zM3 11h2v1H3zM2 12h2v2H2zM1 14h3v1H1z"/>
+</svg>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,6 +5,7 @@
  */
 import { SITE_CONFIG } from '../config/site';
 import { t } from '../i18n/config';
+import { Glyph } from '../ui/Glyph';
 
 interface Props {
   lang: string;
@@ -22,7 +23,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
       <!-- Brand Column -->
       <div class="footer-brand">
         <a href="/" class="brand-link">
-          <span class="brand-icon">🐕</span>
+          <Glyph name="kyaro-mark" size={20} class="brand-icon" aria-label="Kyaro mark" />
           <span class="brand-name">Caro</span>
         </a>
         <p class="brand-tagline">{t(lang, 'landing.footer.brand.tagline')}</p>
@@ -104,7 +105,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
     <!-- Kyaro Mascot Section -->
     <div class="kyaro-banner">
       <div class="kyaro-content">
-        <span class="kyaro-emoji">🐕</span>
+        <Glyph name="kyaro-mark" size={32} class="kyaro-emoji" aria-label="Kyaro mark" />
         <div class="kyaro-info">
           <p class="kyaro-title">{t(lang, 'landing.footer.kyaro.title')}</p>
           <p class="kyaro-text">

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,7 +5,7 @@
  */
 import { SITE_CONFIG } from '../config/site';
 import { t } from '../i18n/config';
-import { Glyph } from '../ui/Glyph';
+import Glyph from '../ui/Glyph/Glyph.astro';
 
 interface Props {
   lang: string;

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,7 +5,8 @@
  */
 import { SITE_CONFIG } from '../config/site';
 import { t } from '../i18n/config';
-import Glyph from '../ui/Glyph/Glyph.astro';
+// NOTE(caro-bsi): kyaro-mark Glyph reverted pending v2.1.1 — current rendering reads
+// as a horned demon / pointy-eared cat rather than a Shiba. Manifest entry retained.
 
 interface Props {
   lang: string;
@@ -23,7 +24,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
       <!-- Brand Column -->
       <div class="footer-brand">
         <a href="/" class="brand-link">
-          <Glyph name="kyaro-mark" size={20} class="brand-icon" aria-label="Kyaro mark" />
+          <span class="brand-icon" aria-label="Caro brand">🐕</span>
           <span class="brand-name">Caro</span>
         </a>
         <p class="brand-tagline">{t(lang, 'landing.footer.brand.tagline')}</p>
@@ -105,7 +106,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
     <!-- Kyaro Mascot Section -->
     <div class="kyaro-banner">
       <div class="kyaro-content">
-        <Glyph name="kyaro-mark" size={32} class="kyaro-emoji" aria-label="Kyaro mark" />
+        <span class="kyaro-emoji" aria-label="Kyaro mascot">🐕</span>
         <div class="kyaro-info">
           <p class="kyaro-title">{t(lang, 'landing.footer.kyaro.title')}</p>
           <p class="kyaro-text">

--- a/website/src/components/landing/LPHero.astro
+++ b/website/src/components/landing/LPHero.astro
@@ -1,6 +1,6 @@
 ---
 import { t, type Locale } from '../../i18n/config';
-import { Glyph } from '../../ui/Glyph';
+import Glyph from '../../ui/Glyph/Glyph.astro';
 
 interface Props {
   lang?: Locale;

--- a/website/src/components/landing/LPHero.astro
+++ b/website/src/components/landing/LPHero.astro
@@ -1,5 +1,6 @@
 ---
 import { t, type Locale } from '../../i18n/config';
+import { Glyph } from '../../ui/Glyph';
 
 interface Props {
   lang?: Locale;
@@ -32,8 +33,8 @@ const { lang = 'en' } = Astro.props;
 
     <div class="trust-badges">
 <a href="/telemetry" class="badge badge-link"><span class="icon">🔒</span> {t(lang, 'landing.hero.trustBadges.zeroTelemetry')}</a>
-      <span class="badge"><span class="icon">🛡️</span> {t(lang, 'landing.hero.trustBadges.validation')}</span>
-      <span class="badge"><span class="icon">⚡</span> {t(lang, 'landing.hero.trustBadges.local')}</span>
+      <span class="badge"><Glyph name="shield" size={16} class="icon" /> {t(lang, 'landing.hero.trustBadges.validation')}</span>
+      <span class="badge"><Glyph name="lightning" size={16} class="icon" /> {t(lang, 'landing.hero.trustBadges.local')}</span>
       <span class="badge"><span class="icon">📖</span> {t(lang, 'landing.hero.trustBadges.openSource')}</span>
     </div>
   </div>

--- a/website/src/components/landing/LPPersonas.astro
+++ b/website/src/components/landing/LPPersonas.astro
@@ -1,5 +1,6 @@
 ---
 // LPPersonas.astro - Three personas section with interactive CTAs
+import { Glyph } from '../../ui/Glyph';
 ---
 
 <section class="personas" id="personas">
@@ -13,7 +14,7 @@
       <!-- The Accelerator -->
       <div class="persona-card accelerator" data-persona="accelerator">
         <div class="persona-icon">
-          <span>🚀</span>
+          <Glyph name="rocket" size={32} aria-label="Accelerator" />
         </div>
         <h3 class="persona-title">The Accelerator</h3>
         <p class="persona-role">Individual Developer</p>
@@ -54,7 +55,7 @@
       <!-- The Guardian -->
       <div class="persona-card guardian" data-persona="guardian">
         <div class="persona-icon">
-          <span>🛡️</span>
+          <Glyph name="shield" size={32} aria-label="Guardian" />
         </div>
         <h3 class="persona-title">The Guardian</h3>
         <p class="persona-role">Security & Platform Lead</p>
@@ -99,7 +100,7 @@
       <!-- The Operator -->
       <div class="persona-card operator" data-persona="operator">
         <div class="persona-icon">
-          <span>⚡</span>
+          <Glyph name="lightning" size={32} aria-label="Operator" />
         </div>
         <h3 class="persona-title">The Operator</h3>
         <p class="persona-role">SRE / DevOps Engineer</p>

--- a/website/src/components/landing/LPPersonas.astro
+++ b/website/src/components/landing/LPPersonas.astro
@@ -1,6 +1,6 @@
 ---
 // LPPersonas.astro - Three personas section with interactive CTAs
-import { Glyph } from '../../ui/Glyph';
+import Glyph from '../../ui/Glyph/Glyph.astro';
 ---
 
 <section class="personas" id="personas">

--- a/website/src/data/icon-manifest.json
+++ b/website/src/data/icon-manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.1.0",
+  "released": "2026-04-28",
+  "grid": 16,
+  "stroke": "integer-pixel",
+  "color": "monochrome via currentColor",
+  "rendering": "shape-rendering: crispEdges; recommended at 16/24/32/48 px",
+  "usage": "Inline <svg> via <Glyph name=\"home\"/> or direct file include. Color via the parent's color: token (e.g. color: var(--fg-strong)).",
+  "icons": {
+    "home":       { "path": "icons/home.svg",       "category": "navigation",    "replaces_emoji": "🏠 / 🏡", "tier": "primary" },
+    "location":   { "path": "icons/location.svg",   "category": "navigation",    "replaces_emoji": "📍",                "tier": "primary" },
+    "teams":      { "path": "icons/teams.svg",      "category": "personas",      "replaces_emoji": "👥",                "tier": "primary" },
+    "tools":      { "path": "icons/tools.svg",      "category": "personas",      "replaces_emoji": "🛠️ / 🔧", "tier": "primary" },
+    "rocket":     { "path": "icons/rocket.svg",     "category": "trust-badge",   "replaces_emoji": "🚀",                "tier": "secondary" },
+    "shield":     { "path": "icons/shield.svg",     "category": "trust-badge",   "replaces_emoji": "🛡️",          "tier": "secondary" },
+    "lightning":  { "path": "icons/lightning.svg",  "category": "trust-badge",   "replaces_emoji": "⚡",                      "tier": "secondary" },
+    "brain":      { "path": "icons/brain.svg",      "category": "feature",       "replaces_emoji": "🧠",                "tier": "secondary" },
+    "kyaro-mark": { "path": "icons/kyaro-mark.svg", "category": "brand",         "replaces_emoji": "🐕",                "tier": "brand" }
+  },
+  "deferred_v3": [
+    "git", "terminal", "package", "model", "gear", "doc", "search", "spinner", "check", "cross",
+    "If you find yourself reaching for a Lucide icon repeatedly, file a v3 ticket — don't import Lucide back in."
+  ]
+}

--- a/website/src/ui/Glyph/Glyph.astro
+++ b/website/src/ui/Glyph/Glyph.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * Glyph - Caro pixel-icon wrapper (v2.1)
+ *
+ * Inlines a 16×16 pixel-grid SVG from the v2.1 icon pack so it inherits
+ * currentColor (recolor via parent `color:` token, dark-mode safe) and
+ * scales crisply at 16/24/32/48 px (shape-rendering: crispEdges).
+ *
+ * Source manifest: `src/data/icon-manifest.json`
+ * Source SVGs:    `public/icons/<name>.svg`
+ *
+ * @example
+ * <Glyph name="rocket" size={20} class="trust-icon" />
+ */
+import manifest from '../../data/icon-manifest.json';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type GlyphName = keyof typeof manifest.icons;
+
+interface Props {
+  name: GlyphName;
+  size?: number;
+  class?: string;
+  ['aria-label']?: string;
+}
+
+const { name, size = 24, class: className, 'aria-label': ariaLabel } = Astro.props;
+
+// Read the SVG body once per build. The manifest path is relative to the
+// website public/ root, so resolve from this component's directory.
+// Cache across renders within the same build.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const svgRelPath = manifest.icons[name].path; // e.g. "icons/home.svg"
+const svgAbsPath = path.resolve(__dirname, '../../../public/', svgRelPath);
+
+let rawSvg = '';
+try {
+  rawSvg = fs.readFileSync(svgAbsPath, 'utf-8');
+} catch (e) {
+  // Fail loudly in dev; render an empty wrapper rather than crashing the page.
+  console.warn(`[Glyph] failed to read icon "${name}" at ${svgAbsPath}`, e);
+}
+
+// Strip the <svg ...> wrapper so we can re-emit with our size + class.
+// Capture inner content between the opening <svg ...> tag and closing </svg>.
+const innerMatch = rawSvg.match(/<svg[^>]*>([\s\S]*?)<\/svg>/i);
+const innerSvg = innerMatch ? innerMatch[1] : '';
+
+const role = ariaLabel ? 'img' : undefined;
+const ariaHidden = ariaLabel ? undefined : 'true';
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 16 16"
+  width={size}
+  height={size}
+  fill="currentColor"
+  shape-rendering="crispEdges"
+  class:list={['glyph', className]}
+  role={role}
+  aria-label={ariaLabel}
+  aria-hidden={ariaHidden}
+  set:html={innerSvg}
+></svg>
+
+<style>
+  .glyph {
+    display: inline-block;
+    vertical-align: -0.125em;
+    flex-shrink: 0;
+  }
+</style>

--- a/website/src/ui/Glyph/Glyph.astro
+++ b/website/src/ui/Glyph/Glyph.astro
@@ -13,9 +13,21 @@
  * <Glyph name="rocket" size={20} class="trust-icon" />
  */
 import manifest from '../../data/icon-manifest.json';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+
+// Eager-load all 9 SVGs as raw strings at build time. Vite resolves these
+// at build, so paths work regardless of where the bundle gets hoisted.
+const svgModules = import.meta.glob<string>('/public/icons/*.svg', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+// Build a name→raw-SVG map keyed by the manifest names ("home", "kyaro-mark", ...).
+const svgByName: Record<string, string> = {};
+for (const [path, raw] of Object.entries(svgModules)) {
+  const m = path.match(/\/([a-z0-9-]+)\.svg$/i);
+  if (m) svgByName[m[1]] = raw;
+}
 
 export type GlyphName = keyof typeof manifest.icons;
 
@@ -28,23 +40,12 @@ interface Props {
 
 const { name, size = 24, class: className, 'aria-label': ariaLabel } = Astro.props;
 
-// Read the SVG body once per build. The manifest path is relative to the
-// website public/ root, so resolve from this component's directory.
-// Cache across renders within the same build.
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const svgRelPath = manifest.icons[name].path; // e.g. "icons/home.svg"
-const svgAbsPath = path.resolve(__dirname, '../../../public/', svgRelPath);
-
-let rawSvg = '';
-try {
-  rawSvg = fs.readFileSync(svgAbsPath, 'utf-8');
-} catch (e) {
-  // Fail loudly in dev; render an empty wrapper rather than crashing the page.
-  console.warn(`[Glyph] failed to read icon "${name}" at ${svgAbsPath}`, e);
+const rawSvg = svgByName[name] ?? '';
+if (!rawSvg) {
+  console.warn(`[Glyph] no SVG found for "${name}"`);
 }
 
 // Strip the <svg ...> wrapper so we can re-emit with our size + class.
-// Capture inner content between the opening <svg ...> tag and closing </svg>.
 const innerMatch = rawSvg.match(/<svg[^>]*>([\s\S]*?)<\/svg>/i);
 const innerSvg = innerMatch ? innerMatch[1] : '';
 

--- a/website/src/ui/Glyph/index.ts
+++ b/website/src/ui/Glyph/index.ts
@@ -1,2 +1,0 @@
-export { default as Glyph } from './Glyph.astro';
-export type { GlyphName } from './Glyph.astro';

--- a/website/src/ui/Glyph/index.ts
+++ b/website/src/ui/Glyph/index.ts
@@ -1,0 +1,2 @@
+export { default as Glyph } from './Glyph.astro';
+export type { GlyphName } from './Glyph.astro';


### PR DESCRIPTION
## Summary

Ingests Claude Design's **v2.1 pixel icon pack** (9 SVGs at the 16×16 logical grid, monochrome via `currentColor`, `shape-rendering: crispEdges`) into the website and migrates the flagged emoji surfaces.

Source: ['Brand · Pixel icons' preview card](https://claude.ai/design/p/332f73e9-84c2-4078-ac8d-169c1855385d) in the Caro Design System workspace. SVGs and `manifest.json` pulled from the design project's served assets.

## What changed

**Foundation** (commits 1–2):
- `website/public/icons/` — 9 v2.1 SVGs (`home`, `location`, `teams`, `tools`, `rocket`, `shield`, `lightning`, `brain`, `kyaro-mark`)
- `website/src/data/icon-manifest.json` — full manifest (categories, replaced-emoji, tier, deferred-v3 list)
- `website/src/ui/Glyph/Glyph.astro` — typed wrapper (`name: GlyphName`, `size`, `class`, `aria-label`). Inlines SVGs via `import.meta.glob('/public/icons/*.svg', { query: '?raw' })` so `currentColor` / class-based recoloring work and Vite resolves paths regardless of bundle hoisting

**Migrations** (commits 3–5, one per component family for bisectability):
- `LPHero.astro` — trust badges 🛡️ → `shield`, ⚡ → `lightning`. 🔒 (zero-telemetry) and 📖 (open-source) have no v2.1 counterparts → kept as emoji
- `LPPersonas.astro` — Accelerator 🚀 → `rocket`, Guardian 🛡️ → `shield`, Operator ⚡ → `lightning`
- `Footer.astro` — both 🐕 occurrences (brand-link header + kyaro-banner) → `kyaro-mark` Glyph (the existing Kyaro PNG/GIF mascot assets stay)

## Gaps (kept as emoji per task constraint)

| File | Emoji | Reason |
|---|---|---|
| `LPHero.astro:34` | 🔒 | No padlock/lock glyph in v2.1; in `deferred_v3` only as "gear" (wrong fit) |
| `LPHero.astro:37` | 📖 | No book/doc glyph in v2.1; "doc" is in `deferred_v3` |
| `LPMoments.astro:16,46,72` | 😰 💀 🤔 | Emotional/scenario glyphs (panic/death/uncertainty) — outside the 9-icon family and not in `deferred_v3` |
| `LPBestPractices.astro:9,16,23,30` | 👤 📁 🐳 🎲 | Persona/folder/docker/random glyphs — not in v2.1 family; closest deferred terms ("doc", "package") don't match intent |
| `LPDifferentiators.astro` | (none) | No emoji in this file |

## Test plan

- [x] `cd website && npm run build` — passes (58 pages, no Glyph errors)
- [x] `node scripts/i18n/validate.mjs --strict` — 0 errors (all 437 warnings are preexisting)
- [x] Built HTML inlines `crispEdges` SVGs at expected sites: 5 in `dist/index.html` (3 personas + 2 trust badges), 2 in each footer'd subpage (`dist/faq/index.html`, `dist/telemetry/index.html`)
- [ ] Visual review on Vercel preview — `currentColor` should pick up dark-mode token automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v2.1 pixel icon pack and a `Glyph` Astro wrapper for crisp, inline icons. Migrates hero trust badges and personas to glyphs; the footer brand mark stays as 🐕 pending v2.1.1, and 🔒/📖 remain emoji.

- **New Features**
  - Ingested 9 `public/icons/*.svg` on a 16×16 grid with `shape-rendering: crispEdges` and `currentColor`.
  - Added `Glyph` (`name`, `size`, `class`, `aria-label`) that inlines SVGs via `import.meta.glob('/public/icons/*.svg', { query: '?raw', eager: true })`; exports `GlyphName`.
  - Introduced `icon-manifest.json` with icon names and categories.

- **Bug Fixes**
  - Reverted `kyaro-mark` in `Footer.astro` to 🐕 with `aria-label`; asset and manifest kept for a v2.1.1 redraw.
  - Dropped `ui/Glyph/index.ts` re-export; import `Glyph.astro` directly in `landing/LPHero.astro` and `landing/LPPersonas.astro` to resolve TS LSP module errors.

<sup>Written for commit 66bed46722689dfa7da60992c4b3dfd6714aa676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

