### PR TITLE
feat(skills): wire caro-coder-loop + caro-backlog-groom to STAKEHOLDERS.yml (reconciled)

### DIFF
--- a/.claude/commands/caro-backlog-groom.md
+++ b/.claude/commands/caro-backlog-groom.md
@@ -75,6 +75,9 @@ for issue in groom_issues.json:
     existing = bd_find_by_external_ref(f"gh-{issue.number}")
     priority = derive_priority(issue.labels)  # P0→0, security→0, P1→1, docs→3
     phase = derive_phase_from_milestone_or_labels(issue)
+    # Compute STAKEHOLDERS.yml suggestions up-front so the coder-loop
+    # doesn't have to re-derive them on every claim.
+    suggested_agents = stakeholders_lookup(issue.body, issue.title)
 
     if not existing:
         bd create <issue.title> \
@@ -83,12 +86,39 @@ for issue in groom_issues.json:
           --parent caro-xk0 \
           --external-ref gh-$issue.number \
           --labels "v1.2.0,$phase,auto-groomed" \
+          --metadata "suggested_agents=$suggested_agents" \
           --description "GH: https://github.com/wildcard/caro/issues/$issue.number"
         log_create(issue.number, beads_id)
     elif existing.title != issue.title or existing.priority != priority:
-        bd update $existing.id --title "$issue.title" --priority $priority
+        bd update $existing.id --title "$issue.title" --priority $priority \
+          --metadata "suggested_agents=$suggested_agents"
         log_update(issue.number, existing.id)
 ```
+
+**`stakeholders_lookup` reference implementation**:
+
+```bash
+stakeholders_lookup() {
+  local body="$1" title="$2"
+  # Extract candidate paths from the issue body + title
+  local paths=$(printf '%s\n%s' "$body" "$title" \
+    | grep -oE '(src/[a-z_/]+|tests/[a-z_]+|website/[^ ]+|\.github/[^ ]+|Cargo\.[a-z]+)' \
+    | sort -u)
+  # For each path, find the longest STAKEHOLDERS glob match. Emit a
+  # comma-separated agent list, deduped, longest-prefix-wins.
+  for p in $paths; do
+    yq -r --arg p "$p" '
+      .areas | to_entries[]
+      | select(.key as $k | $p | test($k))
+      | (.key | length) as $score
+      | "\($score)|\(.value.agents | join(\",\"))"
+    ' .github/STAKEHOLDERS.yml
+  done | sort -rn | head -1 | cut -d'|' -f2
+}
+```
+
+If no path match is found, fall back to the legacy label heuristic
+(`documentation` → `spark`; otherwise `kraken`).
 
 ### B2. Pushed branches without PR → WIP beads task
 

--- a/.claude/commands/caro-coder-loop.md
+++ b/.claude/commands/caro-coder-loop.md
@@ -56,11 +56,48 @@ gh issue view "${GH_ISSUE#gh-}" > /tmp/issue-body.md
 ls specs/v1.2-delivering-on-the-promise/ 2>/dev/null && cat specs/v1.2-delivering-on-the-promise/tech-spec.md
 ```
 
-### 4. Delegate to kraken (or spark for docs)
+### 4. Pick the right specialist agent
 
-**Agent selection:**
+**Consult `.github/STAKEHOLDERS.yml` first.** The map pairs codebase paths
+with the specialist agents that should own changes there. Pick the most
+specific glob match for the paths the task is likely to touch — derived
+from the issue body, beads labels (`area:safety`, `area:ml`, …), or the
+title.
+
+```bash
+# Heuristic: extract candidate paths from the issue body
+PATHS=$(grep -oE '(src/[a-z_/]+|tests/[a-z_]+|website/[^ ]+|\.github/[^ ]+|Cargo\.[a-z]+)' /tmp/issue-body.md | sort -u)
+
+# Look up agents per path; the first concrete glob match wins
+yq -r --arg p "$PATHS" '
+  .areas | to_entries[] | select(.key as $k | $p | test($k))
+  | "\(.key) -> \(.value.agents | join(\",\"))"
+' .github/STAKEHOLDERS.yml | head -3
+```
+
+The agent named on the most-specific match becomes the **primary** specialist
+for the task. Examples:
+
+| Path touched | Primary specialist |
+|---|---|
+| `src/safety/patterns.rs` | `safety-pattern-developer` (TDD discipline required) |
+| `src/safety/**` | `safety-pattern-developer`, fall back to `safety-pattern-auditor` |
+| `src/backends/embedded_backend.rs` | `llm-integration-expert` |
+| `src/ai/**`, `src/eval/**` | `ml-ds-engineer` |
+| `src/cli/**`, `src/main.rs` | `rust-cli-expert` |
+| `Cargo.toml`, `.github/workflows/release.yml` | `caro-release-expert` |
+| `website/**` | `technical-writer` |
+| `website/src/i18n/**` | `technical-writer` + `cultural-heritage-expert` |
+| `specs/**` | `spec-driven-dev-guide` |
+
+**Fallback rules** (when STAKEHOLDERS.yml has no match):
 - `labels` contains `documentation` → use **spark** (Sonnet, fast)
 - Otherwise → use **kraken** (Opus, TDD for Rust safety-critical code)
+
+**Critical**: never bypass `safety-pattern-developer` for `src/safety/**`
+changes — that path requires the TDD-first workflow encoded in the skill.
+
+### 5. Delegate to the specialist
 
 Spawn via Task tool with this prompt template:
 
@@ -76,7 +113,7 @@ You are implementing beads task $NEXT (GitHub #${GH_ISSUE#gh-}) for caro v1.2.0.
 **Acceptance criteria**: see the task description and the v1.2.0 tech spec at specs/v1.2-delivering-on-the-promise/tech-spec.md.
 
 **Conventions** (from /Users/kobik-private/workspace/caro/CLAUDE.md):
-- Rust edition 2021, MSRV 1.83
+- Rust edition 2021, MSRV 1.85
 - Use `thiserror` for error types, `anyhow::Result` for application errors
 - TDD: write failing test FIRST, then make it pass
 - All commit messages conventional: `<type>(<scope>): <subject>` + Co-Authored-By
@@ -91,7 +128,7 @@ When done:
 2. Report: files changed, tests added, clippy status, test pass count
 ```
 
-### 4.5. Reviewer gate (swarm-forge pattern)
+### 6. Reviewer gate (swarm-forge pattern)
 
 Before validating or opening a PR, spawn an independent **Reviewer** sub-agent
 via the Task tool. Borrowed from swarm-forge's Architect → Coder → **Reviewer**
@@ -152,7 +189,7 @@ fi
 bin/notify reviewer "pass $NEXT"
 ```
 
-### 5. Validate locally
+### 7. Validate locally
 
 ```bash
 cargo fmt --check
@@ -162,7 +199,7 @@ cargo test
 
 If any fail: `bd update "$NEXT" --status blocked --notes "validation failed: <err>"`, push branch for debugging, exit loop.
 
-### 6. Open PR + close beads task
+### 8. Open PR + close beads task
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -194,7 +231,7 @@ bin/notify coder "pr opened $PR_URL ($NEXT)"
 echo "✓ closed $NEXT → $PR_URL"
 ```
 
-### 7. Loop
+### 9. Loop
 
 Return to step 1 until `bd ready` has no v1.2.0 entries OR user interrupts.
 


### PR DESCRIPTION
## Summary

Replaces **#1062** (closed because the local proxy blocked the force-push needed after rebasing on top of PR #1030's "Reviewer gate" addition). Same intent, but the conflict is now resolved: both features land cleanly.

Closes the loop on **oz-for-oss Pattern 2**. The `.github/STAKEHOLDERS.yml` map landed in #1032 with no consumers — this PR wires the two skills that orchestrate autonomous development (`caro-coder-loop` and `caro-backlog-groom`) to consult it.

### Reconciled step numbering in `caro-coder-loop.md`

After merging with PR #1030's swarm-forge Reviewer gate:

| Step | Source |
|---|---|
| 1 Claim | existing |
| 2 Create isolated worktree | existing |
| 3 Gather context | existing |
| **4 Pick the right specialist agent** | **this PR** |
| **5 Delegate to the specialist** | **this PR** (renumbered from old "4 Delegate") |
| 6 Reviewer gate (swarm-forge) | from #1030 (was 4.5) |
| 7 Validate locally | existing (was 5, then 6) |
| 8 Open PR + close beads task | existing (was 6, then 7) |
| 9 Loop | existing (was 7, then 8) |

### `caro-coder-loop` — Pattern 2 step

- **Step 4**: derives candidate paths from the issue body (regex over `src/`, `tests/`, `website/`, `.github/`, `Cargo.toml`) and looks them up against `STAKEHOLDERS.yml` via `yq`, longest-glob-prefix wins.
- Explicit reference table of common paths → specialist agent (safety, ml, cli, release, website, i18n, specs).
- **Critical guard**: never bypass `safety-pattern-developer` for `src/safety/**`.
- **Fallback**: legacy `documentation → spark, otherwise kraken` when no STAKEHOLDERS match.
- Bumps MSRV reference from `1.83` to `1.85` to match #1056.

### `caro-backlog-groom`

- **Phase B1 precomputes `stakeholders_lookup(body, title)`** when ingesting GH issues into beads, storing the suggested agents on the bead's metadata.
- Reference bash implementation of `stakeholders_lookup` included — uses `yq` with a longest-glob-prefix-wins scoring rule.
- Backwards compatible — beads without `suggested_agents` metadata fall back to the legacy heuristic.

## Behavior change

**None until the next scheduled tick.** These files are prompt templates consumed by Claude Code at run time. The next `caro-coder-loop` invocation will read the new content; the next `caro-backlog-groom` cycle will start writing `suggested_agents` to bead metadata.

## Test plan

- [ ] Manually invoke `/caro-coder-loop` against a beads task that touches `src/safety/**`. Expect step 4 to identify `safety-pattern-developer`.
- [ ] Manually invoke `/caro-backlog-groom` and verify `bd show <id> --json` includes `suggested_agents` metadata for newly-created tasks.
- [ ] Sanity-check the `yq` snippet against `.github/STAKEHOLDERS.yml` with `$p="src/safety/patterns.rs"` — should return `safety-pattern-developer`.
- [ ] Verify the legacy fallback still works for a beads task whose issue body has no path references.
- [ ] Verify the new step 6 Reviewer gate (from #1030) still runs after step 5 Delegate.

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `caro-coder-loop` and `caro-backlog-groom` to `.github/STAKEHOLDERS.yml` to auto-select specialist agents by path. Reconciles coder-loop step order with the Reviewer gate and updates Rust MSRV reference to 1.85.

- **New Features**
  - `caro-coder-loop`: adds Step 4 to pick the primary specialist from `.github/STAKEHOLDERS.yml` via `yq` (longest-glob-prefix); never bypass `safety-pattern-developer` for `src/safety/**`; fallback stays docs→`spark`, else `kraken`; steps renumbered (5 Delegate, 6 Reviewer gate, 7 Validate, 8 PR, 9 Loop).
  - `caro-backlog-groom`: Phase B1 precomputes `suggested_agents = stakeholders_lookup(body, title)` and stores it in bead metadata; `yq` implementation uses longest-glob-prefix; falls back to the legacy label heuristic when no match.
  - Effective on the next scheduled runs; prompt templates only.

<sup>Written for commit 667ea3a8a6d3a729761a6108ad6dd8966c7baf44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

