### PR TITLE
fix(static-matcher): #979 — emit kill -SIG commands for signal queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature-gated ones. Rust 1.85 was stabilized 2025-02-20, ~14 months
   before this bump.
 
+### Fixed
+
+- **Static matcher: signal-management queries get specific `kill -SIG`
+  commands** instead of the `kill PID` placeholder or `ps aux` catch-all:
+  - `pause a process using SIGSTOP` (and `halt`/`suspend a process`) →
+    `kill -STOP PID`
+  - `resume a stopped process using SIGCONT` (and `continue`/`unpause`) →
+    `kill -CONT PID`
+  - `list all available signals` (and `show`/`enumerate signals`) →
+    `kill -l`
+
+  Three new patterns added before the general "Kill a process" entry in
+  `src/backends/static_matcher.rs`. Word-boundary anchoring on the Pause
+  regex prevents `unpause` from partially matching `pause`. Brings the
+  signals-family cluster pass-rate above #979's 50% acceptance threshold.
+  ([#979](https://github.com/wildcard/caro/issues/979))
+
 ## [1.4.0] - 2026-05-09
 
 ### Added

--- a/src/backends/static_matcher.rs
+++ b/src/backends/static_matcher.rs
@@ -1159,6 +1159,81 @@ impl StaticMatcher {
                 description: "List crontab scheduled jobs".to_string(),
             },
 
+            // ============================================================
+            // Signal handling — match BEFORE the general "Kill a process"
+            // pattern so signal-related queries get specific commands.
+            // Tracked as #979 (cluster: signals-ps-catchall/wrong-command).
+            //
+            // The general "Kill a process" regex `(?i)(kill|stop|terminate)
+            // .*process` mis-fires on `stopped process` (the `stop`
+            // substring inside `stopped`), returning the `kill PID`
+            // placeholder for any query containing "stopped process".
+            // These specific patterns intercept signal-management intent
+            // and emit `kill -<SIG> PID` instead.
+            // ============================================================
+
+            // Pause a process (SIGSTOP)
+            //
+            // Word-boundary `\b` on `pause` is critical so this pattern
+            // does NOT fire on `unpause the process` (where `pause` is a
+            // substring of `unpause`) — that query belongs to the
+            // SIGCONT pattern below.
+            PatternEntry {
+                required_keywords: vec!["pause".to_string(), "process".to_string()],
+                optional_keywords: vec![
+                    "sigstop".to_string(),
+                    "halt".to_string(),
+                    "suspend".to_string(),
+                    "signal".to_string(),
+                ],
+                regex_pattern: Some(
+                    Regex::new(r"(?i)\b(pause|halt|suspend)\s+(a\s+|the\s+)?(process|task)")
+                        .unwrap(),
+                ),
+                gnu_command: "kill -STOP PID".to_string(),
+                bsd_command: Some("kill -STOP PID".to_string()),
+                description: "Pause a process (SIGSTOP)".to_string(),
+            },
+
+            // Resume a stopped process (SIGCONT)
+            PatternEntry {
+                required_keywords: vec!["resume".to_string(), "process".to_string()],
+                optional_keywords: vec![
+                    "sigcont".to_string(),
+                    "continue".to_string(),
+                    "unpause".to_string(),
+                    "signal".to_string(),
+                    "stopped".to_string(),
+                ],
+                regex_pattern: Some(
+                    Regex::new(
+                        r"(?i)(resume|continue|unpause)\s+(a\s+|the\s+)?(stopped\s+)?(process|task)",
+                    )
+                    .unwrap(),
+                ),
+                gnu_command: "kill -CONT PID".to_string(),
+                bsd_command: Some("kill -CONT PID".to_string()),
+                description: "Resume a stopped process (SIGCONT)".to_string(),
+            },
+
+            // List all available signals (kill -l)
+            PatternEntry {
+                required_keywords: vec!["list".to_string(), "signals".to_string()],
+                optional_keywords: vec![
+                    "all".to_string(),
+                    "available".to_string(),
+                    "show".to_string(),
+                    "display".to_string(),
+                    "enumerate".to_string(),
+                ],
+                regex_pattern: Some(
+                    Regex::new(r"(?i)(list|show|display|enumerate)\s+(all\s+)?(available\s+)?signals?\b").unwrap(),
+                ),
+                gnu_command: "kill -l".to_string(),
+                bsd_command: Some("kill -l".to_string()),
+                description: "List all available signals (kill -l)".to_string(),
+            },
+
             // Kill process by PID
             PatternEntry {
                 required_keywords: vec!["kill".to_string(), "pid".to_string()],
@@ -1952,6 +2027,98 @@ mod tests {
 
         let result = matcher.generate_command(&request).await;
         assert!(result.is_ok());
+    }
+
+    /// #979 acceptance criterion 1: "pause a process using SIGSTOP" must
+    /// emit `kill -STOP PID`, not the bare `kill PID` placeholder nor the
+    /// `ps aux` catch-all.
+    #[tokio::test]
+    async fn test_signal_pause_emits_kill_stop() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        for query in [
+            "pause a process using SIGSTOP",
+            "halt a process",
+            "suspend a process",
+        ] {
+            let request = CommandRequest::new(query, ShellType::Bash);
+            let result = matcher.generate_command(&request).await;
+            assert!(
+                result.is_ok(),
+                "Query {:?} expected to match SIGSTOP pattern, got {:?}",
+                query,
+                result
+            );
+            assert_eq!(
+                result.unwrap().command,
+                "kill -STOP PID",
+                "Query {:?} should map to SIGSTOP semantics (#979 acceptance #1)",
+                query
+            );
+        }
+    }
+
+    /// #979 acceptance criterion 2: "resume a stopped process using SIGCONT"
+    /// must emit `kill -CONT PID`. The v1.3.0 / v1.4.0 bug was that the
+    /// general "Kill a process" regex `(?i)(kill|stop|terminate).*process`
+    /// fires on `stopped process` (the `stop` substring inside `stopped`),
+    /// returning `kill PID` placeholder.
+    #[tokio::test]
+    async fn test_signal_resume_emits_kill_cont() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        for query in [
+            "resume a stopped process using SIGCONT",
+            "continue a stopped process",
+            "unpause the process",
+        ] {
+            let request = CommandRequest::new(query, ShellType::Bash);
+            let result = matcher.generate_command(&request).await;
+            assert!(
+                result.is_ok(),
+                "Query {:?} expected to match SIGCONT pattern, got {:?}",
+                query,
+                result
+            );
+            assert_eq!(
+                result.unwrap().command,
+                "kill -CONT PID",
+                "Query {:?} should map to SIGCONT semantics (#979 acceptance #2)",
+                query
+            );
+        }
+    }
+
+    /// #979 acceptance criterion 3: "list all available signals on this
+    /// system" must emit `kill -l`, not the `ls` catch-all (matched on the
+    /// `list` keyword pre-fix).
+    #[tokio::test]
+    async fn test_signal_list_emits_kill_l() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        for query in [
+            "list all available signals on this system",
+            "show all signals",
+            "enumerate signals",
+        ] {
+            let request = CommandRequest::new(query, ShellType::Bash);
+            let result = matcher.generate_command(&request).await;
+            assert!(
+                result.is_ok(),
+                "Query {:?} expected to match list-signals pattern, got {:?}",
+                query,
+                result
+            );
+            assert_eq!(
+                result.unwrap().command,
+                "kill -l",
+                "Query {:?} should resolve to `kill -l` (#979 acceptance #3)",
+                query
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

**Closes #979** (cluster: signals-ps-catchall/wrong-command).

Three signal-management queries from #979's acceptance criteria now resolve to specific \`kill -SIG\` commands instead of placeholders or catch-all matches.

| Query | Before | After |
|---|---|---|
| \"pause a process using SIGSTOP\" | error / \`ps aux\` catch-all | \`kill -STOP PID\` |
| \"resume a stopped process using SIGCONT\" | \`kill PID\` (general pattern misfire) | \`kill -CONT PID\` |
| \"list all available signals on this system\" | error / \`ls\` catch-all | \`kill -l\` |

Variant phrasings (\`halt\` / \`suspend\` / \`continue\` / \`unpause\` / \`show signals\` / \`enumerate signals\`) also map to the correct commands.

## Root cause

The general \"Kill a process\" pattern at \`src/backends/static_matcher.rs:1182\` has regex \`(?i)(kill|stop|terminate).*process\` — the \`stop\` alternation fires on the substring \`stop\` inside \`stopped process\`, returning \`kill PID\` placeholder for any query containing those two words. Other signal queries miss every pattern and fall through to the LLM.

## Fix

Three new \`PatternEntry\` structs inserted BEFORE the general \"Kill a process\" entry (same insertion strategy used in #1069 for #947):

| Pattern | Specificity | Regex |
|---|---|---|
| Pause / SIGSTOP | 2 (pause+process) | \`\\b(pause\\|halt\\|suspend)\\s+(a\\s+\\|the\\s+)?(process\\|task)\` |
| Resume / SIGCONT | 2 (resume+process) | \`(resume\\|continue\\|unpause)\\s+(a\\s+\\|the\\s+)?(stopped\\s+)?(process\\|task)\` |
| List signals / kill -l | 2 (list+signals) | \`(list\\|show\\|display\\|enumerate)\\s+(all\\s+)?(available\\s+)?signals?\\b\` |

The \`\\b\` word boundary on the Pause regex is critical: without it, \"unpause the process\" partially matches \`pause\` and gets the wrong command. Caught by \`test_signal_resume_emits_kill_cont\` during TDD.

## TDD evidence

| Phase | Tests | Status |
|---|---|---|
| **RED** | \`test_signal_pause_emits_kill_stop\` | ❌ \`Err(BackendUnavailable)\` |
| **RED** | \`test_signal_resume_emits_kill_cont\` | ❌ \`left: \"kill PID\"\` |
| **RED** | \`test_signal_list_emits_kill_l\` | ❌ \`Err(BackendUnavailable)\` |
| **GREEN** | All 3 after patch | ✅ pass (with variants) |

## Regression evidence

| Test scope | Before | After |
|---|---|---|
| \`backends::static_matcher\` | 19/19 | 22/22 (✅ +3 new tests) |
| \`backends\` total | 54/54 | 57/57 |
| \`safety\` | 19/19 | 19/19 |
| \`cargo clippy --lib -- -D warnings\` | clean | clean |
| \`cargo fmt --check\` | clean | clean |

## Relationship to other open PRs

- **#1069** (closes #947, P0): fixes the *CPU-kill* sibling bug using the same approach (3-keyword pattern beating the catch-all). Both PRs add specific entries to \`static_matcher.rs\`; merge order doesn't matter — they don't touch the same lines.
- **#1067** (v1.4.0 audit, BLOCKED verdict): the audit's blocking gap is #947, not #979 (#979 is P2). #979 still being open doesn't prevent the audit from clearing once #1069 lands. But closing #979 is independently valuable for the campaign-eval cluster pass-rate.

## Scope honesty

This PR addresses the **3 explicit acceptance criteria** in #979 — pause, resume, list-signals. The remaining 2 sub-bugs in the cluster (general \"send SIGXXX to process\" and \"send signal to process group\") are intentionally out of scope. They need a different shape (per-signal pattern proliferation or a parametric \`kill -<SIG>\` template, both bigger lifts) and #979's acceptance metric is the cluster pass-rate, which this PR satisfies.

## Test plan

- [ ] Confirm \`cargo test backends::static_matcher\` passes (22 tests including 3 new)
- [ ] Confirm \`cargo clippy --lib -- -D warnings\` clean
- [ ] Smoke-test rebuilt binary against the 3 verbatim queries from #979 → expect \`kill -STOP/CONT/l PID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit specific `kill -SIG` commands for signal queries (pause, resume, list) to replace catch-all outputs and meet #979’s acceptance criteria. Closes #979.

- **Bug Fixes**
  - Added three specific patterns in `src/backends/static_matcher.rs` before the general kill rule:
    - pause/halt/suspend a process → `kill -STOP PID`
    - resume/continue/unpause a stopped process → `kill -CONT PID`
    - list/show/enumerate signals → `kill -l`
  - Prevented misfires on “stopped process” by ordering patterns and adding a word boundary on “pause” (so “unpause” matches SIGCONT, not SIGSTOP).
  - Added 3 tests covering the above; all backends tests pass.

<sup>Written for commit 5bb632e26e2c5ae08739ab0222b6dcba630ebdd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

