### PR TITLE
feat(skills): wire caro-coder-loop + caro-backlog-groom to STAKEHOLDERS.yml

### DIFF
--- a/.claude/commands/caro-backlog-groom.md
+++ b/.claude/commands/caro-backlog-groom.md
@@ -75,6 +75,9 @@ for issue in groom_issues.json:
     existing = bd_find_by_external_ref(f"gh-{issue.number}")
     priority = derive_priority(issue.labels)  # P0→0, security→0, P1→1, docs→3
     phase = derive_phase_from_milestone_or_labels(issue)
+    # Compute STAKEHOLDERS.yml suggestions up-front so the coder-loop
+    # doesn't have to re-derive them on every claim.
+    suggested_agents = stakeholders_lookup(issue.body, issue.title)
 
     if not existing:
         bd create <issue.title> \
@@ -83,12 +86,39 @@ for issue in groom_issues.json:
           --parent caro-xk0 \
           --external-ref gh-$issue.number \
           --labels "v1.2.0,$phase,auto-groomed" \
+          --metadata "suggested_agents=$suggested_agents" \
           --description "GH: https://github.com/wildcard/caro/issues/$issue.number"
         log_create(issue.number, beads_id)
     elif existing.title != issue.title or existing.priority != priority:
-        bd update $existing.id --title "$issue.title" --priority $priority
+        bd update $existing.id --title "$issue.title" --priority $priority \
+          --metadata "suggested_agents=$suggested_agents"
         log_update(issue.number, existing.id)
 ```
+
+**`stakeholders_lookup` reference implementation**:
+
+```bash
+stakeholders_lookup() {
+  local body="$1" title="$2"
+  # Extract candidate paths from the issue body + title
+  local paths=$(printf '%s\n%s' "$body" "$title" \
+    | grep -oE '(src/[a-z_/]+|tests/[a-z_]+|website/[^ ]+|\.github/[^ ]+|Cargo\.[a-z]+)' \
+    | sort -u)
+  # For each path, find the longest STAKEHOLDERS glob match. Emit a
+  # comma-separated agent list, deduped, longest-prefix-wins.
+  for p in $paths; do
+    yq -r --arg p "$p" '
+      .areas | to_entries[]
+      | select(.key as $k | $p | test($k))
+      | (.key | length) as $score
+      | "\($score)|\(.value.agents | join(\",\"))"
+    ' .github/STAKEHOLDERS.yml
+  done | sort -rn | head -1 | cut -d'|' -f2
+}
+```
+
+If no path match is found, fall back to the legacy label heuristic
+(`documentation` → `spark`; otherwise `kraken`).
 
 ### B2. Pushed branches without PR → WIP beads task
 

--- a/.claude/commands/caro-coder-loop.md
+++ b/.claude/commands/caro-coder-loop.md
@@ -55,11 +55,48 @@ gh issue view "${GH_ISSUE#gh-}" > /tmp/issue-body.md
 ls specs/v1.2-delivering-on-the-promise/ 2>/dev/null && cat specs/v1.2-delivering-on-the-promise/tech-spec.md
 ```
 
-### 4. Delegate to kraken (or spark for docs)
+### 4. Pick the right specialist agent
 
-**Agent selection:**
+**Consult `.github/STAKEHOLDERS.yml` first.** The map pairs codebase paths
+with the specialist agents that should own changes there. Pick the most
+specific glob match for the paths the task is likely to touch — derived
+from the issue body, beads labels (`area:safety`, `area:ml`, …), or the
+title.
+
+```bash
+# Heuristic: extract candidate paths from the issue body
+PATHS=$(grep -oE '(src/[a-z_/]+|tests/[a-z_]+|website/[^ ]+|\.github/[^ ]+|Cargo\.[a-z]+)' /tmp/issue-body.md | sort -u)
+
+# Look up agents per path; the first concrete glob match wins
+yq -r --arg p "$PATHS" '
+  .areas | to_entries[] | select(.key as $k | $p | test($k))
+  | "\(.key) -> \(.value.agents | join(\",\"))"
+' .github/STAKEHOLDERS.yml | head -3
+```
+
+The agent named on the most-specific match becomes the **primary** specialist
+for the task. Examples:
+
+| Path touched | Primary specialist |
+|---|---|
+| `src/safety/patterns.rs` | `safety-pattern-developer` (TDD discipline required) |
+| `src/safety/**` | `safety-pattern-developer`, fall back to `safety-pattern-auditor` |
+| `src/backends/embedded_backend.rs` | `llm-integration-expert` |
+| `src/ai/**`, `src/eval/**` | `ml-ds-engineer` |
+| `src/cli/**`, `src/main.rs` | `rust-cli-expert` |
+| `Cargo.toml`, `.github/workflows/release.yml` | `caro-release-expert` |
+| `website/**` | `technical-writer` |
+| `website/src/i18n/**` | `technical-writer` + `cultural-heritage-expert` |
+| `specs/**` | `spec-driven-dev-guide` |
+
+**Fallback rules** (when STAKEHOLDERS.yml has no match):
 - `labels` contains `documentation` → use **spark** (Sonnet, fast)
 - Otherwise → use **kraken** (Opus, TDD for Rust safety-critical code)
+
+**Critical**: never bypass `safety-pattern-developer` for `src/safety/**`
+changes — that path requires the TDD-first workflow encoded in the skill.
+
+### 5. Delegate to the specialist
 
 Spawn via Task tool with this prompt template:
 
@@ -75,7 +112,7 @@ You are implementing beads task $NEXT (GitHub #${GH_ISSUE#gh-}) for caro v1.2.0.
 **Acceptance criteria**: see the task description and the v1.2.0 tech spec at specs/v1.2-delivering-on-the-promise/tech-spec.md.
 
 **Conventions** (from /Users/kobik-private/workspace/caro/CLAUDE.md):
-- Rust edition 2021, MSRV 1.83
+- Rust edition 2021, MSRV 1.85
 - Use `thiserror` for error types, `anyhow::Result` for application errors
 - TDD: write failing test FIRST, then make it pass
 - All commit messages conventional: `<type>(<scope>): <subject>` + Co-Authored-By
@@ -90,7 +127,7 @@ When done:
 2. Report: files changed, tests added, clippy status, test pass count
 ```
 
-### 5. Validate locally
+### 6. Validate locally
 
 ```bash
 cargo fmt --check
@@ -100,7 +137,7 @@ cargo test
 
 If any fail: `bd update "$NEXT" --status blocked --notes "validation failed: <err>"`, push branch for debugging, exit loop.
 
-### 6. Open PR + close beads task
+### 7. Open PR + close beads task
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -131,7 +168,7 @@ bd close "$NEXT" --notes "PR: $PR_URL"
 echo "✓ closed $NEXT → $PR_URL"
 ```
 
-### 7. Loop
+### 8. Loop
 
 Return to step 1 until `bd ready` has no v1.2.0 entries OR user interrupts.
 


### PR DESCRIPTION
**Closing in favour of #NEW** — this branch had a rebase conflict with PR #1030's "Reviewer gate" addition to `caro-coder-loop.md`. The local proxy blocks force-push, so the rebased branch was pushed as `feat/wire-coder-loop-to-stakeholders-v2`. Same diff, both features reconciled (4 Pick specialist → 5 Delegate → 6 Reviewer gate → 7 Validate → 8 Open PR → 9 Loop).