### PR TITLE
feat(brand): kyaro-mark v2.1.1 — restore Footer call sites

### DIFF
--- a/website/public/icons/kyaro-mark.svg
+++ b/website/public/icons/kyaro-mark.svg
@@ -1,3 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" shape-rendering="crispEdges" aria-hidden="true">
-  <path fill="currentColor" fill-rule="evenodd" d="M2 2 h2 v2 h1 v-1 h6 v1 h1 v-2 h2 v3 h1 v6 h-1 v2 h-1 v1 h-1 v1 h-6 v-1 h-1 v-1 h-1 v-2 h-1 v-6 h1 z M5 7 h1 v2 h-1 z M10 7 h1 v2 h-1 z M7 10 h2 v1 h-2 z"/>
+  <g fill="currentColor">
+    <rect x="2" y="1" width="2" height="1"/><rect x="12" y="1" width="2" height="1"/>
+    <rect x="1" y="2" width="4" height="1"/><rect x="11" y="2" width="4" height="1"/>
+    <rect x="0" y="3" width="16" height="2"/>
+    <rect x="0" y="5" width="4" height="2"/><rect x="6" y="5" width="4" height="2"/><rect x="12" y="5" width="4" height="2"/>
+    <rect x="0" y="7" width="16" height="2"/>
+    <rect x="1" y="9" width="14" height="1"/><rect x="2" y="10" width="12" height="1"/>
+    <rect x="2" y="11" width="5" height="1"/><rect x="9" y="11" width="5" height="1"/>
+    <rect x="3" y="12" width="10" height="1"/><rect x="4" y="13" width="8" height="1"/>
+  </g>
 </svg>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,8 +5,7 @@
  */
 import { SITE_CONFIG } from '../config/site';
 import { t } from '../i18n/config';
-// NOTE(caro-bsi): kyaro-mark Glyph reverted pending v2.1.1 — current rendering reads
-// as a horned demon / pointy-eared cat rather than a Shiba. Manifest entry retained.
+import Glyph from '../ui/Glyph/Glyph.astro';
 
 interface Props {
   lang: string;
@@ -24,7 +23,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
       <!-- Brand Column -->
       <div class="footer-brand">
         <a href="/" class="brand-link">
-          <span class="brand-icon" aria-label="Caro brand">🐕</span>
+          <Glyph name="kyaro-mark" size={20} class="brand-icon" aria-label="Kyaro mark" />
           <span class="brand-name">Caro</span>
         </a>
         <p class="brand-tagline">{t(lang, 'landing.footer.brand.tagline')}</p>
@@ -106,7 +105,7 @@ const version = import.meta.env.PUBLIC_VERSION || '1.1.0';
     <!-- Kyaro Mascot Section -->
     <div class="kyaro-banner">
       <div class="kyaro-content">
-        <span class="kyaro-emoji" aria-label="Kyaro mascot">🐕</span>
+        <Glyph name="kyaro-mark" size={32} class="kyaro-emoji" aria-label="Kyaro mark" />
         <div class="kyaro-info">
           <p class="kyaro-title">{t(lang, 'landing.footer.kyaro.title')}</p>
           <p class="kyaro-text">

--- a/website/src/data/icon-manifest.json
+++ b/website/src/data/icon-manifest.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "released": "2026-04-28",
+  "lastUpdated": "2026-05-09",
   "grid": 16,
   "stroke": "integer-pixel",
   "color": "monochrome via currentColor",
@@ -15,7 +16,7 @@
     "shield":     { "path": "icons/shield.svg",     "category": "trust-badge",   "replaces_emoji": "🛡️",          "tier": "secondary" },
     "lightning":  { "path": "icons/lightning.svg",  "category": "trust-badge",   "replaces_emoji": "⚡",                      "tier": "secondary" },
     "brain":      { "path": "icons/brain.svg",      "category": "feature",       "replaces_emoji": "🧠",                "tier": "secondary" },
-    "kyaro-mark": { "path": "icons/kyaro-mark.svg", "category": "brand",         "replaces_emoji": "🐕",                "tier": "brand" }
+    "kyaro-mark": { "path": "icons/kyaro-mark.svg", "category": "brand",         "replaces_emoji": "🐕",                "tier": "brand", "version": "2.1.1", "notes": "Redrawn 2026-05-09 to fix horned-demon read at 16-32 px (caro-bsi)" }
   },
   "deferred_v3": [
     "git", "terminal", "package", "model", "gear", "doc", "search", "spinner", "check", "cross",


### PR DESCRIPTION
## Summary

Closes **caro-bsi**: the v2.1 kyaro-mark glyph (shipped in #1007, then reverted in Footer call sites by 66bed467 because it read as a horned demon / pointy-eared cat at 16–32 px).

Claude Design redrew the glyph as **v2.1.1** in the Caro Design System dialogue thread (https://claude.ai/design/p/332f73e9-84c2-4078-ac8d-169c1855385d). The redraw is grounded in the existing Kyaro mascot reference (`assets/kyaro/001-idle/animation_Idle1.png`) — short rounded ears, full-width head crown, chin taper, mouth gap.

### Decision summary from Claude Design

> "v2.1.1 redraw, taking it on now. […] Yes please — let me ground the redraw in the existing Kyaro art before redrawing."

### Files changed

| File | Change |
|---|---|
| `website/public/icons/kyaro-mark.svg` | Replaced with rect-based v2.1.1 markup (16×16 grid, ears 2-row, full crown, mouth gap, chin taper) |
| `website/src/data/icon-manifest.json` | Pack `version` 0.1.0 → 0.1.1, added `lastUpdated`, per-icon `version: "2.1.1"` and `notes` |
| `website/src/components/Footer.astro` | Removed `NOTE(caro-bsi)`, restored `import Glyph` and replaced both 🐕 emoji call sites with `<Glyph name="kyaro-mark" size={20\|32}>` |

### Self-audit

Rendered the v2.1 (current) and v2.1.1 (redraw) SVGs side-by-side at **16 / 20 / 24 / 32 / 48 px** on both paper (`#f4f1df`) and ink (`#1d1c19`) surfaces. Screenshot: `.claude/audits/2026-05-09-kyaro-v211/render.png` (zoomed: `render-zoom.png`).

**Verdict: PASS.**
- v2.1 (current main): horns are unmistakable — two sharp triangle protrusions rising above a narrow head. Reads as horned demon / cat.
- v2.1.1 (redraw): short, rounded ears sitting on top of a full-width head crown; clear eyes (rows 5–6), mouth gap (row 11), chin taper (14→12→10→8 px wide across rows 9–13). Reads as a mammal / canine head at all 5 sizes. The horned-demon read is fully eliminated.

Per Claude Design's caveat: the monochrome silhouette can't carry the cream-cheek mask that makes the full sprites instantly Shiba — the full mascot GIFs in `assets/kyaro/` remain the right call for hero / decision-point / 64 px+ moments.

Build verified locally (`npm run build`): 58 pages, `dist/icons/kyaro-mark.svg` contains the new rect markup, Footer renders inline SVG via Glyph at both call sites with `aria-label="Kyaro mark"`.

### Known pre-existing CI failures

The following CI checks have been failing on unrelated infra and have been admin-merged in PRs #1006, #1007, #1026, #1033, #1039:

- **Check Spelling** — wordlist drift unrelated to icon ingest
- **ChromaDB E2E** — flaky vector store fixture (#871)
- **MSRV** — minimum supported Rust version chain unrelated to website

Recommend the same admin-merge precedent applies here, since this PR touches website assets only.

## Test plan

- [x] `npm run build` passes locally (58 pages)
- [x] `dist/icons/kyaro-mark.svg` contains v2.1.1 markup
- [x] Footer renders inline `<svg>` via Glyph (verified in `dist/faq/index.html`, `dist/ar/index.html`)
- [x] Self-audit at 16/20/24/32/48 px on paper + ink — horned-demon read eliminated
- [ ] Parent visual review on `dist/index.html` after deploy preview lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redrew the `kyaro-mark` glyph to v2.1.1 for clear 16–32 px readability and restored Footer usage of the brand icon. Closes Linear caro-bsi.

- **Bug Fixes**
  - Replaced SVG with rect-based 16×16 grid (2-row rounded ears, full crown, mouth gap, chin taper) to eliminate the horned-demon read.
  - Restored Footer call sites from 🐕 to `<Glyph name="kyaro-mark" size={20|32}>` with `aria-label="Kyaro mark"`.
  - Updated `icon-manifest.json`: bump pack to 0.1.1, add `lastUpdated`, and set per-icon `version: "2.1.1"` with notes.

<sup>Written for commit cf4a04bc185b2768b1f51405301c62c4107c352c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

