### PR TITLE
fix(website): wire tokens.css into Layout.astro — unblocks card token resolution

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import '../ui/tokens.css';
 import Analytics from '@vercel/analytics/astro';
 import PostHog from '../components/PostHog.astro';
 import SnowEffect from '../components/SnowEffect.astro';


### PR DESCRIPTION
## Summary

One-line infrastructure fix. Adds `import '../ui/tokens.css';` to `Layout.astro`'s frontmatter so the modern brand tokens consolidated in PR #1039 actually resolve at runtime.

## The bug (verified)

A visual audit on 2026-05-09 (`.claude/audits/2026-05-09-cards-pr-audit/`) found that:

- PR #1039 added 365 lines of brand tokens (`--accent`, `--bg-raised`, `--shadow-sm`, `--radius-md`, `--border`, `--bg-stage`, `--bg-inverse`, `--fg-strong`, ...) to `website/src/ui/tokens.css`.
- `Layout.astro` never imported that file.
- At runtime, Playwright `getPropertyValue('--accent')` at `:root` returned empty string.
- Existing components survived via fallback syntax `var(--accent, #ef3333)`.
- New card-migration PRs (#1058 light cards, #1059 dark cards) use bare `var(--accent)` and silently broke: invisible Hero CTA, no card frames, no shadows, missing radii.

This is an infrastructure wiring bug, not a design bug. The `tokens.css` file even self-documents the contract it expected: `Imported by Layout.astro (and any component that needs tokens directly).`

## What this PR does

- One line added to `website/src/layouts/Layout.astro` frontmatter:
  ```ts
  import '../ui/tokens.css';
  ```
- Astro bundles this side-effect import into every page's stylesheet — single source of truth preserved.
- Existing `<style is:global>` `:root` block in `Layout.astro` is **unchanged**: the new tokens have distinct names and don't collide. Cleanup of legacy block is tracked separately.

## Verification

- `npm run build` → 58 pages built, no errors.
- After this lands, PR #1058 and #1059 will rebase and the rendered cards (light + dark) will resolve tokens correctly.

## Blocked-on-this

- #1058 — light-bg card migration
- #1059 — dark card migration

## CI note

The 3 known pre-existing CI failures on `main` (unrelated to this change) follow the standard admin-merge precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire `website/src/ui/tokens.css` into `website/src/layouts/Layout.astro` so brand CSS variables load globally at runtime and card styles render correctly. Unblocks card migrations (#1058, #1059) by ensuring tokens like `--accent` resolve without fallbacks.

<sup>Written for commit eae3e83ae7e8029863811edb7f9c63af6a7adbc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

