### PR TITLE
fix(msrv): bump Rust 1.83 → 1.85 to unblock MSRV CI (#1049)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,16 +377,16 @@ jobs:
   # ============================================================================
 
   msrv:
-    name: MSRV Check (Rust 1.83)
+    name: MSRV Check (Rust 1.85)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Rust 1.83
+    - name: Install Rust 1.85
       uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: 1.83
+        toolchain: 1.85
 
     - name: Cache cargo
       uses: actions/cache@v5
@@ -398,11 +398,12 @@ jobs:
         key: ${{ runner.os }}-msrv-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     # Note: We use --no-default-features to exclude the 'knowledge' feature
-    # because its dependencies (fastembed -> image -> aligned) require Rust 2024 edition
-    - name: Build with Rust 1.83
+    # because its dependencies (fastembed -> image -> aligned -> geodatafusion -> i_tree)
+    # require edition2024 which is only stabilized in Rust 1.85+.
+    - name: Build with Rust 1.85
       run: cargo build --release --locked --no-default-features --features embedded-cpu
 
-    - name: Run tests with Rust 1.83
+    - name: Run tests with Rust 1.85
       run: cargo test --lib --locked --no-default-features --features embedded-cpu
       env:
         RUST_BACKTRACE: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV bumped from 1.83 to 1.85** — The CaroML stack (PRs #904–#914) added
+  `lancedb` as an optional dependency (behind the `knowledge` feature).
+  `lancedb 0.23` transitively pulls in `geodatafusion → i_tree`, whose
+  `Cargo.toml` uses `feature = 'edition2024'`, only stabilised in Cargo 1.85.
+  Because `cargo build --locked` parses every entry in `Cargo.lock` regardless
+  of feature flags, the MSRV CI job (which uses `--locked`) failed even with
+  `--no-default-features`. No version of `lancedb 0.23.x` avoids this chain,
+  making a feature-gate insufficient. Rust 1.85 was stabilised 2025-02-20;
+  current stable is 1.86+. Anyone building from source on 1.83/1.84 can pin to
+  v1.3.x. Closes #1049.
+
 ### Added
 
 - **CaroML preview** — a meta-language for intent-tracked shell tasks. A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
  "mlx-rs",
  "once_cell",
  "os_info",
+ "predicates",
  "proptest",
  "regex",
  "reqwest 0.11.27",
@@ -3450,6 +3451,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6198,6 +6208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7182,7 +7198,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "caro"
 version = "1.3.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 description = "Convert natural language to shell commands using local LLMs"
 license = "AGPL-3.0"
 authors = ["Wildcard <kobi@caro.sh>", "Claude Code <noreply@anthropic.com>"]
@@ -133,7 +133,7 @@ regex = "1.10"
 tempfile = "3.10"
 serial_test = "3"
 proptest = "1"
-criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.83
+criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.85
 futures = "0.3"
 serde_yaml = "0.9"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ cargo build --release
 ./target/release/caro --version
 ```
 
-**Prerequisites**: Rust 1.83+, CMake. For Apple Silicon GPU acceleration, install Xcode.
+**Prerequisites**: Rust 1.85+, CMake. For Apple Silicon GPU acceleration, install Xcode.
 
 See [BUILD.md](docs/BUILD.md) for detailed build instructions.
 
@@ -531,7 +531,7 @@ For current usage, ChromaDB works well for basic command storage and retrieval, 
 ## 🔧 Development
 
 ### Prerequisites
-- Rust 1.83+ (latest stable recommended)
+- Rust 1.85+ (latest stable recommended)
 - Cargo
 - Make (optional, for convenience commands)
 - Docker (optional, for development container)


### PR DESCRIPTION
## Summary

- Bumps `rust-version` from `1.83` to `1.85` in `Cargo.toml`
- Updates CI MSRV job name/toolchain from 1.83 to 1.85
- Regenerates `Cargo.lock` to include `predicates` dev-dep added by CaroML stack but missing from the lockfile
- Updates README prerequisites (2 occurrences) and adds CHANGELOG entry

## Root cause

The CaroML stack (PRs #904–#914) added `lancedb` as an optional dependency behind the `knowledge` feature. `lancedb 0.23` transitively requires:

```
lancedb → lance-namespace-impls → lance-geo → geodatafusion → i_tree
```

`geodatafusion v0.1.1`'s `Cargo.toml` uses `feature = 'edition2024'`, which requires Cargo 1.85 to parse. Because `cargo build --locked` parses **every entry** in `Cargo.lock` during resolution — even for packages behind optional feature flags — the MSRV job (`cargo build --release --locked --no-default-features --features embedded-cpu`) fails with:

```
error: failed to download `geodatafusion v0.1.1`
  feature `edition2024` is required
  The package requires the Cargo feature called `edition2024`, but that
  feature is not stabilized in this version of Cargo (1.83.0)
```

## Fix path chosen: (a) bump MSRV

Path (b) — feature-gate caroml — was evaluated and rejected because:

- `lancedb` is already behind the `knowledge` feature (not in `default`)
- The lockfile still contains `geodatafusion`/`i_tree` regardless of `--no-default-features`
- `cargo build --locked` validates ALL lockfile entries at fetch time, making feature gates ineffective against this manifest-parse error
- No version of `lancedb 0.23.x` exists without the `geodatafusion` transitive dep

Rust 1.85 was stabilised 2025-02-20 (~15 months ago); current stable is 1.94. Users on 1.83/1.84 building from source can pin to `v1.3.x`.

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | `rust-version = "1.83"` → `"1.85"`, criterion pin comment updated |
| `Cargo.lock` | Regenerated — adds `predicates`/`float-cmp`/`normalize-line-endings` entries missing since CaroML stack added `predicates` as dev-dep |
| `.github/workflows/ci.yml` | MSRV job name, toolchain, step labels: 1.83 → 1.85; comment updated to mention geodatafusion chain |
| `README.md` | Prerequisites: `Rust 1.83+` → `Rust 1.85+` (2 occurrences) |
| `CHANGELOG.md` | Added `Changed` entry under `[Unreleased]` with full diagnosis |

## Before / after

**Before** (`cargo +1.83 fetch --locked` on original `cb75bd3` lockfile):
```
error: failed to download `geodatafusion v0.1.1`
  feature `edition2024` is required
  The package requires the Cargo feature called `edition2024`, but that
  feature is not stabilized in this version of Cargo (1.83.0)
```

**After** (stable 1.94, sandbox network prevents 1.85 download for direct verification):
```
Finished `release` profile [optimized] target(s) in 2m 47s
```

## Test plan

- [x] `cargo build --release --locked --no-default-features --features embedded-cpu` — Finished cleanly
- [x] `cargo test --lib --locked --no-default-features --features embedded-cpu` — 513 passed; 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo +1.83 fetch --locked` still fails with `edition2024` — confirming root cause documented
- [ ] `cargo +1.85 build --release --locked …` — CI will validate (1.85 not available in sandbox)

Closes #1049

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXrAVMVdnHFUVn7Zasrsgd)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump MSRV to Rust 1.85 to fix MSRV CI failures caused by the optional `lancedb` → `geodatafusion` chain requiring Cargo’s `edition2024`. Updates CI, lockfile, and docs to align with the new MSRV.

- **Dependencies**
  - Set `rust-version = "1.85"` in `Cargo.toml`; update MSRV CI job/toolchain to 1.85.
  - Regenerate `Cargo.lock` (adds `predicates` and related crates); update `README` and `CHANGELOG`.

- **Migration**
  - Require Rust 1.85+ to build. Users on 1.83/1.84 can pin to v1.3.x.

<sup>Written for commit c285818fef256c8a3c35f8ef01c437e239a73315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

