### PR TITLE
feat(brand): per-surface card migration — paper/stage/dark per Claude Design v2.1.1 ruling

### DIFF
--- a/website/src/components/landing/LPMoments.astro
+++ b/website/src/components/landing/LPMoments.astro
@@ -98,7 +98,7 @@
 <style>
   .moments {
     padding: 100px 20px;
-    background: linear-gradient(180deg, #0a0a0f 0%, #0f0f14 100%);
+    background: var(--bg-inverse);
   }
 
   .container {
@@ -130,21 +130,23 @@
   }
 
   .moment-card {
-    background: #12121a;
-    border-radius: 16px;
+    background: var(--bg-inverse);
+    border-radius: var(--radius-md);
     overflow: hidden;
-    border: 1px solid #1f1f2a;
-    transition: all 0.3s ease;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
   }
 
   .moment-card:hover {
-    border-color: #333;
+    border-color: var(--accent);
     transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
   }
 
   .moment-before {
     padding: 28px;
-    background: linear-gradient(180deg, #1a1a24 0%, #12121a 100%);
+    background: var(--bg-inverse);
   }
 
   .moment-icon {
@@ -202,8 +204,8 @@
   }
 
   .with-caro {
-    background: #0f0f14;
-    color: #ff6b35;
+    background: var(--bg-inverse);
+    color: var(--accent);
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -214,7 +216,7 @@
 
   .moment-after {
     padding: 28px;
-    background: #0f0f14;
+    background: var(--bg-inverse);
   }
 
   .moment-example.good,

--- a/website/src/components/landing/LPPersonas.astro
+++ b/website/src/components/landing/LPPersonas.astro
@@ -203,7 +203,7 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
 <style>
   .personas {
     padding: 100px 20px;
-    background: #0f0f14;
+    background: var(--bg);
   }
 
   .container {
@@ -215,13 +215,13 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
     font-size: 2.5rem;
     font-weight: 700;
     text-align: center;
-    color: #ffffff;
+    color: var(--fg-strong);
     margin-bottom: 16px;
   }
 
   .section-subtitle {
     font-size: 1.125rem;
-    color: #888;
+    color: var(--fg-muted);
     text-align: center;
     max-width: 600px;
     margin: 0 auto 60px;
@@ -235,11 +235,12 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   }
 
   .persona-card {
-    background: #16161f;
-    border-radius: 16px;
+    background: var(--bg);
+    border-radius: var(--radius-md);
     padding: 32px;
-    border: 1px solid #222;
-    transition: all 0.3s ease;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
     position: relative;
     overflow: hidden;
     display: flex;
@@ -257,21 +258,16 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
     transition: opacity 0.3s ease;
   }
 
-  .persona-card.accelerator::before {
-    background: linear-gradient(90deg, #ff6b35, #ff8c42);
-  }
-
-  .persona-card.guardian::before {
-    background: linear-gradient(90deg, #50fa7b, #69ff94);
-  }
-
+  .persona-card.accelerator::before,
+  .persona-card.guardian::before,
   .persona-card.operator::before {
-    background: linear-gradient(90deg, #8be9fd, #a4ffff);
+    background: var(--accent);
   }
 
   .persona-card:hover {
-    border-color: #333;
+    border-color: var(--accent);
     transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
   }
 
   .persona-card:hover::before {
@@ -279,7 +275,7 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   }
 
   .persona-card.is-expanded {
-    border-color: #ff6b35;
+    border-color: var(--accent);
   }
 
   .persona-card.is-expanded::before {
@@ -289,25 +285,26 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   .persona-icon {
     width: 56px;
     height: 56px;
-    background: #1f1f2a;
-    border-radius: 12px;
+    background: var(--bg-stage);
+    border-radius: var(--radius-md);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 28px;
     margin-bottom: 20px;
+    color: var(--accent);
   }
 
   .persona-title {
     font-size: 1.5rem;
     font-weight: 700;
-    color: #ffffff;
+    color: var(--fg-strong);
     margin-bottom: 4px;
   }
 
   .persona-role {
     font-size: 0.875rem;
-    color: #666;
+    color: var(--fg-muted);
     margin-bottom: 24px;
   }
 
@@ -327,18 +324,18 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   }
 
   .label.problem {
-    background: rgba(255, 85, 85, 0.15);
-    color: #ff5555;
+    background: rgba(239, 51, 51, 0.12);
+    color: var(--accent);
   }
 
   .label.solution {
-    background: rgba(80, 250, 123, 0.15);
-    color: #50fa7b;
+    background: rgba(34, 197, 94, 0.15);
+    color: #15803d;
   }
 
   .persona-problem p, .persona-solution p {
     font-size: 0.95rem;
-    color: #a0a0a0;
+    color: var(--fg);
     line-height: 1.6;
   }
 
@@ -346,13 +343,13 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
     list-style: none;
     padding: 0;
     margin: 0;
-    border-top: 1px solid #222;
+    border-top: 1px solid var(--border);
     padding-top: 20px;
   }
 
   .persona-benefits li {
     font-size: 0.875rem;
-    color: #888;
+    color: var(--fg);
     padding: 8px 0;
     padding-left: 24px;
     position: relative;
@@ -362,7 +359,7 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
     content: '✓';
     position: absolute;
     left: 0;
-    color: #ff6b35;
+    color: var(--accent);
     font-weight: bold;
   }
 
@@ -380,16 +377,16 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   }
 
   .expanded-content {
-    background: #0a0a0f;
-    border-radius: 12px;
+    background: var(--bg-stage);
+    border-radius: var(--radius-md);
     padding: 20px;
-    border: 1px solid #1e1e24;
+    border: 1px solid var(--border);
   }
 
   .expanded-content h4 {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--fg-strong);
     margin-bottom: 16px;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -417,26 +414,27 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   }
 
   .use-case code.input {
-    background: #1e1e24;
-    color: #888;
+    background: var(--bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
   }
 
   .use-case code.output {
-    background: rgba(34, 197, 94, 0.1);
-    color: #22c55e;
+    background: rgba(34, 197, 94, 0.12);
+    color: #15803d;
   }
 
   .use-case code.blocked {
-    background: rgba(239, 68, 68, 0.1);
-    color: #ef4444;
+    background: rgba(239, 51, 51, 0.1);
+    color: var(--accent);
     text-decoration: line-through;
   }
 
   .blocked-badge {
     font-size: 0.6875rem;
     font-weight: 700;
-    color: #ef4444;
-    background: rgba(239, 68, 68, 0.1);
+    color: var(--accent);
+    background: rgba(239, 51, 51, 0.1);
     padding: 4px 8px;
     border-radius: 4px;
     white-space: nowrap;
@@ -458,22 +456,22 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
   .platform-name {
     font-size: 0.75rem;
     font-weight: 600;
-    color: #888;
+    color: var(--fg-muted);
     min-width: 60px;
   }
 
   .platform-item code {
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
     font-size: 0.75rem;
-    color: #22c55e;
-    background: rgba(34, 197, 94, 0.1);
+    color: #15803d;
+    background: rgba(34, 197, 94, 0.12);
     padding: 4px 8px;
     border-radius: 4px;
   }
 
   .expanded-note {
     font-size: 0.8125rem;
-    color: #666;
+    color: var(--fg-muted);
     line-height: 1.5;
     margin: 12px 0 0;
   }
@@ -491,21 +489,21 @@ import Glyph from '../../ui/Glyph/Glyph.astro';
     margin-top: 20px;
     font-size: 0.875rem;
     font-weight: 600;
-    color: #ff6b35;
+    color: var(--accent);
     background: transparent;
-    border: 1px solid #ff6b35;
-    border-radius: 8px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-md);
     cursor: pointer;
     transition: all 0.2s ease;
   }
 
   .persona-cta:hover {
-    background: rgba(255, 107, 53, 0.1);
+    background: rgba(239, 51, 51, 0.08);
   }
 
   .persona-cta[aria-expanded="true"] {
-    background: #ff6b35;
-    color: #ffffff;
+    background: var(--accent);
+    color: var(--fg-inverse);
   }
 
   .cta-icon {

--- a/website/src/components/landing/LPTestimonials.astro
+++ b/website/src/components/landing/LPTestimonials.astro
@@ -91,7 +91,7 @@ const testimonials: Testimonial[] = [
 <style>
   .testimonials {
     padding: 100px 20px;
-    background: linear-gradient(180deg, #0d0d12 0%, #0a0a0f 100%);
+    background: var(--bg);
   }
 
   .container {
@@ -110,24 +110,24 @@ const testimonials: Testimonial[] = [
     font-weight: 600;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: #ff6b35;
+    color: var(--accent);
     margin-bottom: 16px;
     padding: 8px 16px;
-    background: rgba(255, 107, 53, 0.1);
+    background: rgba(239, 51, 51, 0.1);
     border-radius: 100px;
   }
 
   .section-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #ffffff;
+    color: var(--fg-strong);
     margin-bottom: 16px;
     line-height: 1.2;
   }
 
   .section-subtitle {
     font-size: 1.125rem;
-    color: #888;
+    color: var(--fg-muted);
     max-width: 500px;
     margin: 0 auto;
     line-height: 1.6;
@@ -141,27 +141,28 @@ const testimonials: Testimonial[] = [
   }
 
   .testimonial-card {
-    background: #111116;
-    border: 1px solid #1e1e24;
-    border-radius: 16px;
+    background: var(--bg-stage);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     padding: 32px;
-    transition: all 0.3s ease;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
     display: flex;
     flex-direction: column;
   }
 
   .testimonial-card:hover {
-    border-color: #ff6b35;
+    border-color: var(--accent);
     transform: translateY(-4px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--shadow-lg);
   }
 
   .testimonial-metric {
     display: inline-block;
     font-size: 0.75rem;
     font-weight: 600;
-    color: #22c55e;
-    background: rgba(34, 197, 94, 0.1);
+    color: #15803d;
+    background: rgba(34, 197, 94, 0.15);
     padding: 6px 12px;
     border-radius: 100px;
     margin-bottom: 20px;
@@ -171,7 +172,7 @@ const testimonials: Testimonial[] = [
   .testimonial-quote {
     font-size: 1rem;
     line-height: 1.7;
-    color: #e0e0e0;
+    color: var(--fg);
     margin: 0 0 24px 0;
     flex-grow: 1;
     font-style: italic;
@@ -182,20 +183,20 @@ const testimonials: Testimonial[] = [
     align-items: center;
     gap: 12px;
     padding-top: 20px;
-    border-top: 1px solid #1e1e24;
+    border-top: 1px solid var(--border);
   }
 
   .author-avatar {
     width: 44px;
     height: 44px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #ff6b35, #ff8c5a);
+    background: var(--accent);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 0.875rem;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--fg-inverse);
   }
 
   .author-info {
@@ -207,12 +208,12 @@ const testimonials: Testimonial[] = [
   .author-name {
     font-size: 0.9375rem;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--fg-strong);
   }
 
   .author-role {
     font-size: 0.8125rem;
-    color: #666;
+    color: var(--fg-muted);
   }
 
   .social-proof-bar {
@@ -221,9 +222,9 @@ const testimonials: Testimonial[] = [
     flex-wrap: wrap;
     gap: 32px;
     padding: 32px;
-    background: #111116;
-    border-radius: 12px;
-    border: 1px solid #1e1e24;
+    background: var(--bg-stage);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
   }
 
   .proof-item {
@@ -231,7 +232,7 @@ const testimonials: Testimonial[] = [
     align-items: center;
     gap: 8px;
     font-size: 0.9375rem;
-    color: #888;
+    color: var(--fg);
   }
 
   .proof-icon {

--- a/website/src/components/landing/LPWaitlist.astro
+++ b/website/src/components/landing/LPWaitlist.astro
@@ -165,7 +165,7 @@
 <style>
   .waitlist {
     padding: 80px 20px;
-    background: #0a0a0f;
+    background: var(--bg-inverse);
   }
 
   .container {
@@ -174,16 +174,24 @@
   }
 
   .waitlist-card {
-    background: linear-gradient(135deg, #111116 0%, #16161c 100%);
-    border: 1px solid #ff6b35;
-    border-radius: 24px;
+    background: var(--bg-inverse);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-md);
     padding: 48px;
+    box-shadow: var(--shadow-sm);
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 48px;
     align-items: center;
     position: relative;
     overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .waitlist-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
   }
 
   .waitlist-card::before {
@@ -193,7 +201,7 @@
     left: 0;
     right: 0;
     height: 1px;
-    background: linear-gradient(90deg, transparent, #ff6b35, transparent);
+    background: var(--accent);
   }
 
   .badge {
@@ -202,8 +210,8 @@
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: #ff6b35;
-    background: rgba(255, 107, 53, 0.15);
+    color: var(--accent);
+    background: rgba(239, 51, 51, 0.18);
     padding: 6px 12px;
     border-radius: 100px;
     margin-bottom: 16px;
@@ -212,14 +220,14 @@
   .waitlist-title {
     font-size: 2rem;
     font-weight: 700;
-    color: #ffffff;
+    color: var(--fg-inverse);
     margin-bottom: 16px;
     line-height: 1.2;
   }
 
   .waitlist-description {
     font-size: 1rem;
-    color: #888;
+    color: var(--caro-grey-300, #cccccc);
     line-height: 1.7;
     margin-bottom: 24px;
   }
@@ -238,12 +246,12 @@
     align-items: flex-start;
     gap: 10px;
     font-size: 0.9375rem;
-    color: #ccc;
+    color: var(--caro-grey-300, #cccccc);
     line-height: 1.5;
   }
 
   .check {
-    color: #22c55e;
+    color: #4ade80;
     font-weight: 600;
     flex-shrink: 0;
   }
@@ -286,21 +294,21 @@
     width: 100%;
     padding: 16px 20px;
     font-size: 1rem;
-    color: #ffffff;
-    background: #0a0a0f;
-    border: 1px solid #2a2a30;
-    border-radius: 12px;
+    color: var(--fg-inverse);
+    background: var(--bg-inverse);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
     outline: none;
-    transition: all 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .email-input::placeholder {
-    color: #555;
+    color: var(--fg-muted);
   }
 
   .email-input:focus {
-    border-color: #ff6b35;
-    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(239, 51, 51, 0.15);
   }
 
   .submit-button {
@@ -312,17 +320,18 @@
     padding: 16px 24px;
     font-size: 1rem;
     font-weight: 600;
-    color: #ffffff;
-    background: linear-gradient(135deg, #ff6b35 0%, #ff8c5a 100%);
+    color: var(--fg-inverse);
+    background: var(--accent);
     border: none;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .submit-button:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(255, 107, 53, 0.3);
+    background: var(--accent-hover);
+    box-shadow: var(--shadow-lg);
   }
 
   .submit-button:disabled {
@@ -331,7 +340,7 @@
   }
 
   .submit-button.success {
-    background: linear-gradient(135deg, #22c55e 0%, #4ade80 100%);
+    background: #15803d;
   }
 
   .button-icon {
@@ -344,7 +353,7 @@
 
   .form-note {
     font-size: 0.8125rem;
-    color: #666;
+    color: var(--caro-grey-400, #999);
     text-align: center;
   }
 


### PR DESCRIPTION
## Summary

Closes [`caro-l06`](https://github.com/wildcard/caro/issues/l06). Implements Claude Design's per-surface composition ruling (2026-05-09 dialogue at https://claude.ai/design/p/332f73e9-…) for the four card grids that were previously generic dark-grey:

| Component | New surface | Token | Rationale (her words) |
|---|---|---|---|
| `LPMoments.astro` | dark | `var(--bg-inverse)` | decision-moment, adjacent to terminal demo |
| `LPTestimonials.astro` | **stage grey** | `var(--bg-stage)` (#d1cfc9) | "the back of the business card" |
| `LPPersonas.astro` | paper | `var(--bg)` | empathy work, "warmly precise" |
| `LPWaitlist.astro` | dark | `var(--bg-inverse)` | commitment-CTA earns weight |

## Card spec (her finalized version)

Applied across all 4 surfaces:

- **rest**: `var(--shadow-sm)`, `1px solid var(--border)`, `var(--radius-md)` (8px)
- **hover**: `var(--shadow-lg)`, `translateY(-4px)`, `border-color: var(--accent)`, **no scale**
- `--radius-lg` left untouched (12px) per her explicit instruction

## Bundled correction — closes `caro-246`

Hardcoded near-black hex (`#111116` / `#12121a` / `#16161f` / `#0f0f14` / `#0a0a0f` / etc.) on the four touched surfaces swept to `var(--bg-inverse)` (#4f4f4f). "Never pure black, always brand grey" per her brand rule.

`grep -nE '#11111[0-9a-f]|#12121[0-9a-f]|#16161[0-9a-f]' website/src/components/landing/LP{Moments,Testimonials,Personas,Waitlist}.astro` returns CLEAN.

## Token check

`var(--bg-stage)` and `var(--bg-inverse)` already present in `website/src/ui/tokens.css` (light + `.dark` variants). No token additions needed.

## Build / verification

`npm run build` fails on this branch on a **pre-existing, unrelated** error: `Rollup failed to resolve import "botid/client/core" from website/src/lib/botid-init.ts`. Confirmed reproducible on clean `origin/main` (stashed-changes test). This PR does not introduce the failure and per the admin-merge precedent for the 3 known pre-existing CI failures, merge is gated on visual review by Claude Design rather than CI green.

## Test plan

- [ ] Visual review by Claude Design at the dialogue thread (priority — settles whether stage-grey reads as "back of the business card")
- [ ] Local dev server (`npm run dev`) check at 1440 / 768 / 375 viewports (build-blocked sections still render in dev)
- [ ] Hover state QA on all 4 grids — confirm `translateY(-4px)`, no scale, accent border, shadow lift
- [ ] Personas grid on paper — confirm cards still read as cards (border weight + shadow), not floating text
- [ ] Testimonials text contrast on stage-grey — confirm `var(--fg)` resolves to legible AA contrast on #d1cfc9
- [ ] Waitlist submit button — confirm flat `var(--accent)` (no gradient), preserves form behavior

## Out of scope (separate PR)

`caro-pt1` covers `Card.tsx`, `LPDifferentiators`, `LPHero`, `LPCommunityVoices`, `LPScenarios`, `LPBestPractices`. Per Claude Design's per-surface ruling those each need their own composition decision and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the four landing card grids to the per-surface palette and unifies card states for a clearer, on-brand UI. Implements `caro-l06`.

- **New Features**
  - Surfaces: LPMoments → dark `var(--bg-inverse)`, LPTestimonials cards → stage `var(--bg-stage)`, LPPersonas → paper `var(--bg)`, LPWaitlist → dark `var(--bg-inverse)`.
  - Card spec (all four): rest `var(--shadow-sm)` + `1px solid var(--border)` + `var(--radius-md)`; hover `translateY(-4px)` + border `var(--accent)` + `var(--shadow-lg)` (no scale).
  - Standardizes text/border/accent tokens and removes gradients; no new tokens.

- **Bug Fixes**
  - Replaced hardcoded near-black hex colors with brand tokens (primarily `var(--bg-inverse)`) per the “never pure black” rule (closes `caro-246`).

<sup>Written for commit f72d7b55cb3be5f52fe7aa6a6887eefb78f0665e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

