### PR TITLE
chore(deps): cargo update for RUSTSEC-{0098,0099,0104}; ignore legacy path

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,4 +18,18 @@ ignore = [
     # - We pin time-core=0.1.7 to maintain MSRV; time security fix deferred until
     #   time-core publishes an edition-2021-compatible 0.1.8 or MSRV is raised
     "RUSTSEC-2026-0009",
+
+    # rustls-webpki 0.101.7 - RUSTSEC-2026-0098 / 0099 / 0104
+    # - 3 vulnerabilities surface on the LEGACY rustls 0.21.x path:
+    #     reqwest 0.11.27 → rustls 0.21.12 → rustls-webpki 0.101.7
+    # - rustls 0.21.12 is terminal (last release on the 0.21 line); no patch
+    #   upgrade exists. Fix versions (>=0.103.12) are SemVer-incompatible
+    #   with the 0.101 line.
+    # - The MODERN path (rustls 0.23 → rustls-webpki 0.103.13) is patched
+    #   via cargo update -p rustls-webpki@0.103.10.
+    # - Legacy path full fix tracked in the reqwest 0.11 → 0.12 migration
+    #   epic (separate beads issue).
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8172,7 +8172,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -8229,9 +8229,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Resolves Security Audit failure on every PR. Two-part fix:

1. **Modern path patched**: `rustls-webpki 0.103.10 → 0.103.13` via `cargo update`.
2. **Legacy path documented**: 3 RUSTSEC IDs added to `.cargo/audit.toml` ignore list with full justification — the path goes through `reqwest 0.11.27 → rustls 0.21.12` which is terminal on the 0.21 line.

Matches existing project precedent (RUSTSEC-2023-0071, RUSTSEC-2026-0009). Long-term fix tracked in the reqwest 0.11 → 0.12 migration epic.

## Test plan

- [x] `cargo audit` reports 0 vulnerabilities (3 ignored)
- [x] `cargo build --release` clean
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo test --no-run` compiles
- [ ] CI Security Audit job goes green
- [ ] Unblocks #1006 and #1007 once this lands

## Out of scope

- **ChromaDB Integration Tests** are also failing on every PR (caro-871 second half) — separate fix, not this PR.
- **reqwest 0.11 → 0.12 migration** (long-term legacy-path fix) — separate epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing Security Audit on CI by bumping `rustls-webpki` on the modern TLS path and ignoring three advisories on the legacy path until we migrate to `reqwest 0.12`. Addresses the Security Audit work in Linear caro-871.

- **Dependencies**
  - Updated `rustls-webpki` from `0.103.10` to `0.103.13` on the `rustls 0.23` path via `cargo update`.
  - Ignored `RUSTSEC-2026-0098`, `RUSTSEC-2026-0099`, `RUSTSEC-2026-0104` in `.cargo/audit.toml` for the legacy `reqwest 0.11 -> rustls 0.21 -> rustls-webpki 0.101.7` chain, which has no patch on `0.21.x` and will be resolved by the `reqwest 0.12` migration.

<sup>Written for commit 39c62903410eac8d4e98130081b9f78939c2c591. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1026?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

