### PR TITLE
fix(safety): catch long-flag and 4-digit octal bypasses in chmod pattern

### DIFF
--- a/src/safety/patterns.rs
+++ b/src/safety/patterns.rs
@@ -72,7 +72,7 @@ pub static DANGEROUS_PATTERNS: Lazy<Vec<DangerPattern>> = Lazy::new(|| {
             shell_specific: None,
         },
         DangerPattern {
-            pattern: r"chmod\s+(-[rRfvn]+\s+)*777\s+/".to_string(),
+            pattern: r"chmod\s+((-[rRfvn]+|--recursive)\s+)*0?777\s+/".to_string(),
             risk_level: RiskLevel::High,
             description: "Permission change making root world-writable (recursive or direct)"
                 .to_string(),

--- a/tests/safety_validator_contract.rs
+++ b/tests/safety_validator_contract.rs
@@ -839,3 +839,49 @@ async fn test_bsd_safe_commands_no_false_positives() {
         );
     }
 }
+
+/// Regression: GNU long-flag form (--recursive) must be caught at High risk.
+/// The original pattern only matched short flags (-R, -r, -Rfv).
+#[tokio::test]
+async fn test_chmod_long_flag_recursive_bypass() {
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let result = validator
+        .validate_command("chmod --recursive 777 /", ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        result.risk_level >= RiskLevel::High,
+        "chmod --recursive 777 / should be High risk, got {:?}",
+        result.risk_level
+    );
+}
+
+/// Regression: 4-digit octal (0777) must be caught at High risk.
+#[tokio::test]
+async fn test_chmod_4digit_octal_bypass() {
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let result = validator
+        .validate_command("chmod 0777 /", ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        result.risk_level >= RiskLevel::High,
+        "chmod 0777 / should be High risk, got {:?}",
+        result.risk_level
+    );
+}
+
+/// Regression: combined long flag + 4-digit octal must be caught.
+#[tokio::test]
+async fn test_chmod_long_flag_4digit_octal_bypass() {
+    let validator = SafetyValidator::new(SafetyConfig::strict()).unwrap();
+    let result = validator
+        .validate_command("chmod --recursive 0777 /", ShellType::Bash)
+        .await
+        .unwrap();
+    assert!(
+        result.risk_level >= RiskLevel::High,
+        "chmod --recursive 0777 / should be High risk, got {:?}",
+        result.risk_level
+    );
+}


### PR DESCRIPTION
Fixes 3 filesystem-permission bypasses. Updated regex to catch GNU long flags (--recursive) and 4-digit octal (0777). TDD: 3 regression tests. Supersedes PR #1085 (which had static_matcher regressions from stale branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the chmod safety pattern to catch GNU long flags and 4-digit octal modes, closing permission-bypass gaps. Now flags recursive world-writable changes to `/` as High risk.

- **Bug Fixes**
  - Updated regex to `chmod\s+((-[rRfvn]+|--recursive)\s+)*0?777\s+/` to match `--recursive` and `0?777`.
  - Added 3 regression tests for `chmod --recursive 777 /`, `chmod 0777 /`, and `chmod --recursive 0777 /`.

<sup>Written for commit bea46f366f8d57ba0e4f83f284260f7776528fac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

