### PR TITLE
feat(brand): light-bg card migration — apply Claude Design's finalized card spec

### DIFF
--- a/website/src/components/landing/LPBestPractices.astro
+++ b/website/src/components/landing/LPBestPractices.astro
@@ -159,17 +159,26 @@ const realIncidents = [
   }
 
   .incident-card {
-    background: linear-gradient(135deg, rgba(239, 68, 68, 0.08) 0%, rgba(239, 68, 68, 0.03) 100%);
-    border: 1px solid rgba(239, 68, 68, 0.3);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-top: 4px solid var(--accent);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 24px;
     text-align: center;
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  }
+
+  .incident-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--accent);
   }
 
   .incident-badge {
     display: inline-block;
-    background: rgba(239, 68, 68, 0.15);
-    color: #ef4444;
+    background: rgba(239, 51, 51, 0.15);
+    color: var(--accent);
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
@@ -201,7 +210,7 @@ const realIncidents = [
   .incidents-takeaway {
     text-align: center;
     font-size: 16px;
-    color: #ef4444;
+    color: var(--accent);
     margin-bottom: 50px;
   }
 
@@ -227,16 +236,18 @@ const realIncidents = [
   }
 
   .practice-card {
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 28px;
-    transition: border-color 0.2s, transform 0.2s;
+    transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
   }
 
   .practice-card:hover {
-    border-color: #ff8c42;
-    transform: translateY(-2px);
+    border-color: var(--accent);
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-4px);
   }
 
   .practice-header {
@@ -290,14 +301,15 @@ const realIncidents = [
 
   .caro-badge {
     flex-shrink: 0;
-    color: #ff8c42;
+    color: var(--accent);
     font-weight: 600;
   }
 
   .defense-layers {
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 40px;
     text-align: center;
   }
@@ -377,9 +389,11 @@ const realIncidents = [
   }
 
   .enterprise-scale {
-    background: linear-gradient(135deg, rgba(255, 140, 66, 0.08) 0%, rgba(255, 107, 53, 0.04) 100%);
-    border: 1px solid rgba(255, 140, 66, 0.2);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-top: 4px solid var(--accent);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 40px;
     margin-top: 40px;
     text-align: center;
@@ -405,8 +419,8 @@ const realIncidents = [
   }
 
   .scale-stat.highlight {
-    background: rgba(239, 68, 68, 0.1);
-    border: 1px solid rgba(239, 68, 68, 0.3);
+    background: rgba(239, 51, 51, 0.1);
+    border: 1px solid rgba(239, 51, 51, 0.3);
     border-radius: 8px;
     padding: 16px 24px;
   }
@@ -415,11 +429,11 @@ const realIncidents = [
     display: block;
     font-size: 32px;
     font-weight: 700;
-    color: #ff8c42;
+    color: var(--accent);
   }
 
   .scale-stat.highlight .scale-number {
-    color: #ef4444;
+    color: var(--accent);
   }
 
   .scale-label {
@@ -444,7 +458,7 @@ const realIncidents = [
   }
 
   .scale-note strong {
-    color: #ef4444;
+    color: var(--accent);
   }
 
   @media (max-width: 768px) {

--- a/website/src/components/landing/LPCommunityVoices.astro
+++ b/website/src/components/landing/LPCommunityVoices.astro
@@ -116,20 +116,18 @@ const incidentStats = [
   }
 
   .voice-card {
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     padding: 28px;
-    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
   }
 
   .voice-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
-  }
-
-  :global(.dark) .voice-card:hover {
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--accent);
   }
 
   .voice-icon {
@@ -161,16 +159,17 @@ const incidentStats = [
   }
 
   .voice-insight strong {
-    color: #ff8c42;
+    color: var(--accent);
   }
 
   .stats-bar {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 24px;
-    background: linear-gradient(135deg, rgba(255, 140, 66, 0.08) 0%, rgba(255, 107, 53, 0.04) 100%);
-    border: 1px solid rgba(255, 140, 66, 0.2);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 32px;
     margin-bottom: 50px;
   }
@@ -182,7 +181,7 @@ const incidentStats = [
   .stat-number {
     font-size: 36px;
     font-weight: 700;
-    color: #ff8c42;
+    color: var(--accent);
     margin-bottom: 8px;
   }
 
@@ -193,10 +192,11 @@ const incidentStats = [
   }
 
   .caro-response {
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-left: 4px solid #ff8c42;
-    border-radius: 8px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-top: 4px solid var(--accent);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 28px 32px;
     text-align: center;
   }

--- a/website/src/components/landing/LPDifferentiators.astro
+++ b/website/src/components/landing/LPDifferentiators.astro
@@ -92,22 +92,25 @@ const differentiators = [
   .differentiator {
     display: flex;
     gap: 20px;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     padding: 28px;
-    transition: border-color 0.2s;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
   }
 
   .differentiator:hover {
-    border-color: #ff8c42;
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--accent);
   }
 
   .diff-number {
     flex-shrink: 0;
     width: 40px;
     height: 40px;
-    background: linear-gradient(135deg, #ff8c42 0%, #ff6b35 100%);
+    background: var(--accent);
     color: white;
     border-radius: 50%;
     display: flex;
@@ -155,7 +158,7 @@ const differentiators = [
   }
 
   .diff-caro .diff-label {
-    color: #ff8c42;
+    color: var(--accent);
   }
 
   .diff-detail {
@@ -173,7 +176,7 @@ const differentiators = [
   }
 
   .cta-link {
-    color: #ff8c42;
+    color: var(--accent);
     font-weight: 600;
     text-decoration: none;
     font-size: 16px;

--- a/website/src/components/landing/LPHero.astro
+++ b/website/src/components/landing/LPHero.astro
@@ -58,9 +58,9 @@ const { lang = 'en' } = Astro.props;
 
   .hero-badge {
     display: inline-block;
-    background: linear-gradient(135deg, rgba(255, 140, 66, 0.15) 0%, rgba(255, 107, 53, 0.1) 100%);
-    border: 1px solid rgba(255, 140, 66, 0.3);
-    color: #ff8c42;
+    background: rgba(239, 51, 51, 0.12);
+    border: 1px solid rgba(239, 51, 51, 0.3);
+    color: var(--accent);
     padding: 8px 20px;
     border-radius: 20px;
     font-size: 14px;
@@ -79,10 +79,7 @@ const { lang = 'en' } = Astro.props;
   }
 
   .danger-cmd {
-    background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--accent);
     font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
     font-size: 0.9em;
   }
@@ -98,11 +95,12 @@ const { lang = 'en' } = Astro.props;
   }
 
   .social-proof {
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-left: 4px solid #ff8c42;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-top: 4px solid var(--accent);
     padding: 24px 32px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     margin-bottom: 40px;
     max-width: 600px;
     margin-left: auto;
@@ -141,28 +139,29 @@ const { lang = 'en' } = Astro.props;
   }
 
   .cta-button.primary {
-    background: linear-gradient(135deg, #ff8c42 0%, #ff6b35 100%);
+    background: var(--accent);
     color: white;
   }
 
   .cta-button.primary:hover {
+    background: var(--accent-hover);
     transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(255, 140, 66, 0.3);
+    box-shadow: var(--shadow-lg);
   }
 
   .cta-button.secondary {
     background: transparent;
-    border: 2px solid #ff8c42;
-    color: #ff8c42;
+    border: 2px solid var(--accent);
+    color: var(--accent);
   }
 
   .cta-button.secondary:hover {
-    background: rgba(255, 140, 66, 0.1);
+    background: rgba(239, 51, 51, 0.1);
     transform: translateY(-2px);
   }
 
   :global(.dark) .cta-button.secondary:hover {
-    background: rgba(255, 140, 66, 0.15);
+    background: rgba(239, 51, 51, 0.15);
   }
 
   .trust-badges {
@@ -190,7 +189,7 @@ const { lang = 'en' } = Astro.props;
   }
 
   .badge-link:hover {
-    color: #ff8c42;
+    color: var(--accent);
   }
 
   .privacy-link {
@@ -201,7 +200,7 @@ const { lang = 'en' } = Astro.props;
   }
 
   .privacy-link:hover {
-    color: #ff8c42;
+    color: var(--accent);
   }
 
   @media (max-width: 768px) {

--- a/website/src/components/landing/LPScenarios.astro
+++ b/website/src/components/landing/LPScenarios.astro
@@ -214,13 +214,13 @@ const roles = [
   }
 
   .role-btn:hover {
-    border-color: #ff8c42;
+    border-color: var(--accent);
   }
 
   .role-btn.active {
-    background: linear-gradient(135deg, rgba(255, 140, 66, 0.1) 0%, rgba(255, 107, 53, 0.05) 100%);
-    border-color: #ff8c42;
-    color: #ff8c42;
+    background: rgba(239, 51, 51, 0.08);
+    border-color: var(--accent);
+    color: var(--accent);
   }
 
   .role-icon {
@@ -240,17 +240,25 @@ const roles = [
   .scenario-card {
     display: flex;
     gap: 20px;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     padding: 24px;
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  }
+
+  .scenario-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--accent);
   }
 
   .scenario-number {
     flex-shrink: 0;
     width: 36px;
     height: 36px;
-    background: linear-gradient(135deg, #ff8c42 0%, #ff6b35 100%);
+    background: var(--accent);
     color: white;
     border-radius: 50%;
     display: flex;
@@ -284,13 +292,13 @@ const roles = [
 
   .dangerous-command {
     display: inline-block;
-    background: rgba(239, 68, 68, 0.1);
-    color: #ef4444;
+    background: rgba(239, 51, 51, 0.1);
+    color: var(--accent);
     padding: 8px 14px;
     border-radius: 6px;
     font-family: 'SF Mono', 'Monaco', monospace;
     font-size: 13px;
-    border: 1px solid rgba(239, 68, 68, 0.2);
+    border: 1px solid rgba(239, 51, 51, 0.2);
   }
 
   .scenario-problem {
@@ -317,12 +325,12 @@ const roles = [
     padding: 14px;
     background: rgba(34, 197, 94, 0.08);
     border-radius: 6px;
-    border-left: 3px solid #22c55e;
+    border-top: 3px solid #22c55e;
   }
 
   .caro-label {
     font-weight: 600;
-    color: #ff8c42;
+    color: var(--accent);
     margin-right: 8px;
   }
 

--- a/website/src/ui/Card/Card.module.css
+++ b/website/src/ui/Card/Card.module.css
@@ -8,10 +8,11 @@
    ============================================ */
 
 .card {
-  background: var(--color-bg, #ffffff);
-  border-radius: 12px;
+  background: var(--bg-raised);
+  border-radius: var(--radius-md);
   padding: 30px;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
   transition:
     transform 0.2s,
     box-shadow 0.2s,
@@ -28,16 +29,12 @@
 
 .card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 30px rgba(255, 140, 66, 0.1);
-  border-color: var(--color-primary, #ff8c42);
-}
-
-:global(.dark) .card:hover {
-  box-shadow: 0 10px 30px rgba(255, 140, 66, 0.2);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--accent);
 }
 
 .card:focus-visible {
-  outline: 2px solid var(--color-primary, #ff8c42);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -128,7 +125,7 @@
   position: absolute;
   top: 15px;
   left: 15px;
-  background: linear-gradient(135deg, #ff8c42 0%, #ff6b35 100%);
+  background: var(--accent);
   color: white;
   padding: 4px 12px;
   border-radius: 12px;
@@ -157,7 +154,7 @@
 }
 
 .readMore {
-  color: var(--color-primary, #ff8c42);
+  color: var(--accent);
   text-decoration: none;
   font-weight: 600;
   display: inline-flex;
@@ -203,7 +200,7 @@
 }
 
 .titleLink:hover {
-  color: var(--color-primary, #ff8c42);
+  color: var(--accent);
 }
 
 :global(.dark) .title,
@@ -212,7 +209,7 @@
 }
 
 :global(.dark) .titleLink:hover {
-  color: var(--color-primary, #ff8c42);
+  color: var(--accent);
 }
 
 .description {


### PR DESCRIPTION
\`[agent]\`

**Agent:** Claude Code (\`claude-opus-4-7\`)

---

## Summary

Closes **caro-pt1**. Migrates the 6 light-surface card-bearing components to Claude Design's finalized card spec (2026-05-09 ruling):

- rest: \`var(--bg-raised)\` bg, \`1px var(--border)\`, \`var(--radius-md)\` (8px), \`var(--shadow-sm)\`
- hover: \`var(--shadow-lg)\`, \`translateY(-4px)\`, border \`var(--accent)\`, **no scale**

## Components touched

- \`website/src/ui/Card/Card.module.css\` — base infrastructure. \`12px → 8px\`, \`--color-* fallback\` chains migrated to canonical \`--bg-raised\`/\`--border\`/\`--accent\` tokens. Blog badge gradient flattened to \`var(--accent)\`.
- \`website/src/components/landing/LPDifferentiators.astro\` — \`.differentiator\` card spec; \`#ff8c42\`/\`#ff6b35\` swept.
- \`website/src/components/landing/LPHero.astro\` — \`.social-proof\` panel migrated; left-stripe → top-border; \`.danger-cmd\` gradient → \`var(--accent)\`; CTA primary/secondary swept to flat accent + token shadow.
- \`website/src/components/landing/LPCommunityVoices.astro\` — \`.voice-card\` spec; \`.stats-bar\` gradient removed → flat raised bg; \`.caro-response\` left-stripe → top-border.
- \`website/src/components/landing/LPScenarios.astro\` — \`.scenario-card\` migrated + hover added; inner \`.caro-response\` left-stripe → top-border; \`#ef4444\` → \`var(--accent)\`.
- \`website/src/components/landing/LPBestPractices.astro\` — \`.incident-card\` + \`.practice-card\` migrated; \`.enterprise-scale\` gradient → \`var(--bg-raised)\` with top-border accent; \`#ef4444\`/\`#ff8c42\` swept.

## Sweeps

- All hardcoded \`#ff8c42\` / \`#ff6b35\` / \`#ef4444\` → \`var(--accent)\` ✓
- \`transform: scale(...)\` on hover — none found in scope ✓
- \`linear-gradient(...)\` on default card backgrounds removed; only the hero CTA was previously gradient-based and was flattened to accent for token consistency ✓
- \`border-left: Npx solid <accent>\` left-accent stripes → \`border-top\` (LPHero \`.social-proof\`, LPCommunityVoices \`.caro-response\`, LPScenarios inner \`.caro-response\`) ✓

## Migration notes — surfaces I left intentionally

- **LPBestPractices \`.layer-1\` / \`.layer-2\` / \`.layer-3\` / \`.layer-4\`** — semantic risk-coded indicators (red → yellow → blue → green progression). These are inline meters, not cards, so the brand-accent override would erase the safety semantics. Left as-is.
- **LPScenarios \`.scenario-problem\` (yellow) and inner \`.caro-response\` (green)** — small inner status panels inside a card, semantically tied to warning/success colors. Left tinted-bg untouched; only the left-stripe in caro-response was rotated to top-border.
- **LPHero \`.hero-badge\`** — small decorative pill, not a card. Gradient simplified to flat tinted bg + \`var(--accent)\` text.

## Token decision

Per **caro-5wo**: brand book updates land separately (no code rename here). Existing \`var(--shadow-sm|md|lg|xl)\` stays canonical.

## Build verification

\`npm run build\` produces 58 pages ✓ (after a one-off \`npm install\` to populate \`node_modules/botid\`; the lockfile bump was reverted as out-of-scope).

## Sister PR

\`feat/cards-dark-migration\` handles the 4 dark surfaces (caro-l06) per Claude Design's per-surface composition ruling. Disjoint file scope — no merge conflicts expected.

## Test plan

- [ ] Visual audit pass via \`claude-design-frontend-engineer\` (per \`design-dialogue-protocol.md\` Rule 5) before merge.
- [ ] Spot-check each migrated surface at light mode + dark mode (no dark-specific overrides remain on the migrated cards).
- [ ] Confirm hover state matches spec on \`.differentiator\`, \`.voice-card\`, \`.scenario-card\`, \`.practice-card\` (translateY, accent border, shadow-lg).

---

<details>
<summary>Prompt used to generate this comment</summary>

\`\`\`
caro-pt1: light-bg card migration sweep — apply Claude Design's
finalized card spec to 6 light-surface components. Sub-agent task with
explicit spec, scope, and PR template provided by parent orchestrator.
\`\`\`

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized six light-surface card components to Claude Design’s finalized card spec. Completes Linear `caro-pt1` with `var(--bg-raised)`/`var(--border)`/`var(--radius-md)` and a consistent hover (translateY -4px, `var(--shadow-lg)`, accent border).

- **Refactors**
  - Updated `website/src/ui/Card/Card.module.css` to token styles with base `var(--shadow-sm)`; hover uses `var(--shadow-lg)`/accent border; focus outline `var(--accent)`.
  - Migrated LPHero, LPDifferentiators, LPCommunityVoices, LPScenarios, and LPBestPractices surfaces to the spec; added -4px hover and accent border; gradient badges/numbers flattened to `var(--accent)`.
  - Replaced hardcoded `#ff8c42`/`#ff6b35`/`#ef4444` with `var(--accent)`; standardized tints to `rgba(239, 51, 51, ...)` where needed.
  - Converted left accent stripes to top borders on info panels; left semantic inner status colors as-is.
  - LPHero CTAs flattened to accent (primary hover uses `var(--accent-hover)`); hero badge simplified to a flat tinted pill (non-card).

<sup>Written for commit 03000f0b5033ef8155ad921956295845d4931d0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

