### PR TITLE
feat(automation): adopt oz-for-oss Pattern 5 — config-as-code + GitHub App docs

### DIFF
--- a/.github/CARO_BOT.md
+++ b/.github/CARO_BOT.md
@@ -1,0 +1,100 @@
+# Caro Bot — GitHub App configuration
+
+Currently caro's automation runs as `github-actions[bot]` (the default
+workflow token). The slash router, spec pipeline, and other automation
+post comments under that identity.
+
+For better attribution, finer-grained permissions, and cleaner credential
+rotation, the recommended setup is a dedicated **Caro Bot GitHub App** —
+mirroring [warpdotdev/oz-for-oss's `oz-bot`](https://github.com/warpdotdev/oz-for-oss).
+This document captures the registration steps. **It is a maintainer-only
+task** — agents cannot perform App registration autonomously.
+
+## Why a GitHub App over a Personal Access Token (PAT)
+
+| Concern | PAT | GitHub App |
+|---|---|---|
+| Identity in PR comments | Author's username | `caro-bot[bot]` |
+| Scope | All of the user's repos | Just the caro repo |
+| Permission granularity | Org-wide | Per-resource |
+| Rotation | Manual; user-blocking when expired | Programmatic via short-lived install tokens |
+| Audit trail | Mingled with human user | Separate bot lane |
+
+The recent `CARGO_REGISTRY_TOKEN` expiration incident documented in
+`.claude/rules/release-version-alignment.md` is exactly the failure mode
+an App avoids for non-publish automation (cargo publish itself still
+needs the cargo token).
+
+## Registration steps (maintainer-only)
+
+1. **Create the App** at https://github.com/settings/apps/new
+   - Name: `Caro Bot`
+   - Homepage: https://caro.sh
+   - Webhook: not required for installation-token use
+   - Permissions:
+     - Repository: **Contents** (read), **Issues** (write), **Pull
+       requests** (write), **Metadata** (read)
+     - No organisation permissions, no user permissions
+   - Subscribe to events: none (we use Actions for triggers)
+   - "Where can this GitHub App be installed?": Only on this account
+2. **Generate a private key** on the App's settings page; download the
+   `.pem` file once (you cannot re-download it).
+3. **Install the App** on `wildcard/caro` only.
+4. **Add secrets** under
+   https://github.com/wildcard/caro/settings/secrets/actions:
+   - `CARO_BOT_APP_ID` — the numeric App ID from the App settings page
+   - `CARO_BOT_APP_KEY` — paste the contents of the downloaded `.pem`
+5. **Verify**: run the `Slash Command Router` workflow manually (or
+   comment `/caro version` on any issue/PR). Once the App is wired up
+   (see migration steps below), the reply should be attributed to
+   `caro-bot[bot]` rather than `github-actions[bot]`.
+
+## Migration steps for workflows (also queued for a separate PR)
+
+Workflows that need to attribute their actions to Caro Bot get this
+preface before any `gh`/`actions/github-script` step:
+
+```yaml
+- name: Generate Caro Bot installation token
+  id: caro-bot-token
+  uses: tibdex/github-app-token@v2
+  with:
+    app_id: ${{ secrets.CARO_BOT_APP_ID }}
+    private_key: ${{ secrets.CARO_BOT_APP_KEY }}
+
+- name: Use the token
+  env:
+    GITHUB_TOKEN: ${{ steps.caro-bot-token.outputs.token }}
+  run: gh issue comment …
+```
+
+Initial migration targets (in order of payoff):
+- `.github/workflows/slash-router.yml` — biggest visibility win
+- A future `spec-from-issue.yml` (Pattern 4)
+- A future `implement-from-spec.yml` (Pattern 4)
+
+Workflows that should **not** migrate to the bot token:
+- `release.yml`, `publish.yml` — must use `CARGO_REGISTRY_TOKEN` for
+  crates.io and the default `GITHUB_TOKEN` for GitHub releases.
+- `cla.yml` — owned by a third-party app, leave alone.
+- `dependabot` / `cubic` / `cubic AI` / GitGuardian — third-party
+  identities, leave alone.
+
+## Rotation
+
+When `CARO_BOT_APP_KEY` needs rotating:
+
+1. Generate a new private key on the App's settings page.
+2. Update the `CARO_BOT_APP_KEY` secret.
+3. Delete the old key from the App's settings page.
+4. Trigger any workflow that uses the token (e.g. comment `/caro version`
+   somewhere) — `tibdex/github-app-token@v2` mints a fresh installation
+   token on every workflow run, so there is no cache to invalidate.
+
+## Status
+
+**Today:** not registered. Slash router and any other comment-driven
+automation continues using the default `GITHUB_TOKEN`.
+
+**When wired up:** see migration steps above; track via a new GitHub
+issue tagged `area:ci` + `pattern:5` referencing this document.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,8 @@ Cargo.lock @wildcard
 /.github/workflows/publish.yml @wildcard
 /.github/CODEOWNERS @wildcard
 /.github/STAKEHOLDERS.yml @wildcard
+/.github/caro/ @wildcard
+/.github/CARO_BOT.md @wildcard
 
 # ─── Install distribution ─────────────────────────────────────────────
 /scripts/install.sh @wildcard

--- a/.github/STAKEHOLDERS.yml
+++ b/.github/STAKEHOLDERS.yml
@@ -163,6 +163,20 @@ areas:
     agents: [caro-release-expert]
     review_label: "area:ci"
 
+  ".github/caro/**":
+    humans: ["@wildcard"]
+    agents: [caro-release-expert, dev-team-coordinator]
+    review_label: "area:automation"
+    description: >
+      Caro automation defaults (config-as-code). Changes here ripple
+      through every consumer; review carefully. See
+      `.github/CARO_BOT.md` for the related GitHub App setup.
+
+  ".github/CARO_BOT.md":
+    humans: ["@wildcard"]
+    agents: [caro-release-expert]
+    review_label: "area:automation"
+
   "scripts/install.sh":
     humans: ["@wildcard"]
     agents: [caro-release-expert]

--- a/.github/caro/config.yml
+++ b/.github/caro/config.yml
@@ -1,0 +1,107 @@
+# Caro automation defaults
+#
+# Inspired by warpdotdev/oz-for-oss's `.github/oz/config.yml`. This file
+# centralises automation knobs that would otherwise be hard-coded across
+# .github/workflows/, .claude/skills/, and .claude/commands/.
+#
+# Consumers are wired up incrementally; the data file ships first so
+# downstream workflows can adopt it one at a time without coordination.
+#
+# Resolution rules (when a future consumer reads a key):
+#   1. Look up the most-specific key under the consumer's section
+#   2. Fall back to `defaults`
+#   3. Fall back to a hard-coded sane value in the consumer
+#
+# Editing this file requires CODEOWNERS review (see .github/CODEOWNERS:
+# /.github/caro/ rule, mirrored from .github/STAKEHOLDERS.yml).
+
+version: 1
+
+# ─── Repository-wide defaults ─────────────────────────────────────────
+defaults:
+  # Branch new PRs target. `auto` = detect the repository's default branch
+  # via GitHub's API; explicit `main` would override.
+  base_branch: auto
+
+  # Default reviewers requested on every PR not already covered by
+  # CODEOWNERS or STAKEHOLDERS.yml.
+  reviewers: ["@wildcard"]
+
+  # Default human owner cited in change-management messages.
+  primary_human: "@wildcard"
+
+  # Bot identity. Today this is `github-actions[bot]` (the default
+  # workflow token). When the Caro Bot GitHub App is registered (see
+  # `.github/CARO_BOT.md`) and `CARO_BOT_APP_KEY` is populated, the
+  # slash router and spec/impl pipelines will switch to attribute their
+  # comments to this identity.
+  bot_identity: "caro-bot"
+
+# ─── Issue triage automation ──────────────────────────────────────────
+triage:
+  # Label that issue-triage.yml applies after a successful initial pass.
+  # Consumers downstream (e.g. spec pipeline) gate on this label.
+  triaged_label: "triaged"
+
+  # Labels that, when present on an issue, indicate it should not be
+  # auto-processed any further. Useful for human-flagged escapes.
+  do_not_touch_labels: ["needs-human", "blocked", "wontfix"]
+
+  # Default priority when nothing else matches (mirrors the table in
+  # `.claude/commands/caro-backlog-groom.md::Phase C`).
+  default_priority: 2
+
+# ─── Spec / implementation pipeline (Pattern 4, queued) ───────────────
+# Wired up when the issue → spec → implementation workflow lands.
+spec_pipeline:
+  # Issue label that triggers spec generation.
+  spec_label: "ready-for-spec"
+
+  # PR label that triggers implementation scaffolding once the spec PR
+  # has merged.
+  impl_label: "ready-for-impl"
+
+  # Where generated specs live, relative to repo root.
+  specs_dir: "specs/GH"
+
+  # Reviewers auto-requested on every generated spec PR.
+  reviewers: ["@wildcard"]
+
+# ─── Slash command router (Pattern 3, partial) ────────────────────────
+slash_router:
+  # Commands the router knows about. The list mirrors the case statement
+  # in `.github/workflows/slash-router.yml` -- update both when adding a
+  # command. Status: `available` runs today; `planned` is documented in
+  # `.github/SLASH_COMMANDS.md` but not yet handled.
+  commands:
+    help:               { status: available }
+    echo:               { status: available }
+    version:            { status: available }
+    review:             { status: planned, handler: ultrareview }
+    qa:                 { status: planned, handler: "caro.qa" }
+    spec:               { status: planned, handler: speckit-specify }
+    tune-prompt:        { status: planned, handler: prompt-tuner }
+    release-acceptance: { status: planned, handler: "caro.release.acceptance" }
+
+# ─── Release pipeline ─────────────────────────────────────────────────
+release:
+  # Secret name that the Publish workflow uses to upload to crates.io.
+  # Document the rotation procedure in `.claude/rules/release-version-alignment.md`.
+  publish_token_secret: CARGO_REGISTRY_TOKEN
+
+  # CHANGELOG header to mark a release entry as the cut version.
+  changelog_header_format: "## [{version}] - {date}"
+
+  # MSRV displayed in release notes and README. Bumps require all four
+  # files updated atomically -- see .claude/rules/release-version-alignment.md.
+  msrv: "1.85"
+
+# ─── Coder loop (Pattern 2, wired in #1068) ───────────────────────────
+coder_loop:
+  # Hard cap on consecutive Reviewer-block iterations before a beads
+  # task is marked blocked. Per swarm-forge pattern.
+  max_reviewer_retries: 3
+
+  # Default specialist when STAKEHOLDERS.yml has no path match.
+  fallback_specialist: "kraken"
+  documentation_specialist: "spark"


### PR DESCRIPTION
## Summary

Closes the oz-for-oss adoption rollout with **Pattern 5 — config-as-code + GitHub App docs**.

Two new files centralise automation defaults that were previously hard-coded across workflows and skills:

### `.github/caro/config.yml`

Tiered defaults file modeled on `warpdotdev/oz-for-oss`'s `.github/oz/config.yml`. Sections:

| Section | Knobs |
|---|---|
| `defaults` | `base_branch: auto`, `reviewers: [@wildcard]`, `bot_identity` |
| `triage` | `triaged_label`, `do_not_touch_labels`, `default_priority` |
| `spec_pipeline` | `spec_label`, `impl_label`, `specs_dir` (queued for Pattern 4) |
| `slash_router` | command-status table (mirrors `slash-router.yml` + `SLASH_COMMANDS.md`) |
| `release` | `publish_token_secret`, `changelog_header_format`, `msrv` |
| `coder_loop` | `max_reviewer_retries`, `fallback_specialist`, `documentation_specialist` |

Resolution rules: consumer reads most-specific section → falls back to `defaults` → falls back to a hard-coded sane value. **No behaviour change today** — like `STAKEHOLDERS.yml`, this is the data file; consumers wire up in follow-up PRs.

### `.github/CARO_BOT.md`

Step-by-step GitHub App registration guide for the maintainer (App registration cannot be done autonomously by an agent). Covers:

- App creation form values + permissions (Contents: read, Issues/PRs: write, Metadata: read)
- Required secrets: `CARO_BOT_APP_ID`, `CARO_BOT_APP_KEY`
- `tibdex/github-app-token@v2` migration recipe for `slash-router.yml` and future spec/impl pipelines
- What **not** to migrate (release/publish/cla/dependabot keep their current tokens)
- Rotation procedure

### Ownership

`CODEOWNERS` + `STAKEHOLDERS.yml` updated so `.github/caro/**` and `.github/CARO_BOT.md` route to `@wildcard` + the `caro-release-expert` and `dev-team-coordinator` agents, with a new `area:automation` review label.

## Test plan

- [ ] `python -c "import yaml; yaml.safe_load(open('.github/caro/config.yml'))"` — valid YAML.
- [ ] `STAKEHOLDERS.yml` now lists 36 areas (was 34).
- [ ] CI passes (no executable code touched).
- [ ] Verify the `slash_router.commands` table in `config.yml` matches the case statement in `.github/workflows/slash-router.yml::parse`.

## Rollout status after this PR

| Pattern | State |
|---|---|
| 1 — `setup-rust` composite | ✅ merged (#1032, #1077); 21 jobs / 9 workflows |
| 2 — STAKEHOLDERS routing | ✅ merged (#1032, #1068); coder-loop + backlog-groom consume it |
| 3 — slash command router | ✅ merged (#1041); scaffold only, real handlers queued |
| 4 — issue → spec → impl pipeline | ⏸ queued; needs Claude API key in CI |
| 5 — config-as-code + GitHub App | 🔁 this PR (config + docs; App registration is a maintainer task) |

## Out of scope

- Wiring individual consumers to read from `config.yml` — separate PRs:
  - `.github/workflows/slash-router.yml` reading `slash_router.commands` for trigger filtering
  - `.claude/commands/caro-backlog-groom.md` reading `triage.default_priority` and `triage.do_not_touch_labels`
  - `.claude/commands/caro-coder-loop.md` reading `coder_loop.max_reviewer_retries` and `coder_loop.fallback_specialist`
- GitHub App registration itself — needs maintainer to do steps in `.github/CARO_BOT.md`.
- Migration of comment-posting workflows from `GITHUB_TOKEN` to App token — covered by `CARO_BOT.md`'s migration section, will land once the App exists.

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds config-as-code for automation and a GitHub App setup guide to prepare for bot-based auth. No behavior change; completes oz-for-oss Pattern 5 groundwork.

- **New Features**
  - Added `.github/caro/config.yml` with tiered defaults for `defaults`, `triage`, `spec_pipeline` (queued), `slash_router`, `release`, and `coder_loop` with clear fallback rules; consumers will adopt this incrementally.
  - Added `.github/CARO_BOT.md` with step-by-step GitHub App registration (permissions, secrets `CARO_BOT_APP_ID` and `CARO_BOT_APP_KEY`), migration via `tibdex/github-app-token@v2`, what not to migrate, and rotation.
  - Updated `CODEOWNERS` and `STAKEHOLDERS.yml` to route `.github/caro/**` and `.github/CARO_BOT.md` to `@wildcard` with the `area:automation` review label.

- **Migration**
  - Maintainer to register the Caro Bot GitHub App and add required secrets; workflow migrations will land in a follow-up PR.

<sup>Written for commit 5a2c69bfe929be0f487d101d7d7ae76b91b5579d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

