### PR TITLE
fix(msrv): bump Rust 1.83 → 1.85 to unblock MSRV CI (edition2024 deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
   # ============================================================================
 
   msrv:
-    name: MSRV Check (Rust 1.83)
+    name: MSRV Check (Rust 1.85)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
@@ -322,15 +322,16 @@ jobs:
     - name: Setup Rust
       uses: ./.github/actions/setup-rust
       with:
-        toolchain: "1.83"
+        toolchain: "1.85"
         cache-key-suffix: msrv
 
     # Note: We use --no-default-features to exclude the 'knowledge' feature
-    # because its dependencies (fastembed -> image -> aligned) require Rust 2024 edition
-    - name: Build with Rust 1.83
+    # because its dependencies (fastembed -> image -> aligned) require Rust 2024
+    # edition, only stabilized in 1.85.
+    - name: Build with Rust 1.85
       run: cargo build --release --locked --no-default-features --features embedded-cpu
 
-    - name: Run tests with Rust 1.83
+    - name: Run tests with Rust 1.85
       run: cargo test --lib --locked --no-default-features --features embedded-cpu
       env:
         RUST_BACKTRACE: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV bumped from 1.83 → 1.85** to fix CI breakage caused by transitive
+  dependencies (`lance-geo` → `i_tree`, etc.) requiring `edition2024`,
+  which Cargo only stabilized in 1.85. With MSRV 1.83, `cargo build
+  --locked` failed during dep-graph parsing even when the offending crates
+  were excluded by feature flag (e.g. the embedded-cpu MSRV CI build):
+  `--locked` parses every entry in `Cargo.lock`, including
+  feature-gated ones. Rust 1.85 was stabilized 2025-02-20, ~14 months
+  before this bump.
+
 ## [1.4.0] - 2026-05-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "caro"
 version = "1.4.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 description = "Convert natural language to shell commands using local LLMs"
 license = "AGPL-3.0"
 authors = ["Wildcard <kobi@caro.sh>", "Claude Code <noreply@anthropic.com>"]
@@ -133,7 +133,7 @@ regex = "1.10"
 tempfile = "3.10"
 serial_test = "3"
 proptest = "1"
-criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.83
+criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.85
 futures = "0.3"
 serde_yaml = "0.9"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cargo build --release
 ./target/release/caro --version
 ```
 
-**Prerequisites**: Rust 1.83+, CMake. For Apple Silicon GPU acceleration, install Xcode.
+**Prerequisites**: Rust 1.85+, CMake. For Apple Silicon GPU acceleration, install Xcode.
 
 See [BUILD.md](docs/BUILD.md) for detailed build instructions.
 
@@ -532,7 +532,7 @@ For current usage, ChromaDB works well for basic command storage and retrieval, 
 ## 🔧 Development
 
 ### Prerequisites
-- Rust 1.83+ (latest stable recommended)
+- Rust 1.85+ (latest stable recommended)
 - Cargo
 - Make (optional, for convenience commands)
 - Docker (optional, for development container)


### PR DESCRIPTION
## Summary

Fixes the long-standing MSRV CI failure (exit 101 in ~17s) by bumping MSRV from 1.83 to 1.85.

### Diagnosis

Reproduced locally with `cargo +1.83 fetch --locked`:

```
error: failed to download `i_tree v0.16.0`
Caused by: feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that
feature is not stabilized in this version of Cargo (1.83.0).
```

Root-cause chain:

```
caro → lancedb 0.23.1 → lance-namespace-impls → lance-geo → geodatafusion 0.1.1 → i_tree 0.16.0  (requires edition2024)
```

Even though the MSRV job uses `--no-default-features --features embedded-cpu` (which excludes `lancedb`), **`cargo build --locked` parses every manifest in `Cargo.lock` during resolution**, including feature-gated ones. `i_tree`'s `edition2024` declaration fails to parse on Cargo 1.83 → exit 101 → 17 second CI failure.

A version survey on crates.io confirmed there is **no version** of `geodatafusion` (or `i_tree`) that does not require `edition2024`:

| crate | versions surveyed | min MSRV |
|---|---|---|
| `i_tree` | 0.10.0 .. 0.18.0 (10 versions) | edition2024 (no MSRV declared) |
| `geodatafusion` | 0.1.0-beta.2 .. 0.4.0 | 1.85 |

Therefore pinning is not a path forward — **MSRV must be bumped to 1.85** (the version that stabilized edition2024).

### Changes

| File | Change |
|---|---|
| `Cargo.toml` | `rust-version = "1.85"`, criterion comment updated |
| `README.md` | "Rust 1.85+" in two prerequisite blurbs |
| `.github/workflows/ci.yml` | MSRV job toolchain `1.83` → `1.85`, name + step labels updated |
| `CHANGELOG.md` | `Unreleased` "Changed" entry with the diagnosis |

### Verification

```
cargo +1.85 build --release --locked --no-default-features --features embedded-cpu
   Finished `release` profile [optimized] target(s) in 2m 14s

cargo +1.85 test --lib --locked --no-default-features --features embedded-cpu
   test result: ok. 513 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 7.05s
```

### Risk assessment

Rust 1.85 was stabilized **2025-02-20** — ~14 months before this bump. Current stable is 1.94. This is a conservative bump:

- Most consumers building from source will already have ≥1.85.
- `cargo install caro` and prebuilt binaries are unaffected (binaries built on stable).
- Reverse-compat: anyone on 1.83/1.84 who built from source can pin to v1.4.0 or earlier.

### Out of scope

- Two other orthogonal CI failures noted in #1032: `ChromaDB Integration Tests` and `Check Spelling` (codespell typo). Those need separate investigation.
- `criterion = "=0.7.0"` pin remains because criterion 0.8+ requires Rust 1.86. A separate PR can lift this if/when MSRV bumps further.

## Test plan

- [ ] CI passes — specifically the MSRV job which has been red on every PR for at least 4 days.
- [ ] No other Rust job regresses (the bump is forward-compatible — every other job uses `stable`).
- [ ] Verify version banner / install instructions render correctly in the website preview.

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps MSRV to Rust 1.85 to unblock the MSRV CI job broken by transitive deps requiring `edition2024`. Updates `Cargo.toml`, CI workflow, and docs.

- **Bug Fixes**
  - `geodatafusion` → `i_tree` requires `edition2024`, which Cargo 1.83 can’t parse.
  - `cargo build --locked` reads all `Cargo.lock` entries, so feature-gating didn’t avoid the error.

- **Migration**
  - Building from source now requires Rust 1.85+.
  - If you must stay on 1.83/1.84, pin to v1.4.0 or earlier.

<sup>Written for commit 1d54504c50a15dd6dc9f992ed10ac907e4e23d8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

