### PR TITLE
chore(ci): migrate remaining 5 workflows to setup-rust composite

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          cache-key-suffix: cargo-audit
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -28,10 +28,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zsh
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          cache-key-suffix: installer
 
       - name: Test install.sh on bash
         run: |

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -23,18 +23,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-llm-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: llm
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-llm-
 
       - name: Build release binary
         run: cargo build --release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          cache-key-suffix: publish
+          install-protobuf: "true"
 
       - name: Verify version consistency
         id: version
@@ -40,26 +41,8 @@ jobs:
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "Version check passed: $TAG_VERSION"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v5
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y protobuf-compiler cmake
+      - name: Install cmake (additional system dep)
+        run: sudo apt-get install -y cmake
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/website-claims.yml
+++ b/.github/workflows/website-claims.yml
@@ -45,20 +45,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-claims-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
+          cache-key-suffix: claims
+          cache-restore-keys: |
+            ${{ runner.os }}-cargo-claims-
             ${{ runner.os }}-claims-cargo-
 
       - name: Build caro
@@ -154,19 +146,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: windows-claims-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-key-suffix: claims-windows
+          cache-restore-keys: |
+            Windows-cargo-claims-windows-
+            windows-claims-cargo-
 
       - name: Build caro
         run: cargo build --release --features embedded-cpu,remote-backends


### PR DESCRIPTION
**Closing in favour of #NEW (v2 branch)** — the local proxy is rejecting pushes to this PR's branch (HTTP 403). The follow-up commit reverts the `installer.yml` part of the migration (CI showed `install (ubuntu)` failing at `Test setup.sh on bash` with exit 127, unrelated to the composite but worth de-risking). The other 4 migrations remain.