### PR TITLE
fix(static-matcher): #947 — emit full kill pipeline for CPU-process queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature-gated ones. Rust 1.85 was stabilized 2025-02-20, ~14 months
   before this bump.
 
+### Fixed
+
+- **Static matcher: "find and kill the runaway process eating CPU" now emits
+  the full website-promised pipeline** (`ps aux | sort -nrk 3,3 | head -1 |
+  awk '{print $2}' | xargs kill`) instead of the bare `kill PID` placeholder.
+  Added a 3-keyword pattern (`kill` + `process` + `cpu`) that wins the
+  static matcher's specificity-sort over the general 2-keyword "Kill a
+  process" pattern, so queries that include CPU-process context resolve to
+  a runnable command. Covers `find and kill the runaway process eating CPU`,
+  `kill the process using the most CPU`, `kill the top CPU process`, and
+  `kill the runaway process hogging CPU`. Closes the v1.4.0 release-
+  acceptance P0 carry-forward.
+  ([#947](https://github.com/wildcard/caro/issues/947))
+
 ## [1.4.0] - 2026-05-09
 
 ### Added

--- a/src/backends/static_matcher.rs
+++ b/src/backends/static_matcher.rs
@@ -1159,6 +1159,45 @@ impl StaticMatcher {
                 description: "List crontab scheduled jobs".to_string(),
             },
 
+            // Kill the top CPU-consuming process — matches the website's
+            // "find and kill the runaway process eating CPU" promise
+            // (see website/src/data/gtm-use-cases.ts; tracked as #947).
+            //
+            // Specificity = 3 (kill+process+cpu) → wins the specificity-sort
+            // over the general "Kill a process" pattern (specificity = 2),
+            // preventing the bare `kill PID` placeholder from firing on
+            // queries that include CPU-process context.
+            PatternEntry {
+                required_keywords: vec![
+                    "kill".to_string(),
+                    "process".to_string(),
+                    "cpu".to_string(),
+                ],
+                optional_keywords: vec![
+                    "runaway".to_string(),
+                    "top".to_string(),
+                    "find".to_string(),
+                    "eating".to_string(),
+                    "consuming".to_string(),
+                    "hogging".to_string(),
+                    "highest".to_string(),
+                    "most".to_string(),
+                    "using".to_string(),
+                ],
+                regex_pattern: Some(
+                    Regex::new(
+                        r"(?i)(kill|terminate|stop).*(?:(process|runaway).*(cpu|processor|eating|hogging|consuming|hog)|(cpu|top).*process)",
+                    )
+                    .unwrap(),
+                ),
+                gnu_command: "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill"
+                    .to_string(),
+                bsd_command: Some(
+                    "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill".to_string(),
+                ),
+                description: "Kill the top CPU-consuming process".to_string(),
+            },
+
             // Kill process by PID
             PatternEntry {
                 required_keywords: vec!["kill".to_string(), "pid".to_string()],
@@ -1952,6 +1991,72 @@ mod tests {
 
         let result = matcher.generate_command(&request).await;
         assert!(result.is_ok());
+    }
+
+    /// Website-promised use case at `website/src/data/gtm-use-cases.ts:9`:
+    /// "find and kill the runaway process eating CPU" must emit the full
+    /// pipeline that actually performs the kill, not the bare `kill PID`
+    /// placeholder. Regression caught by `.claude/beta-testing/runs/
+    /// 2026-04-26-smoketest/findings/01-website-broken-promise-find-and-kill.md`
+    /// and the v1.4.0 release-acceptance audit (#947).
+    #[tokio::test]
+    async fn test_website_example_5_find_and_kill_runaway_cpu_process() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        let request = CommandRequest::new(
+            "find and kill the runaway process eating CPU",
+            ShellType::Bash,
+        );
+
+        let result = matcher.generate_command(&request).await;
+        assert!(
+            result.is_ok(),
+            "Expected static-matcher to produce a command, got {:?}",
+            result
+        );
+
+        let cmd = result.unwrap();
+        assert_eq!(
+            cmd.command,
+            "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill",
+            "Tracking #947: caro must emit the full kill pipeline (per website \
+             gtm-use-cases.ts:9), not the bare `kill PID` placeholder. \
+             v1.3.0 emitted only `ps aux | sort -nrk 3,3` (half-pipeline); \
+             v1.4.0 regressed to `kill PID` (literal placeholder)."
+        );
+    }
+
+    /// Sibling phrasings of the v1.4.0 #947 case — once the CPU-kill
+    /// pattern lands, the same pipeline should serve common rewordings.
+    #[tokio::test]
+    async fn test_kill_cpu_process_variant_phrasings() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        let expected =
+            "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill";
+
+        for query in [
+            "kill the process using the most CPU",
+            "kill the top CPU process",
+            "kill the runaway process hogging CPU",
+        ] {
+            let request = CommandRequest::new(query, ShellType::Bash);
+            let result = matcher.generate_command(&request).await;
+            assert!(
+                result.is_ok(),
+                "Query {:?} expected to match CPU-kill pattern, got {:?}",
+                query,
+                result
+            );
+            assert_eq!(
+                result.unwrap().command,
+                expected,
+                "Query {:?} should resolve to the full CPU-kill pipeline (#947)",
+                query
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/backends/static_matcher.rs
+++ b/src/backends/static_matcher.rs
@@ -2018,8 +2018,7 @@ mod tests {
 
         let cmd = result.unwrap();
         assert_eq!(
-            cmd.command,
-            "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill",
+            cmd.command, "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill",
             "Tracking #947: caro must emit the full kill pipeline (per website \
              gtm-use-cases.ts:9), not the bare `kill PID` placeholder. \
              v1.3.0 emitted only `ps aux | sort -nrk 3,3` (half-pipeline); \
@@ -2034,8 +2033,7 @@ mod tests {
         let profile = CapabilityProfile::ubuntu();
         let matcher = StaticMatcher::new(profile);
 
-        let expected =
-            "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill";
+        let expected = "ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill";
 
         for query in [
             "kill the process using the most CPU",


### PR DESCRIPTION
## Summary

**Closes #947** — the v1.4.0 release-acceptance P0 carry-forward.

The static matcher returned the bare \`kill PID\` placeholder for queries like \"find and kill the runaway process eating CPU\" (the website-advertised use case at \`website/src/data/gtm-use-cases.ts:9\`). This PR adds a 3-keyword pattern (\`kill\` + \`process\` + \`cpu\`) that wins the specificity-sort over the existing 2-keyword \"Kill a process general\" pattern, so the matcher emits the website-promised pipeline:

\`\`\`
ps aux | sort -nrk 3,3 | head -1 | awk '{print \$2}' | xargs kill
\`\`\`

## Root cause

\`src/backends/static_matcher.rs:1182-1190\` has a general \"Kill a process\" entry:

\`\`\`rust
required_keywords: vec![\"kill\".to_string(), \"process\".to_string()],
regex_pattern: Some(Regex::new(r\"(?i)(kill|stop|terminate).*process\").unwrap()),
gnu_command: \"kill PID\".to_string(),
\`\`\`

The query \"find and kill the runaway process eating CPU\" contains both required keywords. The matcher sorts patterns by \`required_keywords.len()\` descending, so with no more-specific pattern present, this 2-keyword pattern fires and returns the literal placeholder \`kill PID\`.

## Fix

Added a CPU-specific pattern at \`src/backends/static_matcher.rs:1162\` (immediately before the existing kill patterns):

\`\`\`rust
required_keywords: [\"kill\", \"process\", \"cpu\"]   // specificity = 3
regex_pattern: r\"(?i)(kill|terminate|stop).*(?:(process|runaway).*(cpu|processor|eating|hogging|consuming|hog)|(cpu|top).*process)\"
gnu_command: \"ps aux | sort -nrk 3,3 | head -1 | awk '{print \$2}' | xargs kill\"
description: \"Kill the top CPU-consuming process\"
\`\`\`

Specificity 3 > 2 → new pattern wins the sort and fires first for queries containing all three keywords.

## TDD evidence

| Phase | Test | Status |
|---|---|---|
| **RED** | \`test_website_example_5_find_and_kill_runaway_cpu_process\` | ❌ \`left: \"kill PID\"\` vs \`right: \"ps aux \| sort -nrk 3,3 \| head -1 \| awk ''{print \$2}'' \| xargs kill\"\` |
| **RED** | \`test_kill_cpu_process_variant_phrasings\` (3 variants) | ❌ same shape |
| **GREEN** | Both tests after patch | ✅ pass |

## Regression evidence

| Test scope | Before | After |
|---|---|---|
| \`backends::static_matcher\` (existing) | 19/19 | 21/21 (✅ +2 new tests) |
| \`backends\` total | 54/54 | 56/56 |
| \`safety\` | 19/19 | 19/19 |
| \`cargo clippy --lib -- -D warnings\` | clean | clean |

Manual smoke against the rebuilt v1.4.0 binary:

| Query | Output | Pattern |
|---|---|---|
| \"find and kill the runaway process eating CPU\" (verbatim) | full pipeline ✅ | Kill the top CPU-consuming process |
| \"kill the process using the most CPU\" | full pipeline ✅ | same |
| \"kill the top CPU process\" | full pipeline ✅ | same |
| \"kill the process by name myapp\" | \`killall process_name\` ✅ | Kill all processes by name (no regression) |
| \"kill process with PID 1234\" | \`kill -9 PID\` ✅ | Kill process by PID (no regression) |

Safety level: **Moderate**, not blocked. The pipeline passes safety validation.

## Why this matters

This is the **P0 blocker** documented in \`.claude/releases/v1.4.0-acceptance.md\` (PR #1067). Per \`~/.claude/rules/release-acceptance-verification.md\`, \`/caro.release.prepare\` for v1.4.1 / v1.5.0 cannot proceed while #947 is open. Merging this PR closes #947 and clears the gate.

## Test plan

- [ ] Confirm \`cargo test backends::static_matcher\` passes (21 tests, including 2 new)
- [ ] Confirm \`cargo clippy --lib -- -D warnings\` clean
- [ ] Smoke-test rebuilt binary against \"find and kill the runaway process eating CPU\" → expect full pipeline
- [ ] Verify #947 closes on merge

## Companion PRs in this acceptance cycle

- #1061 — ChromaDB CI flake (unblocks merge queue)
- #1067 — v1.4.0 acceptance audit artifact (\`BLOCKED\` verdict — this PR resolves the blocker)
- #1063 — P2 hardcoded hex in Footer.astro (separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CPU-process kill queries to emit the full pipeline `ps aux | sort -nrk 3,3 | head -1 | awk '{print $2}' | xargs kill` instead of `kill PID` by adding a more specific `kill` + `process` + `cpu` pattern. Closes #947.

- **Bug Fixes**
  - Added a 3-keyword pattern that outranks the general rule so CPU-focused queries return the full pipeline on GNU/BSD; covers “most CPU”, “top CPU process”, and “hogging CPU”.
  - Added tests for the website example and common variants; no regressions for kill-by-name or kill-by-PID.

- **Refactors**
  - Applied `cargo fmt` to test assertions; no behavior change.

<sup>Written for commit b839992025343fd1957a8c204adb66a732e5dc2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

