### PR TITLE
feat(hooks): block financial-data leaks under .beads/ + .claude/memory/

### DIFF
--- a/.claude/hooks/block-budget-leaks.sh
+++ b/.claude/hooks/block-budget-leaks.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block git commits that include dollar amounts or
+# quantitative cost data under .beads/ or .claude/memory/ paths.
+#
+# Caro is the only PUBLIC repo with beads + memory tracking. The budget-watch
+# system writes findings into beads/memory only after passing through the
+# redact.py filter — but if a human or another agent slips raw figures into
+# those paths, this hook is the last line of defense before they reach the
+# public mirror.
+#
+# Companion to ~/.claude/projects/-Users-kobik-private-workspace-caro/memory/
+#   feedback_no_finance_in_public_repos.md
+
+set -euo pipefail
+
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+  exit 0
+fi
+
+COMMAND="${CLAUDE_TOOL_PARAMS_COMMAND:-}"
+if [[ ! "$COMMAND" =~ git[[:space:]]+commit ]]; then
+  exit 0
+fi
+
+# Only act inside caro repo (let other repos use their own rules).
+ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
+if [[ ! "$ORIGIN_URL" =~ wildcard/caro ]]; then
+  exit 0
+fi
+
+# Patterns we refuse to commit into sensitive paths.
+# - dollar amounts:    $42, $1.5, $1,234
+# - explicit USD:      42 USD
+# - minute counts:     1234 minutes
+# - byte counts:       5 GB / 200 MB
+SENSITIVE_RE='\$[0-9]+([.,][0-9]+)?|\b[0-9]+[.,]?[0-9]*[[:space:]]*USD\b|\b[0-9]+[[:space:]]*(minutes?|mins?)\b|\b[0-9]+[[:space:]]*(GB|MB|TB|KB)\b'
+
+# Look only at staged files in protected paths.
+PROTECTED_FILES=$(git diff --cached --name-only --diff-filter=ACMRT 2>/dev/null \
+  | grep -E '^(\.beads/|\.claude/memory/)' || true)
+
+if [[ -z "$PROTECTED_FILES" ]]; then
+  exit 0
+fi
+
+# Scan staged diff (added lines only) for sensitive patterns.
+LEAK=$(git diff --cached --unified=0 -- $PROTECTED_FILES 2>/dev/null \
+  | grep -E '^\+' \
+  | grep -v '^\+\+\+' \
+  | grep -E -i "$SENSITIVE_RE" || true)
+
+if [[ -n "$LEAK" ]]; then
+  cat >&2 <<EOF
+
+🚫 BLOCKED: financial data detected in protected paths
+
+The following added lines under .beads/ or .claude/memory/ contain dollar
+amounts, USD totals, minute counts, or byte counts — caro is a PUBLIC repo
+and this data must stay in ~/.openclaw/workspace/budget/ only.
+
+$LEAK
+
+What to do:
+1. Run the content through the redaction filter:
+   python3 ~/.openclaw/workspace/budget/bin/redact.py < <(git diff --cached -- $PROTECTED_FILES)
+2. Update the staged file(s) with redacted versions.
+3. Re-stage and re-commit.
+
+If this is a false positive (e.g. a release-version reference like "v1.3.0"),
+unstage the affected line and commit it separately, or move the data to a
+private repo.
+
+See .claude/rules/git-workflow.md and the budget-watch feedback memory.
+
+EOF
+  exit 1
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,10 @@
           {
             "type": "command",
             "command": "./.claude/hooks/worktree-protection.sh"
+          },
+          {
+            "type": "command",
+            "command": "./.claude/hooks/block-budget-leaks.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds `.claude/hooks/block-budget-leaks.sh` — a PreToolUse Bash hook that
intercepts `git commit` invocations and rejects staged additions under
`.beads/` or `.claude/memory/` containing dollar amounts, USD totals, minute
counts, or byte counts. caro is the only public repo with active beads +
memory tracking, so it's the only realistic surface where vendor-spend data
could leak into a public mirror.

This is the live guard for a multi-vendor Budget Watch system whose state
lives privately under `~/.openclaw/workspace/budget/`. The system seeds
improvement findings into caro beads via the `budget-improvement` label —
**only after** passing through `~/.openclaw/workspace/budget/bin/redact.py`.
This hook is the last line of defence if a redaction is missed.

## What landed

- `.claude/hooks/block-budget-leaks.sh` — new (chmod 755). Mirrors the shape
  of `block-main-commits.sh` and `worktree-protection.sh` — exits 0 on
  non-`git commit` Bash, exits 0 outside `wildcard/caro`, only inspects
  files staged under `.beads/` or `.claude/memory/`, blocks (exit 1) with a
  helpful error if added lines match the sensitive-pattern regex.
- `.claude/settings.json` — registers the hook as the third entry in the
  Bash PreToolUse chain, after the existing main-branch and worktree
  guards.

## Why now

The user is wiring a multi-vendor budget guardrail (Vercel, GitHub,
Anthropic, OpenRouter, OpenAI) to protect financial stability across
projects. The constraint "don't expose sensitive info or financial data on
any public repo" was explicitly flagged when scoping the system. caro is
public; everything else stays private.

## Test plan

- Smoke-tested manually: hook exits 0 for non-`git commit` Bash, exits 0
  for `git commit` with no protected staged files. Will be exercised in
  anger when budget-improvement issues land in beads via the daily 22:00
  cron poll.
- 3 example beads issues already exist (P3, label `budget-improvement`):
  `caro-x06`, `caro-y10`, `caro-5iv` — all redacted, structural
  recommendations only.

## Companion artifacts (not in this PR)

- `~/.openclaw/workspace/budget/` — config + poll script + redaction filter
  (private, never committed).
- Remote trigger `trig_01CSvdJBRLa3tPGnV6fMyCF2` (Vercel spend reactor)
  reacts to webhooks via the PA's Gmail pipeline.
- `~/.claude/projects/-Users-kobik-private-workspace-caro/memory/`
  `project_budget_watch.md` + `feedback_no_finance_in_public_repos.md`
  document the constraint and operating model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PreToolUse Bash hook that blocks committing financial or usage data under `.beads/` and `.claude/memory/` in the public `caro` repo. Registers the hook in `.claude/settings.json` to prevent vendor-spend leaks.

- **New Features**
  - Added `.claude/hooks/block-budget-leaks.sh` (executable).
  - Runs only for `git commit` in `wildcard/caro`; scans staged changes under `.beads/` and `.claude/memory/`.
  - Blocks added lines with dollar amounts, explicit USD, minute counts, or byte sizes; prints offending lines and redaction steps.
  - Hook added to the PreToolUse chain after the main-branch and worktree guards.

<sup>Written for commit 5b48451e9b711a1e45b9bad48e30f0e841e4dbd6. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1028?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

