### PR TITLE
fix(safety): block chmod -R 777 / and other recursive chmod variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
  "mlx-rs",
  "once_cell",
  "os_info",
+ "predicates",
  "proptest",
  "regex",
  "reqwest 0.11.27",
@@ -3450,6 +3451,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6198,6 +6208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7182,7 +7198,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/src/safety/patterns.rs
+++ b/src/safety/patterns.rs
@@ -72,7 +72,12 @@ pub static DANGEROUS_PATTERNS: Lazy<Vec<DangerPattern>> = Lazy::new(|| {
             shell_specific: None,
         },
         DangerPattern {
-            pattern: r"chmod\s+777\s+/".to_string(),
+            // Match `chmod 777 /` with any combination of intervening flag
+            // tokens (e.g. `-R`, `-Rfv`, `--recursive`). The optional
+            // `(?:\s+-{1,2}\S+)*` group is what closes caro#1034: the prior
+            // pattern only matched the bare `chmod 777 /` form and silently
+            // let the recursive variant pass under --safety strict.
+            pattern: r"chmod(?:\s+-{1,2}\S+)*\s+0?777\s+/".to_string(),
             risk_level: RiskLevel::High,
             description: "Recursive permission change from root".to_string(),
             shell_specific: None,
@@ -463,5 +468,41 @@ mod tests {
     fn test_critical_patterns_exist() {
         let critical = get_patterns_by_risk(RiskLevel::Critical);
         assert!(!critical.is_empty(), "Should have critical risk patterns");
+    }
+
+    /// Returns true when at least one built-in pattern of risk High or
+    /// Critical matches `command`. Strict safety mode blocks anything at
+    /// or above High, so this mirrors the gate that user-facing strict
+    /// mode applies.
+    fn matches_high_or_critical(command: &str) -> bool {
+        DANGEROUS_PATTERNS.iter().any(|p| {
+            p.risk_level >= RiskLevel::High
+                && regex::Regex::new(&p.pattern)
+                    .map(|r| r.is_match(command))
+                    .unwrap_or(false)
+        })
+    }
+
+    /// Regression test for caro#1034: `chmod -R 777 /` and recursive
+    /// variants must be blocked under strict mode (High or Critical risk).
+    /// Prior to the fix, the pattern at line 75 only matched literal
+    /// `chmod 777 /` with no flags, so the recursive form silently passed.
+    #[test]
+    fn test_chmod_recursive_root_blocked_strict() {
+        let must_block = [
+            "chmod 777 /",             // existing behavior (regression-protect)
+            "chmod -R 777 /",          // canonical bypass from #1034
+            "chmod -Rfv 777 /",        // combined short flags
+            "chmod --recursive 777 /", // GNU long flag
+            "chmod -R 0777 /",         // 4-digit octal, recursive
+        ];
+
+        for cmd in must_block {
+            assert!(
+                matches_high_or_critical(cmd),
+                "command {cmd:?} must match at least one High-or-Critical pattern \
+                 (would be blocked by --safety strict)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1034 — a P0 safety regression where `chmod -R 777 /` and other recursive `chmod` variants silently bypassed `--safety strict`.

The HIGH-risk pattern at [`src/safety/patterns.rs:75`](src/safety/patterns.rs:75) only matched bare `chmod 777 /` with no flags. Any token between `chmod` and `777` (`-R`, `-Rfv`, `--recursive`) caused the regex to miss, so caro happily generated and dry-ran the most dangerous form of the five canonical dangerous commands the project's safety story is built around.

## What changed

| File | Change |
|------|--------|
| `src/safety/patterns.rs:75` | Regex now allows zero-or-more intervening flag tokens and an optional leading `0` on the octal mode |
| `src/safety/patterns.rs` (tests) | New unit test `test_chmod_recursive_root_blocked_strict` covering five variants + regression-protecting the bare form |
| `Cargo.lock` | Refresh to materialize `predicates = \"3\"` entry from Cargo.toml (added in #913, never locked) |

### Regex change

```diff
- pattern: r\"chmod\\s+777\\s+/\"
+ pattern: r\"chmod(?:\\s+-{1,2}\\S+)*\\s+0?777\\s+/\"
```

The non-capturing `(?:\\s+-{1,2}\\S+)*` group matches zero-or-more flag tokens, both short (`-R`, `-Rfv`) and long (`--recursive`). Risk level stays HIGH so strict mode keeps blocking; moderate and permissive modes are unaffected.

## Test cases now blocked

- `chmod 777 /` (regression-protected — the existing form keeps working)
- `chmod -R 777 /` (the canonical bypass from #1034)
- `chmod -Rfv 777 /` (combined short flags)
- `chmod --recursive 777 /` (GNU long flag)
- `chmod -R 0777 /` (4-digit octal with recursive flag)

## Verification

```
cargo test --lib safety::patterns::tests::test_chmod_recursive_root_blocked_strict  # GREEN
cargo test --lib                                                                      # 519 passed, 0 failed
cargo clippy --lib -- -D warnings                                                     # clean
cargo fmt -- --check                                                                  # clean
```

End-to-end against the release binary, all five variants now error with `Unsafe command detected: Detected ... High risk level (recursive, privilege escalation)` under `--safety strict --dry-run`.

## Scope discipline

- **In scope:** the line-75 pattern, a focused unit test, the Cargo.lock catch-up.
- **Out of scope (filed mentally for follow-up):**
  - `tests/website_claims.rs:817` (`test_example_safety_002_blocks_chmod_777`) is a non-asserting test — it prints \"WARNING\" but never fails — which is why this regression slipped past CI. Worth converting to a real assertion in a separate PR.
  - The MODERATE pattern at `src/safety/patterns.rs:291` (`chmod\\s+[0-7]{3,4}\\s+`) has the same `\\s+` rigidity and won't match `chmod -R 755 /etc`. Lower priority since the HIGH/Critical pattern at line 69 already catches `chmod` against `/etc` etc., but worth a separate audit pass.

## Test plan

- [x] Failing test added first (RED), then fix made it pass (GREEN)
- [x] Full lib test suite passes (519/519)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` clean
- [x] End-to-end repro from #1034 verified via release binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a P0 safety regression where recursive root `chmod` commands (e.g., `chmod -R 777 /`) were not blocked under strict mode. Closes #1034.

- **Bug Fixes**
  - Generalized the high‑risk `chmod` regex to allow flag tokens and an optional leading 0, blocking forms like `chmod -R 777 /`, `chmod --recursive 777 /`, and `chmod -R 0777 /`.
  - Added unit test `test_chmod_recursive_root_blocked_strict` covering five variants, including the bare `chmod 777 /`.
  - Refreshed `Cargo.lock` to include the `predicates` dependency.

<sup>Written for commit 509820287956f325e7180d5039212f6fc439beb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

