### PR TITLE
feat(demo): caro-demo-video drift detection + maintenance protocol

### DIFF
--- a/.claude/skills/caro-demo-video/SKILL.md
+++ b/.claude/skills/caro-demo-video/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: caro-demo-video
-description: Build, render, and ship the caro landing-page demo video using Remotion (React-based programmatic video). Use when creating, updating, re-rendering, or extending the project demo MP4 that lives in website/public/caro-demo.mp4 and feeds the LPVideoDemo slot on the English landing page.
+description: Build, render, ship, AND MAINTAIN the caro landing-page demo video using Remotion. Use when creating, updating, re-rendering, extending the project demo MP4 at website/public/caro-demo.mp4 — or when responding to a drift alert from the caro-demo-drift CI workflow or a beads task with label `caro-demo-video`.
 ---
 
 # Caro Demo Video
 
 Reproducible, on-brand product demo video for the caro website, rendered
-from React code via [Remotion](https://www.remotion.dev/).
+from React code via [Remotion](https://www.remotion.dev/). This skill
+covers the full lifecycle: **build → render → ship → detect drift →
+re-render**.
 
 ## When to Use
 
@@ -15,6 +17,8 @@ from React code via [Remotion](https://www.remotion.dev/).
 - "update the landing page video"
 - "add a new scene to the demo"
 - "the demo on the website is missing / outdated"
+- "the caro-demo-drift workflow flagged my PR — what now?"
+- A beads task with label `caro-demo-video` is in your `bd ready` queue
 
 ## What This Skill Owns
 
@@ -195,6 +199,107 @@ explicitly extending scope.
 3. Re-render and re-ship per the Build Workflow above.
 4. Bump the version number in the demo's title bar (e.g.
    `caro v1.4.0 — demo`) only if a major release dropped.
+
+## Drift Detection
+
+The video bakes in mutable facts: brand colors, terminal chrome design,
+real CLI output strings, the "52+" pattern count, install commands.
+These come from 7 specific files. Drift between those files and the
+shipped MP4 means the video is lying about the product.
+
+### Baseline manifest
+
+[`demos/remotion-video/.baseline-manifest.json`](../../demos/remotion-video/.baseline-manifest.json)
+is the source of truth. It records:
+
+1. **Tripwire SHAs** — SHA-256 of each watched file at the last
+   successful render. Mechanical, cheap to check.
+2. **Semantic claims** — the actual scene-text strings baked into the
+   video: pattern count, install command, block message, the three
+   Scene 2 query/output pairs, the Scene 3 query. So the next agent
+   reading the manifest can see at a glance what the video *says*,
+   without having to re-derive it from the source code.
+
+### Watched files (7)
+
+| File | Why it matters | Affects |
+|---|---|---|
+| `website/src/ui/tokens.css` | Brand palette | All scenes |
+| `website/src/components/landing/LPDemo.astro` | Terminal chrome design | All scenes |
+| `src/main.rs` (lines ~1014–1023) | CLI block-message string | Scene 3 |
+| `.claude/beta-testing/test-cases.yaml` | Verified caro queries + outputs | Scene 2 |
+| `src/safety/patterns.rs` | Pattern count (currently 52) | Scene 3 caption |
+| `homebrew-tap/README.md` | Install command | Scene 4 |
+| `install.sh` | Curl-pipe install | Scene 4 |
+
+### Run the check
+
+```bash
+demos/remotion-video/scripts/check-drift.sh --human
+```
+
+Exit codes: `0` no drift, `1` drift detected, `2` tooling error.
+Default output is JSON; `--human` is for terminals.
+
+### Triggers (how an agent gets here)
+
+Three independent channels — at least one will catch drift:
+
+1. **CI watcher (path-filtered)** —
+   [`.github/workflows/caro-demo-drift.yml`](../../.github/workflows/caro-demo-drift.yml)
+   runs `check-drift.sh` on every PR that touches a watched file. If
+   drift is detected, the workflow comments on the PR with the specific
+   files that changed and links here.
+2. **Monthly cron** — a scheduled beads task (label `caro-demo-video`)
+   forces a fresh check even when no PR touched a watched path. Catches
+   slow brand drift over many small commits.
+3. **Manual / human-triggered** — anyone can run the check script and
+   file a beads task tagged `caro-demo-video`.
+
+## Trust Model — when can an agent ship without human review?
+
+The re-rendered MP4 is a public-facing marketing asset. Two paths:
+
+| Drift type | Examples | Required action |
+|---|---|---|
+| **Output-equivalent** | tokens.css color literal renames (e.g. variable rename, same hex value); whitespace-only changes in LPDemo.astro; install.sh comment edits | Agent re-renders and ships directly. Visual diff against the prior poster.png must be within ±5% pixel delta. |
+| **Cosmetic but visible** | Hex color value changes; LPDemo chrome restyle; new pattern count claim ("52+" → "60+") | Agent renders, opens a PR with the new MP4 + poster, requests human review. |
+| **Semantic** | Scene 2 query strings drift; block message changes; install command changes | Agent renders, opens a PR with side-by-side commentary (old vs new strings), requests human review. **Do not auto-ship.** |
+
+The agent decides which bucket applies by reading the
+`claims_baked_into_video` section of the manifest against the current
+working tree. If a query string in `test-cases.yaml` changed, that's
+semantic → PR. If only a hex value changed in `tokens.css`, that's
+cosmetic-but-visible → PR. If nothing semantic changed and the render
+is byte-identical, the agent may push directly to main.
+
+## Claiming a Maintenance Task
+
+This skill is **agent-claimable**. A Claude Code session reaching this
+section should:
+
+1. **Check the trigger**.
+   - Beads task in `bd ready` with label `caro-demo-video` → read
+     `bd show <id>` for the trigger note.
+   - PR comment from `caro-demo-drift workflow` → read the comment
+     for the drifted-files list.
+   - Manual invocation → run `check-drift.sh --human` for the report.
+2. **Decide the trust bucket** from the table above.
+3. **Re-render** with
+   `demos/remotion-video/scripts/render-and-ship.sh` — this also
+   refreshes the baseline manifest, so subsequent drift checks anchor
+   to this render.
+4. **Ship per trust bucket**:
+   - *Output-equivalent*: commit + merge directly.
+   - *Cosmetic / Semantic*: open a PR with the rendered MP4 + poster +
+     refreshed manifest, request human review.
+5. **Close the beads task** with `bd close <id> --reason="re-rendered
+   <reason>; commit <sha>"`.
+
+If unable to complete (e.g. queries failed when verified against the
+current `caro` binary, terminal chrome rebuild needed), keep the task
+`in_progress` and add a comment explaining what's blocking, so the next
+agent (or a human) can pick up.
 
 ## Out of Scope (track separately if requested)
 

--- a/.github/workflows/caro-demo-drift.yml
+++ b/.github/workflows/caro-demo-drift.yml
@@ -1,0 +1,106 @@
+name: caro-demo drift check
+
+# Runs the drift checker for the landing-page demo video whenever a PR
+# touches one of the files baked into the rendered MP4. If drift is
+# detected, posts a comment on the PR with the specific files that
+# changed and links to the maintenance skill.
+#
+# Security: no untrusted input is interpolated into run: commands. The
+# only ${{ ... }} usages reference our own step outputs and event-context
+# fields (issue.number, repo.owner) that are not attacker-controlled.
+# The drift report body is loaded from a file we generate in this job
+# and is composed in github-script via a JS string assembly (no shell).
+
+on:
+  pull_request:
+    paths:
+      - 'website/src/ui/tokens.css'
+      - 'website/src/components/landing/LPDemo.astro'
+      - 'src/main.rs'
+      - '.claude/beta-testing/test-cases.yaml'
+      - 'src/safety/patterns.rs'
+      - 'homebrew-tap/README.md'
+      - 'install.sh'
+      - 'demos/remotion-video/.baseline-manifest.json'
+      - '.github/workflows/caro-demo-drift.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-drift:
+    name: Check video drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sanity-check jq availability
+        run: jq --version
+
+      - name: Run drift check
+        id: drift
+        run: |
+          set +e
+          REPORT=$(demos/remotion-video/scripts/check-drift.sh)
+          EXIT=$?
+          set -e
+          printf '%s\n' "$REPORT" > /tmp/drift-report.json
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          if [ "$EXIT" -eq 1 ]; then
+            echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift_detected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR (drift detected)
+        if: steps.drift.outputs.drift_detected == 'true'
+        uses: actions/github-script@v8
+        env:
+          REPORT_PATH: /tmp/drift-report.json
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, 'utf8'));
+            const drifted = report.files.filter(f => f.status !== 'OK');
+            const lines = drifted.map(f =>
+              `- \`${f.path}\` — ${f.status}\n   _${f.purpose}_`
+            ).join('\n');
+            const body = [
+              '`[agent]`',
+              '',
+              '**Agent:** caro-demo-drift workflow (`github-actions`)',
+              '',
+              '---',
+              '',
+              '### caro-demo landing video drift detected',
+              '',
+              `This PR changes ${drifted.length} file(s) that the landing-page demo video at \`website/public/caro-demo.mp4\` is rendered from. The video may no longer match the product.`,
+              '',
+              `**Last rendered:** ${report.last_rendered_at} (commit \`${report.last_rendered_commit}\`)`,
+              '',
+              '**Drifted sources:**',
+              lines,
+              '',
+              '#### What to do',
+              '1. If the change is purely cosmetic (no scene text affected), no action needed — the monthly cron task will refresh.',
+              '2. If the change affects what the video says (scene queries, block messages, install commands, pattern count), please trigger a re-render either by checking out this PR and running `demos/remotion-video/scripts/render-and-ship.sh`, or by filing a beads task referencing this PR.',
+              '3. See `.claude/skills/caro-demo-video/SKILL.md` (Drift Detection → Triggers → Trust Model) for the full workflow.',
+              '',
+              '---',
+              '',
+              '<details>',
+              '<summary>Full drift report (JSON)</summary>',
+              '',
+              '```json',
+              JSON.stringify(report, null, 2),
+              '```',
+              '',
+              '</details>'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/demos/remotion-video/.baseline-manifest.json
+++ b/demos/remotion-video/.baseline-manifest.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "comment": "Tripwire manifest for the caro-demo landing-page video. Each entry records the SHA-256 of a source file the video depends on at the moment of the last shipped render. scripts/check-drift.sh compares the working tree to this manifest. When drift is detected the skill at .claude/skills/caro-demo-video/SKILL.md takes over. DO NOT EDIT BY HAND — regenerate with `scripts/render-and-ship.sh` (it rewrites this file on a successful render).",
+  "rendered_at": "2026-04-26T02:07:00Z",
+  "rendered_commit": "4c45fc56",
+  "caro_version_at_render": "1.3.0",
+  "video_output": {
+    "path": "website/public/caro-demo.mp4",
+    "poster": "website/public/caro-demo-poster.png",
+    "duration_seconds": 30.06,
+    "width": 1920,
+    "height": 1080,
+    "fps": 30
+  },
+  "claims_baked_into_video": {
+    "pattern_count": 52,
+    "pattern_count_claim_text": "52+ patterns. Blocked before damage.",
+    "install_command": "cargo install caro",
+    "block_message": "✗ command blocked by safety validator (Critical)",
+    "block_reason_text": "Recursive deletion of root, home, current, or parent directory",
+    "scene_2_queries": [
+      {
+        "input": "find all PDF files larger than 10MB in Downloads",
+        "expected_output": "find ~/Downloads -name \"*.pdf\" -size +10M -ls"
+      },
+      {
+        "input": "find python files modified last week",
+        "expected_output": "find . -name \"*.py\" -type f -mtime -7"
+      },
+      {
+        "input": "find all errors in application logs",
+        "expected_output": "grep ERROR logs/app.log"
+      }
+    ],
+    "scene_3_query": {
+      "input": "delete everything in the current directory",
+      "expected_output": "rm -rf ./*"
+    }
+  },
+  "watched_files": [
+    {
+      "path": "website/src/ui/tokens.css",
+      "sha256": "c7f38e748a8cda98adb2d29443aed333d266eb0322cd8a78c594b904085934a5",
+      "purpose": "Brand colors. Mirrored verbatim into demos/remotion-video/src/tokens.ts. A drift here is the most common trigger — any palette change requires re-render."
+    },
+    {
+      "path": "website/src/components/landing/LPDemo.astro",
+      "sha256": "1d3108ab1c3849599cf72145f6d22c0d48a0e972e16a6e537726a7bd141e9e8d",
+      "purpose": "macOS terminal chrome design (traffic-light dots, title bar). The Remotion TerminalWindow component copies this look. If the website's terminal styling changes, the video must follow."
+    },
+    {
+      "path": "src/main.rs",
+      "sha256": "6f47a8e154c6198176836d903bb6e462f646c895887400c3799199e7fa38fd31",
+      "purpose": "CLI output strings. Scene 3 quotes the block-message literal from around line 1016. If the CLI's user-facing strings change, the video lies."
+    },
+    {
+      "path": ".claude/beta-testing/test-cases.yaml",
+      "sha256": "f528f884024a43d9d238015303705791ca4f65ebbe599d46243b3daccdf13270",
+      "purpose": "Source of truth for Scene 2's three queries. If a test case shifts (e.g. a flag changes for BSD-vs-GNU compat), the video must follow."
+    },
+    {
+      "path": "src/safety/patterns.rs",
+      "sha256": "30d29615cb61cc728ef37fe0c4c0518a3af8ce5450f6af1e2347237f94be82b0",
+      "purpose": "Safety pattern definitions. Pattern count drives the Scene 3 caption '52+ patterns'. Drift here may bump the claim text."
+    },
+    {
+      "path": "homebrew-tap/README.md",
+      "sha256": "8d85e785e55c0d16ceaa568791141fee22a59aeecb7a02a1d2bbe71aad994803",
+      "purpose": "Homebrew install instructions. Scene 4's install line should match the canonical install command."
+    },
+    {
+      "path": "install.sh",
+      "sha256": "fb9f92c3ea7a4971a48cbb83d6ae9d5dc1e7e9f44e457f4789490f32860bd9f7",
+      "purpose": "Curl-pipe install script. Same rationale as the homebrew tap — Scene 4 should reference a current, working install path."
+    }
+  ]
+}

--- a/demos/remotion-video/scripts/check-drift.sh
+++ b/demos/remotion-video/scripts/check-drift.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Detect drift between the shipped caro-demo video and the source files
+# it depends on. Reads .baseline-manifest.json (captured at the last
+# successful render) and compares each watched file's current SHA-256.
+#
+# Exit codes:
+#   0  No drift — video is up to date.
+#   1  Drift detected — re-render warranted. See JSON output for details.
+#   2  Tooling error (jq missing, manifest missing, etc.).
+#
+# Output: JSON on stdout. The CI workflow and the agent both parse this.
+#
+# Usage:
+#   demos/remotion-video/scripts/check-drift.sh
+#   demos/remotion-video/scripts/check-drift.sh --human   (pretty-print)
+set -euo pipefail
+
+# Resolve script-relative paths so it works from any cwd.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$SCRIPT_DIR/.."
+REPO_ROOT="$PROJECT_DIR/../.."
+MANIFEST="$PROJECT_DIR/.baseline-manifest.json"
+
+HUMAN=0
+[[ "${1:-}" == "--human" ]] && HUMAN=1
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"error":"jq not installed"}' >&2
+  exit 2
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "{\"error\":\"manifest not found at $MANIFEST\"}" >&2
+  exit 2
+fi
+
+# Portable SHA-256 — shasum is on macOS, sha256sum on Linux.
+sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    sha256sum "$1" | cut -d' ' -f1
+  fi
+}
+
+# Build a JSON array of drift entries. Each entry has: path, expected_sha,
+# actual_sha, purpose, status (DRIFTED | MISSING | OK).
+ENTRIES=$(jq -c '.watched_files[]' "$MANIFEST")
+DRIFT_REPORT='[]'
+HAS_DRIFT=0
+
+while IFS= read -r entry; do
+  path=$(jq -r '.path' <<<"$entry")
+  expected=$(jq -r '.sha256' <<<"$entry")
+  purpose=$(jq -r '.purpose' <<<"$entry")
+  abs="$REPO_ROOT/$path"
+
+  if [[ ! -f "$abs" ]]; then
+    status="MISSING"
+    actual="null"
+    HAS_DRIFT=1
+  else
+    actual=$(sha256 "$abs")
+    if [[ "$actual" == "$expected" ]]; then
+      status="OK"
+    else
+      status="DRIFTED"
+      HAS_DRIFT=1
+    fi
+  fi
+
+  DRIFT_REPORT=$(jq --arg path "$path" \
+                    --arg status "$status" \
+                    --arg expected "$expected" \
+                    --arg actual "$actual" \
+                    --arg purpose "$purpose" \
+                    '. + [{path: $path, status: $status, expected_sha: $expected, actual_sha: $actual, purpose: $purpose}]' \
+                    <<<"$DRIFT_REPORT")
+done <<<"$ENTRIES"
+
+RENDERED_AT=$(jq -r '.rendered_at' "$MANIFEST")
+RENDERED_COMMIT=$(jq -r '.rendered_commit' "$MANIFEST")
+
+OUTPUT=$(jq -n \
+  --arg rendered_at "$RENDERED_AT" \
+  --arg rendered_commit "$RENDERED_COMMIT" \
+  --argjson has_drift "$HAS_DRIFT" \
+  --argjson files "$DRIFT_REPORT" \
+  '{
+    drift_detected: ($has_drift == 1),
+    last_rendered_at: $rendered_at,
+    last_rendered_commit: $rendered_commit,
+    files: $files,
+    summary: {
+      total: ($files | length),
+      ok: ($files | map(select(.status == "OK")) | length),
+      drifted: ($files | map(select(.status == "DRIFTED")) | length),
+      missing: ($files | map(select(.status == "MISSING")) | length)
+    }
+  }')
+
+if [[ "$HUMAN" == "1" ]]; then
+  echo "$OUTPUT" | jq -r '
+    "caro-demo drift check",
+    "  last rendered: \(.last_rendered_at) (commit \(.last_rendered_commit))",
+    "  total watched: \(.summary.total)  ok: \(.summary.ok)  drifted: \(.summary.drifted)  missing: \(.summary.missing)",
+    "",
+    (.files[] |
+      if .status == "OK" then
+        "  ✓ \(.path)"
+      elif .status == "MISSING" then
+        "  ✗ MISSING: \(.path)\n      └─ \(.purpose)"
+      else
+        "  ⚠ DRIFTED: \(.path)\n      └─ \(.purpose)"
+      end
+    )'
+else
+  echo "$OUTPUT"
+fi
+
+if [[ "$HAS_DRIFT" == "1" ]]; then
+  exit 1
+fi
+exit 0

--- a/demos/remotion-video/scripts/render-and-ship.sh
+++ b/demos/remotion-video/scripts/render-and-ship.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Render the caro-demo video, place outputs in website/public/, and
+# rewrite the baseline manifest so the next drift check is anchored to
+# this render.
+#
+# Intended caller: a Claude Code session that has decided to re-render
+# based on drift detection. The skill at .claude/skills/caro-demo-video/
+# documents when this is appropriate.
+#
+# Does NOT commit — the caller is responsible for staging + commit +
+# review, because the trust model varies (output-equivalent → ship;
+# semantic change → open PR for review).
+#
+# Usage:
+#   demos/remotion-video/scripts/render-and-ship.sh
+#   demos/remotion-video/scripts/render-and-ship.sh --skip-install
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$SCRIPT_DIR/.."
+REPO_ROOT="$PROJECT_DIR/../.."
+MANIFEST="$PROJECT_DIR/.baseline-manifest.json"
+
+cd "$PROJECT_DIR"
+
+SKIP_INSTALL=0
+[[ "${1:-}" == "--skip-install" ]] && SKIP_INSTALL=1
+
+if [[ "$SKIP_INSTALL" == "0" ]]; then
+  echo "==> Installing Remotion deps (use --skip-install if already done)…"
+  npm install --no-audit --no-fund --prefer-offline
+fi
+
+echo "==> Rendering MP4 → website/public/caro-demo.mp4 …"
+npx remotion render CaroDemo \
+  ../../website/public/caro-demo.mp4 \
+  --codec=h264 --crf=23 --image-format=jpeg --log=info
+
+echo "==> Rendering poster → website/public/caro-demo-poster.png …"
+npx remotion still CaroDemo \
+  ../../website/public/caro-demo-poster.png \
+  --frame=60 --image-format=png
+
+# Portable SHA-256 helper.
+sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    sha256sum "$1" | cut -d' ' -f1
+  fi
+}
+
+echo "==> Refreshing baseline manifest…"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+HEAD_COMMIT=$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+CARO_VERSION=$(grep -m1 '^version' "$REPO_ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+PATTERN_COUNT=$(grep -c 'description:' "$REPO_ROOT/src/safety/patterns.rs")
+
+# Rewrite the tripwire fields while preserving the comment and schema.
+# jq's slurp+update keeps the existing structure intact; we only update
+# rendered_at, rendered_commit, caro_version_at_render, pattern_count,
+# and each watched file's sha256.
+TMP=$(mktemp)
+jq --arg now "$NOW" \
+   --arg commit "$HEAD_COMMIT" \
+   --arg version "$CARO_VERSION" \
+   --argjson pcount "$PATTERN_COUNT" \
+   '.rendered_at = $now
+    | .rendered_commit = $commit
+    | .caro_version_at_render = $version
+    | .claims_baked_into_video.pattern_count = $pcount' \
+   "$MANIFEST" > "$TMP"
+
+# Update each watched file's sha256 in place.
+COUNT=$(jq '.watched_files | length' "$TMP")
+for i in $(seq 0 $((COUNT - 1))); do
+  path=$(jq -r ".watched_files[$i].path" "$TMP")
+  abs="$REPO_ROOT/$path"
+  if [[ -f "$abs" ]]; then
+    new_hash=$(sha256 "$abs")
+    jq ".watched_files[$i].sha256 = \"$new_hash\"" "$TMP" > "$TMP.next" && mv "$TMP.next" "$TMP"
+  fi
+done
+
+mv "$TMP" "$MANIFEST"
+
+echo ""
+echo "==> Done. Outputs:"
+ls -lh "$REPO_ROOT/website/public/caro-demo.mp4" "$REPO_ROOT/website/public/caro-demo-poster.png" 2>&1
+echo ""
+echo "==> Baseline manifest refreshed to commit $HEAD_COMMIT at $NOW."
+echo "==> Next step (for the caller): stage and commit:"
+echo ""
+echo "    git add website/public/caro-demo.mp4 website/public/caro-demo-poster.png \\"
+echo "            demos/remotion-video/.baseline-manifest.json"
+echo "    git commit -m \"chore(demo): re-render caro-demo video\""
+echo ""
+echo "    If you also changed source files in demos/remotion-video/src/,"
+echo "    stage those too. If the scene text changed, open a PR for"
+echo "    human review (see .claude/skills/caro-demo-video/ Trust Model)."


### PR DESCRIPTION
## Description

Adds the missing **maintenance layer** for the landing-page demo video shipped in #885. The video bakes in mutable facts (brand colors, terminal chrome, real CLI strings, "52+" pattern count, install commands) and goes stale silently when those drift. This PR closes that gap.

### Motivation

PR #885 shipped a 30-second Remotion-rendered demo into the English landing page. But:

- The colors come from `website/src/ui/tokens.css` — a rebrand makes the video look off-brand.
- The terminal chrome comes from `LPDemo.astro` — a redesign makes the video look out of date.
- Scene 2's three queries come from `test-cases.yaml` — a test fixture update makes the video lie.
- Scene 3 quotes the CLI's block message from `src/main.rs:1014–1023` — a copy edit there desyncs the demo.
- Scene 3's "52+ patterns" claim comes from `src/safety/patterns.rs` — when we add patterns, the number drifts.
- Scene 4's install command comes from `homebrew-tap/README.md` and `install.sh`.

Without a maintenance protocol, none of this is detected until a human happens to watch the video again.

## What this PR adds

### 1. Baseline manifest (the "what the video says" snapshot)

[`demos/remotion-video/.baseline-manifest.json`](demos/remotion-video/.baseline-manifest.json) captures **two layers** at the moment of the last render:

- **SHA-256 tripwires** of each watched file — mechanical drift detection
- **Semantic claims** (the actual scene-text strings: pattern count, install command, block message, all three Scene 2 query/output pairs, Scene 3 query) — so the next agent reading the manifest sees at a glance what the video *says*, without having to re-derive it

### 2. Drift-check script

```bash
demos/remotion-video/scripts/check-drift.sh --human
```

Exit codes: `0` no drift, `1` drift detected, `2` tooling error. JSON or human output. Portable (`shasum`/`sha256sum`).

### 3. Re-render script

```bash
demos/remotion-video/scripts/render-and-ship.sh
```

Renders MP4 + poster, refreshes the baseline manifest (rewrites SHAs + rendered_at + rendered_commit + caro_version_at_render + pattern_count). The caller is responsible for staging/committing — because the trust model differs between output-equivalent and semantic re-renders.

### 4. Three independent trigger channels

| Channel | Implementation | Catches |
|---|---|---|
| **CI watcher** | [`.github/workflows/caro-demo-drift.yml`](.github/workflows/caro-demo-drift.yml) — path-filtered on the 7 watched files | Sudden changes in a single PR |
| **Monthly cron** | Scheduled remote agent `trig_015odXQD79ccpcDWfcioKt68` — 1st of each month at 12:00 UTC | Slow drift across many small PRs |
| **Beads queue** | Epic `caro-bce`, monthly task `caro-75k`, label `caro-demo-video` — auto-claimable by `caro-coder-loop` | Manual + scheduled invocations |

### 5. Trust model (codified in the skill)

| Drift type | Required action |
|---|---|
| Output-equivalent (whitespace, variable rename with same value) | Agent re-renders and ships directly |
| Cosmetic-but-visible (hex value change, chrome restyle) | Agent renders, opens PR, requests human review |
| Semantic (scene text changes, query strings drift) | Agent renders, opens PR with side-by-side commentary, requests human review |

### 6. Skill upgrade

[`.claude/skills/caro-demo-video/SKILL.md`](.claude/skills/caro-demo-video/SKILL.md) gains three new sections:

- **Drift Detection** — what's watched and why
- **Trust Model** — when can an agent ship without human review
- **Claiming a Maintenance Task** — step-by-step for the next agent that picks up a beads task

## Self-test

```
$ demos/remotion-video/scripts/check-drift.sh --human
caro-demo drift check
  last rendered: 2026-04-26T02:07:00Z (commit 4c45fc56)
  total watched: 7  ok: 7  drifted: 0  missing: 0

  ✓ website/src/ui/tokens.css
  ✓ website/src/components/landing/LPDemo.astro
  ✓ src/main.rs
  ✓ .claude/beta-testing/test-cases.yaml
  ✓ src/safety/patterns.rs
  ✓ homebrew-tap/README.md
  ✓ install.sh
(exit code: 0)
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD or tooling (changes to build, release, or development tools)
- [x] Documentation update (skill expanded with three new sections)

## Scope notes

- **No Rust code changed.** No backend/CLI behavior changed.
- **No re-render performed.** The current MP4 is unchanged; this PR just adds the infrastructure to detect future drift.
- The CI workflow only **comments** on drifted PRs — it never blocks merge. Drift detection is informational, not gating.
- The monthly cron agent is **conservative** by design: it only auto-ships output-equivalent re-renders. Anything that changes scene text gets a PR for human review.

## Related

- PR #885 — original demo + skill
- Routine `trig_015odXQD79ccpcDWfcioKt68` — monthly cron ([routines](https://claude.ai/code/routines/trig_015odXQD79ccpcDWfcioKt68))
- Beads `caro-bce` (epic), `caro-75k` (first monthly check task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drift detection and a maintenance workflow for the landing-page demo video. Automatically flags changes to brand tokens, terminal chrome, CLI strings, pattern count, and install commands, with scripts and CI to re-render safely.

- **New Features**
  - Baseline manifest `demos/remotion-video/.baseline-manifest.json` with SHA-256 tripwires and a snapshot of the video’s semantic claims.
  - Drift checker `demos/remotion-video/scripts/check-drift.sh` (JSON or `--human` output; exit 0/1/2).
  - Render helper `demos/remotion-video/scripts/render-and-ship.sh` to produce MP4 + poster and refresh the manifest.
  - CI watcher `.github/workflows/caro-demo-drift.yml` that comments on PRs touching watched files.
  - Skill doc update `.claude/skills/caro-demo-video/SKILL.md` covering drift detection, a trust model (auto-ship output-equivalent; PR for cosmetic/semantic), and maintenance steps.

<sup>Written for commit e8207b54150438260ef917f740b6ca8ec83a0b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

