### PR TITLE
fix(static-matcher): word-boundary size alternation in patterns 2 & 6

### DIFF
--- a/src/backends/static_matcher.rs
+++ b/src/backends/static_matcher.rs
@@ -235,10 +235,23 @@ impl StaticMatcher {
             PatternEntry {
                 required_keywords: vec!["file".to_string(), "100".to_string()],
                 optional_keywords: vec!["find".to_string(), "over".to_string(), "mb".to_string(), "large".to_string(), "big".to_string(), "bigger".to_string()],
-                regex_pattern: Some(Regex::new(r"(?i)(find|locate|show|list).*(large|big|bigger).*(files?).*(over|above|bigger|greater|than).*(100|100mb|100m|megabyte)").unwrap()),
+                regex_pattern: Some(Regex::new(r"(?i)(find|locate|show|list).*(large|big|bigger).*(files?).*(over|above|bigger|greater|than).*\b100\s*(?:mb|m|megabyte)\b").unwrap()),
                 gnu_command: "find . -type f -size +100M".to_string(),
                 bsd_command: Some("find . -type f -size +100M".to_string()),
                 description: "Find large files over 100MB".to_string(),
+            },
+
+            // Pattern 2b: "find files larger than 100MB" (files-before-larger
+            // word order, mirrors Pattern 6's structure for the 10MB bucket).
+            // Word-boundary on the size value prevents accidental matches on
+            // "1000MB". Added after PR #1079 review identified the latent bug.
+            PatternEntry {
+                required_keywords: vec!["file".to_string(), "100".to_string(), "larger".to_string()],
+                optional_keywords: vec!["find".to_string(), "bigger".to_string(), "mb".to_string()],
+                regex_pattern: Some(Regex::new(r"(?i)(find|locate|list|show).*(files?).*(larger|bigger|over|above|greater).*\b100\s*(?:mb|m)\b").unwrap()),
+                gnu_command: "find . -type f -size +100M".to_string(),
+                bsd_command: Some("find . -type f -size +100M".to_string()),
+                description: "Find files larger than 100MB".to_string(),
             },
 
             // Pattern 3: "show me disk usage/space by directory, sorted" (SPECIFIC - moved from Pattern 48)
@@ -300,10 +313,12 @@ impl StaticMatcher {
             },
 
             // Pattern 6: "find files larger than 10MB" (GENERAL - was Pattern 5)
+            // The size alternation is word-boundary-anchored so a 10MB query
+            // is not accidentally satisfied by the "10" inside "100MB" / "1000MB".
             PatternEntry {
                 required_keywords: vec!["file".to_string(), "10".to_string(), "larger".to_string()],
                 optional_keywords: vec!["find".to_string(), "bigger".to_string(), "mb".to_string()],
-                regex_pattern: Some(Regex::new(r"(?i)(find|locate|list|show).*(files?).*(larger|bigger|over|above|greater).*(10|10mb|10m)").unwrap()),
+                regex_pattern: Some(Regex::new(r"(?i)(find|locate|list|show).*(files?).*(larger|bigger|over|above|greater).*\b10\s*(?:mb|m)\b").unwrap()),
                 gnu_command: "find . -type f -size +10M".to_string(),
                 bsd_command: Some("find . -type f -size +10M".to_string()),
                 description: "Find files larger than 10MB".to_string(),
@@ -2066,6 +2081,43 @@ mod tests {
 
         let result = matcher.generate_command(&request).await;
         assert!(result.is_err());
+    }
+
+    // Regression: PR #1079 review surfaced that the 10MB pattern's size
+    // alternation `(10|10mb|10m)` would substring-match the "10" inside
+    // "100MB" / "1000MB", returning `+10M` for a query asking about 100MB.
+    // After the word-boundary fix, the 10MB pattern only fires on a real
+    // 10MB query and the new Pattern 2b handles 100MB explicitly.
+    #[tokio::test]
+    async fn test_size_pattern_word_boundary_10mb_vs_100mb() {
+        let profile = CapabilityProfile::ubuntu();
+        let matcher = StaticMatcher::new(profile);
+
+        let r10 = matcher
+            .generate_command(&CommandRequest::new(
+                "find all files larger than 10MB",
+                ShellType::Bash,
+            ))
+            .await
+            .expect("10MB query should match");
+        assert!(
+            r10.command.contains("+10M") && !r10.command.contains("+100M"),
+            "10MB query should produce +10M, got: {}",
+            r10.command
+        );
+
+        let r100 = matcher
+            .generate_command(&CommandRequest::new(
+                "find all files larger than 100MB",
+                ShellType::Bash,
+            ))
+            .await
+            .expect("100MB query should match (Pattern 2b)");
+        assert!(
+            r100.command.contains("+100M"),
+            "100MB query should produce +100M, got: {}",
+            r100.command
+        );
     }
 
     #[tokio::test]

--- a/src/evaluation/evaluators/utils.rs
+++ b/src/evaluation/evaluators/utils.rs
@@ -67,10 +67,14 @@ pub fn command_equivalence(cmd1: &str, cmd2: &str) -> bool {
                 // Remove explicit -s and --max-depth for normalization
                 flags.retain(|f| !f.starts_with("-s") && !f.starts_with("--max-depth"));
                 flags.sort();
-                format!("du {} {}", flags.join(" ").trim(), args.join(" ")).trim().to_string()
+                format!("du {} {}", flags.join(" ").trim(), args.join(" "))
+                    .trim()
+                    .to_string()
             } else {
                 flags.sort();
-                format!("du {} {}", flags.join(" ").trim(), args.join(" ")).trim().to_string()
+                format!("du {} {}", flags.join(" ").trim(), args.join(" "))
+                    .trim()
+                    .to_string()
             }
         }
         if normalize_du(&norm1) == normalize_du(&norm2) {

--- a/tests/evaluation/dataset.yaml
+++ b/tests/evaluation/dataset.yaml
@@ -98,10 +98,23 @@
   input_request: "find all files larger than 10MB"
   expected_command: "find . -type f -size +10M"
   validation_rule: pattern_match
-  validation_pattern: "find.*-size.*+10M"
+  validation_pattern: "find.*-size.*\\+10M"
   tags: ["find", "size", "disk"]
   difficulty: medium
   source: "manual"
+
+# Regression test for pattern-6 substring-match bug: a "100MB" query
+# must not be satisfied by the 10MB pattern (whose alternation contained a
+# bare "10" that matched inside "100"). See fix/pattern6-word-boundary.
+- id: correctness-008b
+  category: correctness
+  input_request: "find all files larger than 100MB"
+  expected_command: "find . -type f -size +100M"
+  validation_rule: pattern_match
+  validation_pattern: "find.*-size.*\\+100M"
+  tags: ["find", "size", "disk", "regression"]
+  difficulty: medium
+  source: "review-1079"
 
 - id: correctness-009
   category: correctness


### PR DESCRIPTION
## Summary

Surfaced during [`/review` of #1079](https://github.com/wildcard/caro/pull/1079#issuecomment-4438214141). PR #1079 addressed the symptom (eval input said 100MB but expected `+10M`) by changing the input to 10MB to match the static matcher's output. This PR fixes the **root cause** so a real user typing `100MB` also gets the correct command.

## The bug

Pattern 6's size alternation:

```rust
regex_pattern: Some(Regex::new(r"(?i)(find|locate|list|show).*(files?).*(larger|bigger|over|above|greater).*(10|10mb|10m)").unwrap())
```

The bare `10` in `(10|10mb|10m)` had no word boundary, so it substring-matched the `10` inside `100MB`, `1000MB`, etc. A user typing `find all files larger than 100MB` fired Pattern 6 and got `+10M`.

Pattern 2 (`find large files over 100MB`) only matched the `large + files + over` word order, leaving the natural `files + larger + 100MB` order uncovered — so it didn't save us either.

## The fix

- **Pattern 6** regex: `\b10\s*(?:mb|m)\b` — word boundary anchors the size value so `10` no longer matches inside `100`. Still accepts `10MB`, `10 MB`, `10m`.
- **Pattern 2** regex: tightened to `\b100\s*(?:mb|m|megabyte)\b` for consistency with Pattern 6.
- **New Pattern 2b** mirrors Pattern 6's structure but for 100MB, covering the `files + larger + 100MB` word order.
- **New eval case** `correctness-008b`: locks in `find all files larger than 100MB` → `+100M` as a regression test.
- **Fixed escape regression** on `correctness-008`'s `validation_pattern` — the unescaped `+` from PR #1079 parsed as a regex quantifier (technically valid, semantically wrong).
- **New Rust unit test** `test_size_pattern_word_boundary_10mb_vs_100mb` asserts both queries route to the right pattern.

## Verification

```bash
cargo test --lib static_matcher
# test result: ok. 22 passed; 0 failed
cargo clippy --lib --no-deps
# clean
```

## Why this is a separate PR from #1079

PR #1079 is about introducing the Hermes agent. The eval/matcher changes that landed alongside it (commits 60603452 / a9d8cd2e) addressed the failing test by changing the question rather than fixing the regex. That's now on `main`, so this PR is a small forward-looking correctness improvement that doesn't conflict with #1079.

## Test plan

- [x] `cargo build --lib` succeeds
- [x] `cargo test --lib static_matcher` — 22/22 pass
- [x] `cargo clippy --lib --no-deps` — clean
- [x] New regression test `test_size_pattern_word_boundary_10mb_vs_100mb` covers both sizes
- [ ] CI passes (will verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes size matching so “100MB” no longer triggers the 10MB rule. Tightens regexes with word boundaries and adds a 100MB pattern so users get the correct find command.

- **Bug Fixes**
  - Pattern 6: use `\b10\s*(?:mb|m)\b` to prevent substring matches inside `100MB`/`1000MB`.
  - Pattern 2: tighten to `\b100\s*(?:mb|m|megabyte)\b`; add Pattern 2b to cover the “files + larger + 100MB” order.
  - Tests: add eval case `correctness-008b` and unit test `test_size_pattern_word_boundary_10mb_vs_100mb`.
  - Dataset: escape `+` in `validation_pattern` to match literal `+10M`.

- **Refactors**
  - Format `src/evaluation/evaluators/utils.rs` with `cargo fmt` to satisfy `rustfmt`/CI; no logic changes.

<sup>Written for commit 35e3659b56ac1ec6d7fc9ee4d3a4badcd7912f95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

