### PR TITLE
chore(gitignore): ignore .claude/worktrees/ from sub-agent isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ tests/evaluation/results/*.md
 
 # Git worktrees (local development, not shared)
 .worktrees/
+.claude/worktrees/
 
 # Continuous-Claude session continuity
 # Ledgers are OPTIONAL to track (uncomment if you want to share session state)


### PR DESCRIPTION
## Summary

The Claude Code Task tool spawns sub-agents in isolated git worktrees under `.claude/worktrees/agent-<id>/`. These are ephemeral parallel workspaces — they should never be tracked.

This mirrors the existing `.worktrees/` line (gitignored at .gitignore:217) for `bin/sk-new-feature` worktrees. Same intent, different parent directory.

## Why now

Surfaced by the `stop-hook-git-check.sh` after I spawned 3 background follow-up agents (issues #1049, #1050, #1051) from the just-merged swarm-forge integration session (#1030). The hook correctly flagged `.claude/worktrees/` as untracked; this PR is the minimal fix.

## Test plan

- [x] `git status --short` clean after the change (the running sub-agent worktrees are now ignored)
- [x] Existing `.worktrees/` ignore unchanged
- [ ] On next sub-agent spawn, no untracked-file noise from the stop hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXrAVMVdnHFUVn7Zasrsgd)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `.claude/worktrees/` in `.gitignore` so ephemeral sub-agent worktrees created with `isolation: worktree` aren’t tracked. Mirrors the existing `.worktrees/` rule and prevents stop-hook untracked-file noise.

<sup>Written for commit b94eb7a4f28323d394185b440d152b708b759f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

