### PR TITLE
feat(devflow): incorporate swarm-forge patterns

### DIFF
--- a/.claude/commands/caro-coder-loop.md
+++ b/.claude/commands/caro-coder-loop.md
@@ -26,6 +26,7 @@ NEXT=$(bd ready --json 2>/dev/null | jq -r '.[] | select(.labels[]? == "v1.2.0")
 [ -z "$NEXT" ] && { echo "no ready v1.2.0 work"; exit 0; }
 bd claim "$NEXT"
 bd show "$NEXT"
+bin/notify coder "claim $NEXT"
 ```
 
 Capture:
@@ -90,6 +91,56 @@ When done:
 2. Report: files changed, tests added, clippy status, test pass count
 ```
 
+### 4.5. Reviewer gate (swarm-forge pattern)
+
+Before validating or opening a PR, spawn an independent **Reviewer** sub-agent
+via the Task tool. Borrowed from swarm-forge's Architect → Coder → **Reviewer**
+pipeline: the coder cannot self-approve.
+
+**Subagent**: `qa-testing-expert` (model: opus)
+
+**Reviewer prompt template:**
+
+```
+You are the REVIEWER gate for caro v1.2.0 task $NEXT (PR not yet opened).
+
+Working directory: $(pwd)
+Branch: $(git branch --show-current)
+Diff to review: `git diff main...HEAD`
+
+You MUST run, and your verdict MUST cite the actual output of:
+  1. `cargo fmt --all -- --check`
+  2. `cargo clippy --all-targets --all-features -- -D warnings`
+  3. `cargo test`
+  4. Constitution check: any change under `src/safety/` MUST have a
+     corresponding test added in the same diff (see
+     `.claude/rules/constitution.md` Tier-1 / `safety-pattern-developer`
+     skill).
+  5. Good-boy-scout check: the diff does not introduce obvious
+     nearby brokenness left unfixed.
+
+Return JSON on the LAST line of your reply:
+  {"verdict":"pass"} | {"verdict":"block","reasons":["...","..."]}
+
+Be terse. No PR is opened on `block` — instead the loop sends your
+reasons back to the coder for a fix pass.
+```
+
+Capture the verdict:
+
+```bash
+# Reviewer JSON is on the last line of the agent reply.
+# If verdict == block, do NOT open a PR. Append reasons to the
+# kraken/spark prompt and re-delegate (max 2 retries before bailing).
+if [ "$VERDICT" = "block" ]; then
+  bin/notify reviewer "block $NEXT: $REASONS"
+  # re-delegate to coder with $REASONS appended; on third block, mark blocked.
+  bd update "$NEXT" --status blocked --notes "reviewer blocked: $REASONS"
+  exit 1
+fi
+bin/notify reviewer "pass $NEXT"
+```
+
 ### 5. Validate locally
 
 ```bash
@@ -128,6 +179,7 @@ EOF
 )" --json url --jq .url)
 
 bd close "$NEXT" --notes "PR: $PR_URL"
+bin/notify coder "pr opened $PR_URL ($NEXT)"
 echo "✓ closed $NEXT → $PR_URL"
 ```
 

--- a/.claude/commands/caro-coder-loop.md
+++ b/.claude/commands/caro-coder-loop.md
@@ -113,9 +113,9 @@ You MUST run, and your verdict MUST cite the actual output of:
   2. `cargo clippy --all-targets --all-features -- -D warnings`
   3. `cargo test`
   4. Constitution check: any change under `src/safety/` MUST have a
-     corresponding test added in the same diff (see
-     `.claude/rules/constitution.md` Tier-1 / `safety-pattern-developer`
-     skill).
+     corresponding test added in the same diff (see the
+     `safety-pattern-developer` skill for the source-of-truth
+     requirement).
   5. Good-boy-scout check: the diff does not introduce obvious
      nearby brokenness left unfixed.
 
@@ -126,12 +126,23 @@ Be terse. No PR is opened on `block` — instead the loop sends your
 reasons back to the coder for a fix pass.
 ```
 
-Capture the verdict:
+Capture the verdict (concrete extraction):
 
 ```bash
-# Reviewer JSON is on the last line of the agent reply.
-# If verdict == block, do NOT open a PR. Append reasons to the
-# kraken/spark prompt and re-delegate (max 2 retries before bailing).
+# 1. Pipe the agent reply (stdout) to a file: $REVIEW_OUT
+# 2. Grab the LAST non-empty line — that's the verdict JSON
+LAST_LINE=$(grep -v '^$' "$REVIEW_OUT" | tail -1)
+
+# 3. Validate it parses as JSON; if not, treat as block (defensive default)
+if ! echo "$LAST_LINE" | jq -e . >/dev/null 2>&1; then
+  VERDICT="block"
+  REASONS="reviewer did not return valid JSON on last line: $LAST_LINE"
+else
+  VERDICT=$(echo "$LAST_LINE" | jq -r '.verdict // "block"')
+  REASONS=$(echo "$LAST_LINE" | jq -r '.reasons // [] | join("; ")')
+fi
+
+# 4. Branch on verdict
 if [ "$VERDICT" = "block" ]; then
   bin/notify reviewer "block $NEXT: $REASONS"
   # re-delegate to coder with $REASONS appended; on third block, mark blocked.

--- a/.claude/commands/pr-management-loop.md
+++ b/.claude/commands/pr-management-loop.md
@@ -60,6 +60,7 @@ git push --force-with-lease
 
 # Comment
 gh pr comment <number> --body "🔄 Rebased with main"
+bin/notify pr-mgmt "rebased PR #<number>"
 ```
 
 **CI Failing:**
@@ -92,6 +93,7 @@ gh pr comment <number> --body "Applied Kubic suggestion..."
 ```bash
 # If auto-merge enabled
 gh pr merge <number> --squash --auto
+bin/notify pr-mgmt "auto-merge queued PR #<number>"
 ```
 
 ## Example Session

--- a/.claude/commands/qa-automation-loop.md
+++ b/.claude/commands/qa-automation-loop.md
@@ -41,6 +41,15 @@ Expected behavior:
 - Reports findings in structured format
 ```
 
+Notify the shared log on profile start/end so other parallel sessions see
+this loop running:
+
+```bash
+bin/notify qa "spawn profile=$PROFILE"
+# ... profile run ...
+bin/notify qa "complete profile=$PROFILE findings=$N"
+```
+
 ### 3. Collect Results
 
 Each profile returns findings in format:
@@ -75,6 +84,7 @@ gh issue create \
   --title "[QA] ${title}" \
   --label "qa,${severity},${type}" \
   --body "${body}"
+bin/notify qa "issue opened severity=$severity title=\"$title\""
 ```
 
 Issue body template:

--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -1,0 +1,63 @@
+# Caro Constitution
+
+This file takes precedence over every other file in `.claude/rules/`.
+
+Read and obey the following subordinate documents in order. **If two
+subordinate documents conflict, the earlier one wins.**
+
+Borrowed from Uncle Bob's swarm-forge `constitution.prompt` pattern: a
+flat pile of rules has no precedence; a layered constitution does.
+
+---
+
+## Tier 1 — Project safety (highest priority)
+
+These rules protect the repository and the parallel-session workflow. They
+override anything below them.
+
+1. **[git-workflow.md](./git-workflow.md)** — Feature branches are mandatory.
+   Never commit to `main`. Enforced by a PreToolUse hook.
+
+## Tier 2 — Engineering discipline
+
+These rules govern how code is written, reviewed, and released.
+
+2. **[dev-process.md](./dev-process.md)** — Branch / PR / CI workflow,
+   conventional commits, code style.
+3. **[release-version-alignment.md](./release-version-alignment.md)** — The
+   6-file release checklist; every release PR touches all six files.
+4. **[adr-numbering.md](./adr-numbering.md)** — ADRs are sequential, no gaps;
+   renumber on merge if PRs land out of order.
+
+## Tier 3 — Workflow hygiene
+
+These rules govern session ergonomics and surface-level conventions. They
+yield to anything in Tier 1 or Tier 2.
+
+5. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
+   found it; do not gold-plate.
+6. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
+   Quick-Actions footer when stopping for user input.
+7. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
+   Escape `{` in shell snippets inside `.astro` / `.jsx` / `.tsx` templates
+   (esbuild treats it as a JSX expression boundary).
+
+---
+
+## How to use this file
+
+- A new agent or session should treat this constitution as the entry point
+  for `.claude/rules/`. Read this file first; it tells you which rules
+  exist and which one wins on a tie.
+- When you find that two rules genuinely conflict, follow the higher-tier
+  one and open a PR amending the lower-tier one so the conflict goes away.
+- When adding a new rule, place it in the correct tier and update this
+  index in the same PR — orphan rules default to no precedence and
+  therefore get ignored under contention.
+
+## Why this exists
+
+Inspired by [swarm-forge](https://github.com/unclebob/swarm-forge)'s
+constitution layering. With 7 rule files and 4–5 parallel Claude sessions,
+"first one I happen to load" is not a deterministic conflict resolution
+strategy; explicit precedence is.

--- a/.codespellignore
+++ b/.codespellignore
@@ -35,3 +35,4 @@ assomption
 teh
 delet
 aliged
+preserv

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,6 +26,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   mutation-test:
     name: cargo-mutants on src/safety/
@@ -56,7 +59,7 @@ jobs:
         run: |
           cargo mutants \
             --no-shuffle \
-            --timeout "${{ inputs.timeout || 300 }}" \
+            --timeout "${{ github.event.inputs.timeout || '300' }}" \
             --file 'src/safety/**/*.rs' \
             --output mutants.out \
             || true  # don't fail the job on survivors — we want the report

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,108 @@
+name: Safety Mutation Testing
+
+# Weekly mutation testing scoped to src/safety/.
+#
+# Inspired by swarm-forge's "Mutation Hunter" role: 52+ regex patterns
+# in src/safety/ are exactly the kind of code where a flipped boundary
+# or loosened character class is silent under green tests but lets a
+# dangerous command through in production. cargo-mutants runs each
+# mutation against the test suite and reports survivors — code paths
+# the tests do not actually pin down.
+#
+# Schedule: Monday 04:00 UTC (off-peak). Manually dispatchable.
+# Not per-PR — full mutation runs are too slow for the inner loop.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: 'Per-mutant timeout in seconds'
+        required: false
+        default: '300'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  mutation-test:
+    name: cargo-mutants on src/safety/
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-mutants-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+
+      - name: Run mutation tests on src/safety/
+        run: |
+          cargo mutants \
+            --no-shuffle \
+            --timeout "${{ inputs.timeout || 300 }}" \
+            --file 'src/safety/**/*.rs' \
+            --output mutants.out \
+            || true  # don't fail the job on survivors — we want the report
+
+      - name: Summarize results
+        id: summary
+        run: |
+          if [ -f mutants.out/outcomes.json ]; then
+            CAUGHT=$(jq '[.outcomes[] | select(.summary == "CAUGHT")] | length' mutants.out/outcomes.json)
+            MISSED=$(jq '[.outcomes[] | select(.summary == "MISSED")] | length' mutants.out/outcomes.json)
+            TIMEOUT=$(jq '[.outcomes[] | select(.summary == "TIMEOUT")] | length' mutants.out/outcomes.json)
+            UNVIABLE=$(jq '[.outcomes[] | select(.summary == "UNVIABLE")] | length' mutants.out/outcomes.json)
+            TOTAL=$((CAUGHT + MISSED + TIMEOUT + UNVIABLE))
+            echo "caught=$CAUGHT" >> "$GITHUB_OUTPUT"
+            echo "missed=$MISSED" >> "$GITHUB_OUTPUT"
+            echo "timeout=$TIMEOUT" >> "$GITHUB_OUTPUT"
+            echo "unviable=$UNVIABLE" >> "$GITHUB_OUTPUT"
+            echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Safety Mutation Testing Results"
+              echo ""
+              echo "| Outcome | Count |"
+              echo "|---------|-------|"
+              echo "| Caught (test killed mutant) | $CAUGHT |"
+              echo "| Missed (mutant survived — gap in tests) | $MISSED |"
+              echo "| Timeout | $TIMEOUT |"
+              echo "| Unviable | $UNVIABLE |"
+              echo "| **Total** | **$TOTAL** |"
+              echo ""
+              if [ "$MISSED" -gt 0 ]; then
+                echo "### Surviving mutants (action required)"
+                echo ""
+                echo '```'
+                jq -r '.outcomes[] | select(.summary == "MISSED") | "\(.scenario.mutant.file):\(.scenario.mutant.line) — \(.scenario.mutant.description)"' mutants.out/outcomes.json | head -50
+                echo '```'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No outcomes.json produced — likely cargo-mutants failure" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Upload mutants.out artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-out-${{ github.run_id }}
+          path: mutants.out/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ tests/evaluation/results/*.md
 .claude/credentials/
 .claude/.env
 .claude/cache/
+.claude/notifications.log
 
 # Codex CLI
 .codex/sessions/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,11 +128,13 @@ Check `.claude/memory/current-tasks.md` for active work items.
 
 ## Important Files to Know
 
+- `.claude/rules/constitution.md` - **Precedence index for all `.claude/rules/` files (read first)**
 - `src/safety/patterns.rs` - All dangerous command patterns
 - `src/prompts/command_templates.rs` - LLM prompt templates
 - `.claude/skills/` - Domain expertise (load on-demand)
 - `.claude/commands/` - Workflow commands
 - `.claude/beta-testing/` - Test infrastructure
+- `bin/notify` - Cross-session agent notification log helper
 
 ## Exploration Pattern
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test clean fmt lint audit check bench install
+.PHONY: help build test clean fmt lint audit check bench install test-mutants-safety
 
 # Default target
 help:
@@ -17,6 +17,7 @@ help:
 	@echo "  test-contract  - Run contract tests only"
 	@echo "  test-integration - Run integration tests only"
 	@echo "  test-property  - Run property-based tests only"
+	@echo "  test-mutants-safety - Mutation testing scoped to src/safety/ (slow, weekly)"
 	@echo "Quality Checks:"
 	@echo "  fmt       - Format code with rustfmt"
 	@echo "  lint      - Run clippy lints"
@@ -87,6 +88,15 @@ test-watch:
 	} || { \
 		echo "cargo-watch not found. Install with: cargo install cargo-watch"; \
 	}
+
+# Mutation testing — scoped to src/safety/ (52+ regex patterns where
+# a flipped boundary or loosened character class is silent under green
+# tests). Inspired by swarm-forge's "Mutation Hunter" role; runs weekly
+# on CI, not per-PR. Requires: cargo install cargo-mutants
+test-mutants-safety:
+	@command -v cargo-mutants >/dev/null 2>&1 || { \
+		echo "cargo-mutants not installed. Install with: cargo install cargo-mutants"; exit 1; }
+	cargo mutants --no-shuffle --timeout 300 --file 'src/safety/**/*.rs'
 
 # Code quality
 fmt:

--- a/bin/notify
+++ b/bin/notify
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Cross-session agent notification log.
+#
+# Inspired by swarm-forge's notify-agent.sh — gives parallel Claude sessions
+# (and humans) a single tail-able stream of who-did-what-when across all
+# agents, loops, and worktrees. Tail with:
+#
+#   tail -f .claude/notifications.log
+#
+# Usage:
+#   bin/notify <role> <message...>
+#
+# Examples:
+#   bin/notify coder "claim caro-xk0.1"
+#   bin/notify reviewer "block: clippy warning in src/safety/patterns.rs"
+#   bin/notify pr-mgmt "rebased PR #602"
+#
+# Environment:
+#   CARO_NOTIFY_LOG  override log path (default: <repo-root>/.claude/notifications.log)
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <role> <message...>" >&2
+  exit 2
+fi
+
+ROLE="$1"; shift
+MSG="${*:-}"
+
+if LOG="${CARO_NOTIFY_LOG:-}"; [ -z "$LOG" ]; then
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  LOG="$ROOT/.claude/notifications.log"
+fi
+
+mkdir -p "$(dirname "$LOG")"
+printf '%s | %-16s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ROLE" "$MSG" >> "$LOG"

--- a/website/src/config/types.ts
+++ b/website/src/config/types.ts
@@ -226,7 +226,7 @@ export interface HolidayEvent {
 
   /**
    * Rules for when to auto-select this theme as default.
-   * If no rules match, theme is available but not pre-selected.
+   * If no rules match, theme is available but not preselected.
    */
   defaultFor?: DefaultRule[];
 


### PR DESCRIPTION
## Summary

Adopts four practices from [unclebob/swarm-forge](https://github.com/unclebob/swarm-forge) that map onto our existing worktree + agent-loop infrastructure. No Rust runtime code touched — purely dev-flow tooling.

## What changed

### 1. Reviewer gate in `caro-coder-loop` (Architect → Coder → **Reviewer**)
`.claude/commands/caro-coder-loop.md` gets a new step **4.5** between coder delegation and PR open. Spawns the `qa-testing-expert` sub-agent with a constrained prompt: must run `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and check `.claude/rules/` violations. Returns JSON `{verdict: "pass"|"block", reasons: [...]}`. On block, the loop re-delegates to the coder with reasons appended; PR opens only on pass. Coder cannot self-approve.

### 2. Constitution precedence index
New `.claude/rules/constitution.md` mirrors swarm-forge's `constitution.prompt`. Organizes the 7 existing rule files into **3 tiers** (project safety / engineering / workflow hygiene) with explicit *"earlier file wins on conflict"*. Replaces the flat pile of rules — under 4–5 parallel sessions, "first one I happen to load" was non-deterministic.

CLAUDE.md now points to it under "Important Files to Know".

### 3. Mutation testing scoped to `src/safety/`
New `make test-mutants-safety` target + weekly `.github/workflows/mutation.yml` (Monday 04:00 UTC). Runs `cargo-mutants` over the 52+ regex patterns — exactly where a flipped `\b` boundary or loosened character class is silent under green tests but lets a dangerous command through in production. Workflow summarizes survivors in the run page and uploads `mutants.out` as an artifact. Not per-PR (too slow).

Inspired by swarm-forge's "Mutation Hunter" role, scoped to our highest-risk subsystem.

### 4. Cross-session notification log (`bin/notify`)
~15-line bash helper that appends `ISO8601 | role | message` lines to `.claude/notifications.log` (gitignored). Mirrors swarm-forge's `notify-agent.sh`. Tail with `tail -f .claude/notifications.log`.

Wired into:
- `caro-coder-loop` — claim, reviewer pass/block, PR opened
- `qa-automation-loop` — profile spawn/complete, issue creation
- `pr-management-loop` — rebase, auto-merge

## Explicitly NOT adopted

| Skipped | Why |
|---|---|
| Tmux pane orchestration | Multiple Claude sessions already give multi-pane visibility |
| 3-role topology (architect/coder/reviewer only) | Our 29 specialized agents are richer than swarm-forge's by design |
| Gherkin `features/*.feature` files | spec-kitty narrative format is established and integrated |
| CRAP metric tooling | clippy `cognitive_complexity` already covers ~80% of the value |

## Files changed

| Type | File |
|---|---|
| New | `.claude/rules/constitution.md` |
| New | `.github/workflows/mutation.yml` |
| New | `bin/notify` (executable) |
| Modify | `.claude/commands/caro-coder-loop.md` (reviewer gate + notify hooks) |
| Modify | `.claude/commands/qa-automation-loop.md` (notify hooks) |
| Modify | `.claude/commands/pr-management-loop.md` (notify hooks) |
| Modify | `CLAUDE.md` (constitution + notify pointers) |
| Modify | `Makefile` (test-mutants-safety target + help text) |
| Modify | `.gitignore` (.claude/notifications.log) |

## Test plan

- [x] `bin/notify` smoke test: writes correctly formatted line to log
- [x] `make help` advertises `test-mutants-safety`
- [x] `mutation.yml` validates as YAML
- [x] Constitution index references all 7 existing rule files in correct tiers
- [ ] Trigger `mutation.yml` via `workflow_dispatch` to confirm cargo-mutants runs cleanly on `src/safety/` (will run once first)
- [ ] Run `caro-coder-loop` against a stub task with intentional clippy warning to confirm reviewer blocks PR open

## Source

- https://github.com/unclebob/swarm-forge
- https://github.com/unclebob/swarm-forge/blob/main/SwarmForgeInitSpec.md
- https://pyshine.com/Swarm-Forge-Uncle-Bobs-AI-Agent-Coordinator/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXrAVMVdnHFUVn7Zasrsgd)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates four Swarm‑Forge patterns into our dev flow to harden reviews, tests, and session visibility. Also unblocks Check Spelling by ignoring a deliberate `preserv` regex and fixing a small typo; no Rust runtime changes.

- New Features
  - Reviewer gate in `caro-coder-loop`: independent `qa-testing-expert` runs `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and constitution checks; extracts last-line JSON, validates with `jq`, defaults to block if invalid; coder cannot self-approve; sends notifications.
  - Constitution precedence index: `.claude/rules/constitution.md` defines 3 tiers with explicit conflict order; linked from `CLAUDE.md`.
  - Safety mutation testing: weekly `cargo-mutants` on `src/safety/**`; workflow sets `permissions: contents: read` and a safe default timeout; `make test-mutants-safety` for local runs.
  - Cross-session notifications: `bin/notify` appends to `.claude/notifications.log`; wired into coder, QA, and PR management loops.

- Bug Fixes
  - Codespell: add `.codespellignore` entry for intentional `preserv` regex prefix to unblock CI.
  - Website: “preselected” typo fix in `website/src/config/types.ts`.

<sup>Written for commit 5731b260ac2f82654063b78348689c468bb3e683. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1030?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

