### PR TITLE
fix(safety): v1.3.1 patch — chmod -R bypass, exit codes, test hardening

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -35,3 +35,4 @@ assomption
 teh
 delet
 aliged
+preserv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     variants (`gpart show`, `zfs list`, `pkg info`, etc.). Pattern total
     grows from 52 → 62.
 
+## [1.3.1] - 2026-05-09
+
+### Fixed
+
+- **P0 safety regression**: `chmod -R 777 /` and `chmod -R <mode> /` variants now
+  correctly match the dangerous-pattern list. The original `chmod 777 /` pattern
+  did not account for the `-R` (recursive) flag, allowing world-writable
+  root-directory commands to pass through `--safety strict`. Two patterns added:
+  one that handles optional flag prefixes before the mode (`chmod (-flags)* 777 /`)
+  and one that broadly catches any recursive chmod on the root
+  (`chmod -R <mode> /`). Closes #1034.
+- **P1 exit-code regression**: Unsafe commands detected by the static matcher
+  now propagate as `Err` immediately instead of silently falling through to the
+  LLM backend. Previously, `GeneratorError::Unsafe` was caught by the
+  `BackendUnavailable` fall-through arm in the agent loop, causing the LLM to
+  re-attempt a command that was already known dangerous, and the final exit code
+  to be 0 even when an error was printed to stderr. Closes #1035.
+- **P1 non-asserting safety test**: `test_example_safety_002_blocks_chmod_777` in
+  `tests/website_claims.rs` printed `WARNING: not blocked` instead of failing the
+  test. The `println!` has been replaced with `assert!`, turning the silent watch
+  into an enforced regression guard. Closes #1037.
+- **P2 CLAUDE.md version banner**: `CLAUDE.md` incorrectly displayed version
+  `1.1.0 (GA)` since that file was not part of the release version checklist.
+  Updated to `1.3.0`. Closes #1044.
+
 ## [1.3.0] - 2026-04-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ A Rust CLI that converts natural language descriptions into safe POSIX shell com
 
 - **Language**: Rust (edition 2021, MSRV 1.83)
 - **License**: AGPL-3.0
-- **Version**: 1.1.0 (GA)
+- **Version**: 1.3.0 (GA)
 - **Crate**: [crates.io/crates/caro](https://crates.io/crates/caro)
 
 ## Key Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "caro"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -1476,6 +1476,7 @@ dependencies = [
  "mlx-rs",
  "once_cell",
  "os_info",
+ "predicates",
  "proptest",
  "regex",
  "reqwest 0.11.27",
@@ -3450,6 +3451,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6198,6 +6208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7182,7 +7198,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caro"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 rust-version = "1.83"
 description = "Convert natural language to shell commands using local LLMs"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Have questions or want to discuss caro with other users? Join the community!
   - - **[Documentation](https://caro.sh)** - Check out our comprehensive docs
 ## 📋 Project Status
 
-**Current Version:** 1.3.0 (General Availability)
+**Current Version:** 1.3.1 (General Availability)
 
 This project is **generally available** with all core features implemented, tested, and working. The CLI achieves 93.1% pass rate on comprehensive test suite with zero false positives in safety validation.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Caro Development Roadmap
 
-**Last Updated**: April 20, 2026
+**Last Updated**: May 9, 2026
 
 > **Recent Update**: Integrated 104 PRs (#557-660) into roadmap with milestone assignments and tracking issues.
 
@@ -297,6 +297,7 @@ gantt
 
 | Milestone | Due Date | Items (Issues + PRs) | Complete | Progress | Status |
 |-----------|----------|---------------------|----------|----------|---------|
+| **v1.3.1** | May 9, 2026 | P0/P1 safety patch | 4 | 100% | ✅ **RELEASED** |
 | **v1.3.0** | Apr 20, 2026 | `caro ai` + `caro shell-init` | 1 | 100% | ✅ **RELEASED** |
 | **v1.2.0** | Mar 26, 2026 | Docs & website launch | — | 100% | ✅ **RELEASED** |
 | **v1.1.2** | Jan 15, 2026 | 5 | 5 | 100% | ✅ **RELEASED** |

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -87,7 +87,7 @@ When releasing a new version of caro:
 
 ```bash
 # Download and compute checksums for a release
-VERSION=1.3.0
+VERSION=1.3.1
 for platform in macos-silicon macos-intel linux-amd64 linux-arm64; do
   curl -sL "https://github.com/wildcard/caro/releases/download/v${VERSION}/caro-${VERSION}-${platform}" | sha256sum
 done

--- a/nuget/tools/install.ps1
+++ b/nuget/tools/install.ps1
@@ -1,6 +1,6 @@
 # Download and install caro binary for Windows
 param(
-    [string]$Version = "1.3.0",
+    [string]$Version = "1.3.1",
     [string]$InstallPath = $PSScriptRoot
 )
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -234,8 +234,13 @@ impl AgentLoop {
 
                     return Ok(command);
                 }
+                Err(GeneratorError::BackendUnavailable { .. }) => {
+                    debug!("Static matcher: no match, falling back to LLM");
+                }
                 Err(e) => {
-                    debug!("Static matcher: no match ({}), falling back to LLM", e);
+                    // Security rejections (Unsafe, ValidationFailed) must not fall through
+                    // to the LLM — the LLM might generate the same dangerous command.
+                    return Err(e);
                 }
             }
         }

--- a/src/safety/patterns.rs
+++ b/src/safety/patterns.rs
@@ -74,7 +74,8 @@ pub static DANGEROUS_PATTERNS: Lazy<Vec<DangerPattern>> = Lazy::new(|| {
         DangerPattern {
             pattern: r"chmod\s+(-[rRfvn]+\s+)*777\s+/".to_string(),
             risk_level: RiskLevel::High,
-            description: "Permission change making root world-writable (recursive or direct)".to_string(),
+            description: "Permission change making root world-writable (recursive or direct)"
+                .to_string(),
             shell_specific: None,
         },
         DangerPattern {

--- a/src/safety/patterns.rs
+++ b/src/safety/patterns.rs
@@ -72,9 +72,15 @@ pub static DANGEROUS_PATTERNS: Lazy<Vec<DangerPattern>> = Lazy::new(|| {
             shell_specific: None,
         },
         DangerPattern {
-            pattern: r"chmod\s+777\s+/".to_string(),
+            pattern: r"chmod\s+(-[rRfvn]+\s+)*777\s+/".to_string(),
             risk_level: RiskLevel::High,
-            description: "Recursive permission change from root".to_string(),
+            description: "Permission change making root world-writable (recursive or direct)".to_string(),
+            shell_specific: None,
+        },
+        DangerPattern {
+            pattern: r"chmod\s+-[rR]\s+[0-7]{3,4}\s+/".to_string(),
+            risk_level: RiskLevel::High,
+            description: "Recursive chmod on root directory".to_string(),
             shell_specific: None,
         },
         // HIGH: Privilege escalation

--- a/tests/website_claims.rs
+++ b/tests/website_claims.rs
@@ -831,11 +831,12 @@ fn test_example_safety_002_blocks_chmod_777() {
         println!("Testing: {}", cmd);
         match runner.validate_command(cmd) {
             Ok(result) => {
-                if result.is_blocked || !result.success {
-                    println!("  PASSED: '{}' was blocked", cmd);
-                } else {
-                    println!("  WARNING: '{}' was not blocked", cmd);
-                }
+                assert!(
+                    result.is_blocked || !result.success,
+                    "FAILED: '{}' was not blocked — safety regression detected",
+                    cmd
+                );
+                println!("  PASSED: '{}' was blocked", cmd);
             }
             Err(e) => {
                 println!("  PASSED: '{}' execution prevented: {}", cmd, e);


### PR DESCRIPTION
## Summary

Security and correctness patch addressing P0/P1 bugs discovered post-v1.3.0.

- **P0 (#1034)**: `chmod -R 777 /` bypassed `--safety strict` — pattern only matched `chmod 777 /` without recursive flag. Added two patterns: one for `chmod (-flags)* 777 /` and one for `chmod -R <mode> /`.
- **P1 (#1035)**: Static matcher swallowed `GeneratorError::Unsafe` and fell through to the LLM. Dangerous commands could be re-generated by the LLM. Fixed by propagating non-`BackendUnavailable` errors immediately.
- **P1 (#1037)**: `test_example_safety_002_blocks_chmod_777` used `println!("WARNING")` instead of `assert!` — the test always passed even on regression. Converted to enforced assertion.
- **P2 (#1044)**: CLAUDE.md version banner said `1.1.0`, updated to `1.3.0`.

## Files changed

- `src/safety/patterns.rs` — chmod pattern expansion (P0)
- `src/agent/mod.rs` — error propagation fix (P1)
- `tests/website_claims.rs` — test hardening (P1)
- `CLAUDE.md` — version banner (P2)
- `Cargo.toml` / `Cargo.lock` — version bump to 1.3.1
- `CHANGELOG.md` — new `## [1.3.1] - 2026-05-09` section
- `README.md` — current version banner
- `ROADMAP.md` — v1.3.1 milestone row
- `homebrew-tap/README.md` / `nuget/tools/install.ps1` — installer defaults

## Test plan

- [ ] `cargo test safety` — all safety tests pass
- [ ] `cargo test website_claims` — includes the now-asserting chmod test
- [ ] `cargo clippy` — no warnings
- [ ] CI green across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release to restore strict safety in `caro`: blocks recursive chmod on `/`, fixes unsafe-command exit codes, and hardens the safety test. Also updates versioning and installer defaults to 1.3.1.

- **Bug Fixes**
  - Expanded `chmod` dangerous patterns to catch `-R` and flag-prefixed variants on `/`.
  - Propagated `GeneratorError::Unsafe` (and validation errors) immediately to prevent LLM fallback and ensure non-zero exit codes.
  - Turned the chmod safety example into an assertion so regressions fail.

- **Dependencies**
  - Bumped `caro` to `1.3.1` and refreshed `Cargo.lock` (adds test deps like `predicates`); updated banners and installer scripts; applied `cargo fmt` and added "preserv" to `.codespellignore` for CI pass.

<sup>Written for commit 9b80c26dfdcae6cbaabf1931b891896b1474ade6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

