### PR TITLE
feat(automation): add /caro slash-command router (oz-for-oss Pattern 3)

### DIFF
--- a/.github/SLASH_COMMANDS.md
+++ b/.github/SLASH_COMMANDS.md
@@ -1,0 +1,76 @@
+# /caro slash commands
+
+Comment `/caro <command> [args]` on any issue or PR to invoke an automated
+workflow. Implemented by `.github/workflows/slash-router.yml`. Inspired by
+[`warpdotdev/oz-for-oss`](https://github.com/warpdotdev/oz-for-oss)'s
+`/oz-verify` pattern.
+
+## Available commands
+
+| Command | Description | Status |
+|---|---|---|
+| `/caro help` | Show the command list as a comment | ✅ available |
+| `/caro echo <text>` | Echo `<text>` back (proves routing works end-to-end) | ✅ available |
+| `/caro version` | Show caro version from Cargo.toml | ✅ available |
+| `/caro review` | Trigger multi-agent code review | 🛠 planned |
+| `/caro qa` | Run QA investigation against this PR | 🛠 planned |
+| `/caro spec` | Generate a spec from the linked issue | 🛠 planned |
+| `/caro tune-prompt` | Run prompt-tuner against test failures | 🛠 planned |
+| `/caro release-acceptance` | Audit release readiness | 🛠 planned |
+
+## Feedback signals
+
+Every recognised command gets immediate feedback:
+- 👀 **eyes** reaction on the original comment when the router accepts the
+  command
+- 👍 **+1** reaction when the handler succeeds
+- A reply comment with the result (or an error if the handler failed)
+
+Unknown commands fall through to `help` with an "Unknown command" hint.
+
+## Adding a new command
+
+1. **Whitelist** the command name in `slash-router.yml::parse::Parse command`
+   (the bash `case` statement). Without this it falls through to
+   `help-unknown`.
+2. **Add a handler job** to `slash-router.yml`:
+   ```yaml
+   <name>:
+     name: /caro <name>
+     needs: parse
+     if: needs.parse.outputs.command == '<name>'
+     runs-on: ubuntu-latest
+     steps:
+       - # … your handler …
+   ```
+3. **Update this file's table** to document the command.
+4. **Reuse existing skills**: prefer mapping the slash command to an existing
+   `.claude/skills/<name>/SKILL.md` rather than implementing logic in the
+   workflow. The handler should `gh workflow run`, `repository_dispatch`, or
+   shell out to a runner script — keep YAML thin.
+
+## Permissions
+
+The router runs with `issues: write`, `pull-requests: write`, `contents: read`.
+Handlers that need more (e.g. `actions: write` to dispatch other workflows)
+should set `permissions:` at the **job** level, not workflow level — keep the
+default surface small.
+
+## Future: agent dispatch
+
+Long-running handlers (review, QA, spec generation) should:
+1. Acknowledge the command synchronously (post a comment "starting…")
+2. Dispatch the actual work via `repository_dispatch` to a dedicated workflow
+3. Report back when the dispatched run completes
+
+This pattern keeps the slash router cheap (~30s per invocation) and makes
+each handler independently retriable. See
+[oz-for-oss `respond-to-pr-comment-local.yml`](https://github.com/warpdotdev/oz-for-oss/tree/main/.github/workflows)
+for a reference implementation we can mirror.
+
+## Auth
+
+Currently uses `GITHUB_TOKEN` (the default workflow token). When we land
+Pattern 5 (GitHub App auth), this will switch to `CARO_BOT_APP_KEY` so
+comments and reactions are attributed to "caro-bot" instead of
+"github-actions[bot]".

--- a/.github/workflows/slash-router.yml
+++ b/.github/workflows/slash-router.yml
@@ -1,0 +1,183 @@
+name: Slash Command Router
+
+# Inspired by warpdotdev/oz-for-oss's `/oz-verify` pattern.
+# Listens on issue and PR comments for `/caro <command> [args]` and dispatches
+# to per-command handlers. Initially supports help/echo/version as a routing
+# scaffold; future PRs wire up handlers for /caro review, /caro qa,
+# /caro spec, /caro tune-prompt, /caro release-acceptance — each maps to an
+# existing skill in .claude/skills/ or agent in .claude/agents/.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # Serialize per-issue/PR so two simultaneous /caro commands don't collide.
+  group: slash-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  parse:
+    name: Parse /caro command
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/caro ') || github.event.comment.body == '/caro'
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+      args: ${{ steps.parse.outputs.args }}
+      is_pr: ${{ steps.parse.outputs.is_pr }}
+    steps:
+      - name: Add 'eyes' reaction (acknowledgement)
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Parse command and args
+        id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # Strip leading "/caro " (or just "/caro"); take first token as command,
+          # remainder as args. Defaults command to "help" when no token.
+          line="${BODY#/caro}"
+          line="${line# }"
+          command="${line%% *}"
+          if [ -z "$command" ]; then
+            command="help"
+            args=""
+          else
+            args="${line#"$command"}"
+            args="${args# }"
+          fi
+          # Whitelist allowed commands -- unknown commands fall through to help
+          # with an "unknown command" hint.
+          case "$command" in
+            help|echo|version) ;;
+            *) args="$command $args"; command="help-unknown" ;;
+          esac
+          echo "command=$command" >> "$GITHUB_OUTPUT"
+          # Multi-line-safe arg passing
+          {
+            echo "args<<EOF"
+            echo "$args"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          # Detect PR vs issue (issue_comment fires for both; PRs have pull_request key)
+          if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  help:
+    name: /caro help
+    needs: parse
+    if: needs.parse.outputs.command == 'help' || needs.parse.outputs.command == 'help-unknown'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reply with command list
+        uses: actions/github-script@v8
+        env:
+          UNKNOWN_HINT: ${{ needs.parse.outputs.command == 'help-unknown' && needs.parse.outputs.args || '' }}
+        with:
+          script: |
+            const unknown = process.env.UNKNOWN_HINT.trim();
+            const prefix = unknown
+              ? `Unknown command: \`/caro ${unknown.split(' ')[0]}\`. Available commands:\n\n`
+              : `Available **/caro** commands:\n\n`;
+            const body = prefix + [
+              '| Command | Description | Status |',
+              '|---|---|---|',
+              '| `/caro help` | Show this help text | ✅ available |',
+              '| `/caro echo <text>` | Echo `<text>` back as a comment | ✅ available |',
+              '| `/caro version` | Show caro version from Cargo.toml | ✅ available |',
+              '| `/caro review` | Run a multi-agent code review | 🛠 planned |',
+              '| `/caro qa` | Run QA investigation against this PR | 🛠 planned |',
+              '| `/caro spec` | Generate a spec from the linked issue | 🛠 planned |',
+              '| `/caro tune-prompt` | Run prompt-tuner against test failures | 🛠 planned |',
+              '| `/caro release-acceptance` | Audit release readiness | 🛠 planned |',
+              '',
+              '_Inspired by [oz-for-oss](https://github.com/warpdotdev/oz-for-oss)._'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+  echo:
+    name: /caro echo
+    needs: parse
+    if: needs.parse.outputs.command == 'echo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo args back
+        uses: actions/github-script@v8
+        env:
+          ARGS: ${{ needs.parse.outputs.args }}
+        with:
+          script: |
+            const args = process.env.ARGS || '(no args)';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🔊 \`${args}\``
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+  version:
+    name: /caro version
+    needs: parse
+    if: needs.parse.outputs.command == 'version'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read Cargo.toml version
+        id: ver
+        run: |
+          v=$(grep -m1 '^version *= *"' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+      - name: Reply with version
+        uses: actions/github-script@v8
+        env:
+          VERSION: ${{ steps.ver.outputs.value }}
+          SHA: ${{ github.sha }}
+        with:
+          script: |
+            const v = process.env.VERSION;
+            const sha = process.env.SHA.slice(0, 7);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `📦 caro **v${v}** (default branch \`${sha}\`)`
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });


### PR DESCRIPTION
## Summary

Adopts **Pattern 3** from [`warpdotdev/oz-for-oss`](https://github.com/warpdotdev/oz-for-oss): comment-driven slash commands. Comment `/caro <command> [args]` on any issue or PR; a router workflow parses, dispatches to a handler job, and replies with reactions + a comment.

Independent of [#1032](https://github.com/wildcard/caro/pull/1032) and [#1040](https://github.com/wildcard/caro/pull/1040) — no shared files, branched off `main`.

### What ships

- `.github/workflows/slash-router.yml` — the router. Triggers on `issue_comment`. Parses `/caro <cmd> [args]`, whitelists known commands, and fans out to per-command jobs.
- `.github/SLASH_COMMANDS.md` — contract documentation and the "adding a new command" recipe.

### Initial commands (intentionally minimal — just the routing primitive)

| Command | Behaviour |
|---|---|
| `/caro help` | Posts a comment with the command table |
| `/caro echo <text>` | Echoes `<text>` back (proves parsing → reply pipeline) |
| `/caro version` | Reads `Cargo.toml` version and posts it |

Unknown commands fall through to `help` with an "Unknown command" hint.

### Feedback signals

- 👀 reaction immediately on the original comment when the router accepts
- 👍 reaction when the handler succeeds
- A reply comment with the result

### Why minimal

Future PRs wire up the *real* handlers — `/caro review`, `/caro qa`, `/caro spec`, `/caro tune-prompt`, `/caro release-acceptance` — each mapping to an existing `.claude/skills/` entry. Per the oz-for-oss pattern, long-running handlers should dispatch via `repository_dispatch` to dedicated workflows so the router stays cheap (~30s per invocation) and each handler is independently retriable. Documented in `.github/SLASH_COMMANDS.md`.

### Auth

Uses `GITHUB_TOKEN` (default workflow token). When we land Pattern 5 (GitHub App), this will switch to `CARO_BOT_APP_KEY` so comments are attributed to a "caro-bot" identity rather than `github-actions[bot]`.

## Test plan

- [ ] Comment `/caro help` on this PR after merge — expect a comment + 👀 then 👍 reactions on the original.
- [ ] Comment `/caro echo hello world` — expect a `🔊 hello world` reply.
- [ ] Comment `/caro version` — expect `📦 caro vX.Y.Z (default branch <sha>)`.
- [ ] Comment `/caro nonexistent` — expect the help table prefixed with "Unknown command: `/caro nonexistent`".
- [ ] Comment something not starting with `/caro ` — workflow should not run (no spurious notifications).
- [ ] Verify the router does NOT collide with the existing `cla.yml` `issue_comment` handler (different trigger paths: CLA matches an exact signature line; this matches `/caro ` prefix).

## Out of scope

- Real handlers (`/caro review`, `/caro qa`, etc.) — separate PRs each.
- `pull_request_review_comment` trigger — only `issue_comment` for now (covers regular PR conversation comments and issue comments).
- GitHub App auth — Pattern 5, separate PR.

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/caro` slash-command router GitHub Action that listens to issue and PR comments, parses commands, and replies with reactions and a comment. Ships `help`, `echo`, and `version` to prove the end-to-end flow; unknown commands fall back to help.

- **New Features**
  - Added `.github/workflows/slash-router.yml` to parse `/caro <command> [args]`, whitelist commands, and dispatch to per-command jobs with 👀 on accept and 👍 on success.
  - Initial commands: `/caro help`, `/caro echo <text>`, `/caro version` (reads from `Cargo.toml`).
  - Documented contract and “add a command” steps in `.github/SLASH_COMMANDS.md`.
  - Safe defaults: `GITHUB_TOKEN`, scoped permissions, per-thread concurrency, and no-op on non-`/caro` comments.

<sup>Written for commit e209b2f955709a4f441324a308fcf9e4fe285d02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

