### PR TITLE
chore(ci): migrate release.yml + safety-validation.yml to setup-rust composite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
             echo "Found tag: $TAG (version: $VERSION)"
           fi
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          cache-key-suffix: release-prepare
 
       - name: Verify version consistency
         run: |
@@ -195,27 +195,11 @@ jobs:
         with:
           ref: ${{ needs.prepare-release.outputs.tag }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
           targets: ${{ matrix.target }}
-
-      - name: Determine Rust version
-        id: rust-version
-        run: echo "version=$(rustc --version)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ steps.rust-version.outputs.version }}-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ steps.rust-version.outputs.version }}-index-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: release-build-${{ matrix.target }}
 
       - name: Install cross (for cross-compilation)
         if: matrix.target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/safety-validation.yml
+++ b/.github/workflows/safety-validation.yml
@@ -62,21 +62,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/setup-rust
         with:
-          components: rustfmt, clippy
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
+          components: rustfmt,clippy
+          cache-key-suffix: safety-pattern
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-safety-pattern-
             ${{ runner.os }}-cargo-
 
       - name: Check pattern compilation
@@ -105,18 +96,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: safety-build
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-safety-build-
+            ${{ runner.os }}-cargo-
 
       - name: Build release binary
         run: cargo build --release
@@ -147,18 +132,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: safety-build
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-safety-build-
+            ${{ runner.os }}-cargo-
 
       - name: Build release binary
         run: cargo build --release
@@ -187,18 +166,12 @@ jobs:
           fetch-depth: 0  # Need full history for baseline comparison
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: safety-build
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-safety-build-
+            ${{ runner.os }}-cargo-
 
       - name: Build release binary
         run: cargo build --release


### PR DESCRIPTION
## Summary

**Stacks on top of #1032.** Migrates two more workflows to the `setup-rust` composite action introduced in that PR. Net **−43 LOC**, 5 jobs migrated.

| Workflow | Job | Before |
|---|---|---|
| `release.yml` | `prepare-release` | dtolnay + (no cache) |
| `release.yml` | `build-and-upload` | dtolnay + 2 separate `actions/cache@v5` steps (registry + index) |
| `safety-validation.yml` | `pattern-compilation` | dtolnay + components + cache@v5 + restore-keys |
| `safety-validation.yml` | `static-matcher-tests` | dtolnay + cache@v5 |
| `safety-validation.yml` | `embedded-backend-tests` | dtolnay + cache@v5 |
| `safety-validation.yml` | `regression-check` | dtolnay + cache@v5 |

After: every job uses `uses: ./.github/actions/setup-rust` with a per-job `cache-key-suffix`. The composite owns toolchain install + cache + (optional) protobuf install.

### Cache shape change

Before: `safety-validation.yml` cached `~/.cargo/bin/, registry/index/, registry/cache/, git/db/, target/`. The composite caches `~/.cargo/registry, ~/.cargo/git, target` (matches `ci.yml`). One-time cache miss on first post-merge run, then unified shape forever.

`cache-restore-keys` are configured to fall back to the legacy `<os>-cargo-` prefix so even the first run can salvage some of the registry contents.

### `release.yml` notes

- The `build-and-upload` job previously had a *version-aware* cache key (`<os>-<target>-<rustc-version>-registry-...`). The composite drops `<rustc-version>` from the key. This is fine because `Cargo.lock` is part of the key — and Rust toolchain bumps will already invalidate via the rustup install step.
- The job's previous strategy of caching `~/.cargo/registry` and `~/.cargo/git` separately is consolidated into one cache entry that also includes `target/`, which **adds** target caching on release builds — net positive for build time.

### Stacking strategy

Base branch is `claude/learn-warp-dev-process-eA69f` (PR #1032), not `main`. After #1032 merges, GitHub will auto-rebase this onto main. If the user prefers, this PR can be re-pointed to `main` after #1032 lands.

## Test plan

- [ ] Wait for #1032 to merge first (the composite action must exist on the base ref).
- [ ] Verify CI on this PR. The `Safety Pattern Validation` workflow runs on PRs that touch `src/safety/**` — to actually exercise the migrated jobs, may need to trigger via `workflow_dispatch` or a follow-up commit touching `src/safety/`.
- [ ] Verify the `Release` workflow only runs on `workflow_run` from `Publish to crates.io` — won't fire on this PR. Manual test plan: dry-run `gh workflow run release.yml --ref <commit-sha> -f tag=v9.9.9-test`.
- [ ] Confirm `Setup Rust` step appears in any failing job output (proof composite resolved correctly).

## Out of scope

- `installer.yml`, `llm-tests.yml`, `website-claims.yml`, `dependency-review.yml`, `publish.yml` — also use `dtolnay/rust-toolchain` and would benefit from migration. Queued for separate follow-up PRs to keep blast radius small.
- Extracting a `_reusable-rust-checks.yml` workflow (`workflow_call: true`). Composite action is the right primitive for now; reusable workflows make sense once 5+ workflows share *the entire job graph*, not just the toolchain step.

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate `release.yml` and `safety-validation.yml` to the shared `./.github/actions/setup-rust` composite for toolchain setup and caching. This simplifies CI (−43 LOC), unifies cache shape, and speeds up release builds by caching `target/`.

- **Refactors**
  - Migrated 5 jobs to `./.github/actions/setup-rust` with per-job `cache-key-suffix`.
  - Replaced `dtolnay/rust-toolchain` and `actions/cache@v5`; composite handles toolchain, components, targets, and cache.
  - Unified cache to `~/.cargo/registry`, `~/.cargo/git`, and `target/`; release builds now cache `target/`.
  - Cache key drops rustc version; `Cargo.lock` drives invalidation with restore keys falling back to `<os>-cargo-`.
  - Preserves stable toolchain and `rustfmt,clippy` where needed.

<sup>Written for commit 48514a2ad37ee036cc27ed119df71b9e153e5621. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

