### PR TITLE
fix(safety): catch long-flag and 4-digit octal bypasses in filesystem-permission pattern

### DIFF
--- a/src/safety/patterns.rs
+++ b/src/safety/patterns.rs
@@ -72,7 +72,7 @@ pub static DANGEROUS_PATTERNS: Lazy<Vec<DangerPattern>> = Lazy::new(|| {
             shell_specific: None,
         },
         DangerPattern {
-            pattern: r"chmod\s+(-[rRfvn]+\s+)*777\s+/".to_string(),
+            pattern: r"chmod\s+((-[rRfvn]+|--recursive)\s+)*0?777\s+/".to_string(),
             risk_level: RiskLevel::High,
             description: "Permission change making root world-writable (recursive or direct)"
                 .to_string(),

--- a/tests/safety_validator_contract.rs
+++ b/tests/safety_validator_contract.rs
@@ -839,3 +839,61 @@ async fn test_bsd_safe_commands_no_false_positives() {
         );
     }
 }
+
+// --- filesystem-permission bypass tests (TDD RED phase) ---
+// Three variants that bypass the line-75 pattern. Each must be High/Critical
+// and blocked. They are expected to FAIL until the pattern is updated.
+
+#[tokio::test]
+async fn test_chmod_long_flag_recursive_bypass() {
+    // GNU long-option form: (-[rRfvn]+\s+)* iterates zero times, so
+    // "--recursive " stands between "chmod " and "777", breaking the match.
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let cmd = "chmod --recursive 777 /";
+    let result = validator
+        .validate_command(cmd, ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        matches!(result.risk_level, RiskLevel::High | RiskLevel::Critical),
+        "chmod --recursive 777 / must be High/Critical, got {:?}",
+        result.risk_level
+    );
+    assert!(!result.allowed, "chmod --recursive 777 / must be blocked");
+}
+
+#[tokio::test]
+async fn test_chmod_4digit_octal_bypass() {
+    // 4-digit octal: line-75 matches literal "777"; the leading zero in "0777"
+    // shifts the digit sequence so the pattern never anchors correctly.
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let cmd = "chmod -R 0777 /";
+    let result = validator
+        .validate_command(cmd, ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        matches!(result.risk_level, RiskLevel::High | RiskLevel::Critical),
+        "chmod -R 0777 / must be High/Critical, got {:?}",
+        result.risk_level
+    );
+    assert!(!result.allowed, "chmod -R 0777 / must be blocked");
+}
+
+#[tokio::test]
+async fn test_chmod_long_flag_4digit_octal_bypass() {
+    // Combined: GNU long flag + 4-digit octal. Neither existing pattern covers
+    // this combination.
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let cmd = "chmod --recursive 0777 /";
+    let result = validator
+        .validate_command(cmd, ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        matches!(result.risk_level, RiskLevel::High | RiskLevel::Critical),
+        "chmod --recursive 0777 / must be High/Critical, got {:?}",
+        result.risk_level
+    );
+    assert!(!result.allowed, "chmod --recursive 0777 / must be blocked");
+}


### PR DESCRIPTION
Fixes 3 dangerous chmod bypasses in the filesystem-permission regex at patterns.rs line 75. The old pattern only matched short flags (-R) and literal 777. Now also matches GNU long flags (--recursive) and 4-digit octal (0777). TDD: tests first, then fix. All 21 tests pass, clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the filesystem-permission regex to catch `chmod` bypasses using GNU long flags and 4-digit octal. This blocks commands like `chmod --recursive 777 /` and `chmod -R 0777 /` as High risk.

- **Bug Fixes**
  - Update pattern to `chmod\s+((-[rRfvn]+|--recursive)\s+)*0?777\s+/` to cover `--recursive` and `0?777`.
  - Add three contract tests for long-flag, 4-digit octal, and their combination.

<sup>Written for commit 6cb442749ae29999345eb0686d6e226653de502a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

