### PR TITLE
fix(cli): loud error when remote backend requested without feature (#1081)

### DIFF
--- a/.claude/memory/integrator-log.md
+++ b/.claude/memory/integrator-log.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-05-13 (23:00 PT fire) — option 2 loud-error code fix for #1081
+
+- **Validated:** re-confirmed [#1081](https://github.com/wildcard/caro/issues/1081) reproduces on the newly-published `caro 1.4.0` from crates.io (the prior validation was on 1.3.0). `caro --backend ollama --dry-run -p "list pdf files"` still emits `WARN  caro::cli: Remote backends not compiled in` and silently falls through to `ls -la` via the static matcher. Identical reproduction for `vllm` and `exo`. `--backend claude` still returns `Error: Invalid argument: Unknown backend 'claude'`. `--backend embedded` works (control). Evidence: claim-verification step before touching code, per the project rule that says "code premised on a stale evidence base is a wasted PR."
+
+- **Shipped:** code fix at `src/cli/mod.rs` — replaces the `tracing::warn!` silent-fallback arm (lines 395–400) with `return Err(Self::remote_backend_unavailable_error(model))`. Extracted a tiny `remote_backend_unavailable_error(backend: &str) -> CliError` helper (gated `#[cfg_attr(feature = "remote-backends", allow(dead_code))]`) so the error message can be unit-tested in isolation. Message names the requested backend, the missing feature, the exact `cargo install caro --features remote-backends --locked` invocation that fixes it, and the no-setup-required embedded alternative. Added `test_remote_backend_unavailable_error_message` in `cli::tests` covering all four message assertions. Smoke-tested against the branch binary: `caro --backend ollama` → exit 1 with the new error; `caro --backend vllm` and `caro --backend exo` produce equivalent errors; `caro --backend embedded` exit 0 (no regression). Both feature configurations (`embedded-cpu` and `embedded-cpu remote-backends`) clippy-clean with `-D warnings`; `cargo fmt --all -- --check` clean.
+
+- **Filed:** none. Tonight's PR closes the loop on the existing P1 ([#1081](https://github.com/wildcard/caro/issues/1081)) for option **2** of its remediation menu; the issue itself stays open until the related options ship (option 3: default-feature flip, or release-workflow `--features` injection; option 5: Claude CLI wiring). Dedup-checked `gh issue list --label integration --state all --search "remote-backends OR loud-error OR silent fallback"` — no other matches.
+
+- **Discovered:**
+  - **PR #1082** (last night's integrator's docs re-statusing PR) is still **open**, with `Lint & Format` and `MSRV Check (Rust 1.85)` CI failures. Both failures originate in pre-existing main code (`src/evaluation/evaluators/utils.rs` fmt — already removed on main by [#1084](https://github.com/wildcard/caro/pull/1084), and `backends::static_matcher::tests::test_website_example_2` — also fixed by #1084). A rebase of PR #1082 onto current `main` (HEAD `fcfa844a`) will clear both. Out of scope for tonight's one-PR-per-night budget — flagged for next pass or for a maintainer's hand on the original branch.
+  - `caro 1.4.0` shipped to crates.io between the last fire and tonight (`max: 1.4.0 newest: 1.4.0` from `crates.io/api/v1/crates/caro`). New top-level subcommands include `caro skill`, `caro do`, `caro run`, `caro generate`, `caro adopt`, `caro experiment`, `caro history`, `caro why`, `caro check`, `caro list`, `caro jobs`, `caro new`, `caro export`, `caro render`, `caro ai`, `caro suggest` — the CaroML task language has clearly landed. `caro mcp serve` and `caro serve --openai` are **not** yet in the help output, so the matrix queue ordering is unchanged. No new `--backend` options either.
+  - `caro skill` subcommand exists — useful next-pass surface for surfacing the bundled `caro-shell` skill from the CLI itself. File this as a research item rather than a regression.
+
+- **Next pass should:**
+  - (a) Rebase PR #1082 onto current `main` if it's still open and unmerged, so the previous integrator's matrix-row re-statusing can finally land. Trivial rebase; the only conflict will be on the date-banner line in `integrations-status.md` which intentionally was not edited tonight.
+  - (b) Pursue [#1081](https://github.com/wildcard/caro/issues/1081) option **5** (Claude CLI wiring) — `validate_backend_name` arm for `"claude"`, a new `create_backend` match arm wiring `ClaudeBackend::new(api_key)`, and a config-error path for the missing `ANTHROPIC_API_KEY`. ~30 LOC, fits a single-night PR. The existing `src/backends/remote/claude.rs` already does the heavy lifting; only CLI glue is missing.
+  - (c) If both (a) and (b) are unblocked, prioritize (a) — keeping last night's PR alive is higher value than starting a new code fix.
+
+---
+
 ## 2026-05-10 (23:00 PT fire) — third bootstrap-blocked night, awaiting merge action
 
 - **Validated:** none — bootstrap-check still says PLAYBOOK_NOT_MERGED. PR #939 remains OPEN. Per the scheduled-task header protocol, no integration-row validation runs until the playbook lands on `main`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -394,9 +394,7 @@ impl CliApp {
                     }
                     #[cfg(not(feature = "remote-backends"))]
                     "ollama" | "exo" | "vllm" => {
-                        tracing::warn!(
-                            "Remote backends not compiled in. Build with --features remote-backends"
-                        );
+                        return Err(Self::remote_backend_unavailable_error(model));
                     }
                     _ => {
                         tracing::warn!("Unknown backend '{}', using auto-detect", model);
@@ -490,6 +488,29 @@ impl CliApp {
                 backend, suggestion
             ),
         })
+    }
+
+    /// Build the error returned when the user requests a remote backend
+    /// in a binary that was compiled without the `remote-backends` feature.
+    ///
+    /// Returning a hard `CliError::ConfigurationError` (instead of a silent
+    /// `tracing::warn!` and fallback to the embedded backend) preserves the
+    /// contract a user expects when they pass `--backend <name>`. Tracked by
+    /// [#1081](https://github.com/wildcard/caro/issues/1081).
+    #[cfg_attr(feature = "remote-backends", allow(dead_code))]
+    fn remote_backend_unavailable_error(backend: &str) -> CliError {
+        CliError::ConfigurationError {
+            message: format!(
+                "Backend '{}' requires the 'remote-backends' feature, \
+                 which is not compiled into this build.\n\n\
+                 The default `cargo install caro` binary ships without remote \
+                 backends. To use {}, build from source with:\n  \
+                 cargo install caro --features remote-backends --locked\n\n\
+                 Alternatively, use the embedded backend (no setup required):\n  \
+                 caro --backend embedded \"<your prompt>\"",
+                backend, backend
+            ),
+        }
     }
 
     /// Get list of available backend names
@@ -898,5 +919,26 @@ mod tests {
         assert!(backends.contains(&"ollama"));
         assert!(backends.contains(&"exo"));
         assert!(backends.contains(&"vllm"));
+    }
+
+    #[test]
+    fn test_remote_backend_unavailable_error_message() {
+        // Verifies the loud-error contract for issue #1081 — when a user
+        // requests a remote backend but the binary lacks the feature, the
+        // error message must (a) name the backend, (b) point to the fix
+        // (build with --features remote-backends), and (c) suggest the
+        // no-setup-required embedded alternative.
+        let err = CliApp::remote_backend_unavailable_error("ollama");
+        let msg = err.to_string();
+        assert!(msg.contains("ollama"), "names the requested backend");
+        assert!(msg.contains("remote-backends"), "names the missing feature");
+        assert!(
+            msg.contains("cargo install caro --features remote-backends"),
+            "tells the user exactly how to rebuild"
+        );
+        assert!(
+            msg.contains("caro --backend embedded"),
+            "suggests the embedded alternative"
+        );
     }
 }


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-opus-4-7`) — caro-integrator

---

## Summary

Tonight's caro-integrator nightly pass (2026-05-13 23:00 PT) — the first real post-bootstrap cycle. The priority queue's topmost item was option **2** of issue [#1081](https://github.com/wildcard/caro/issues/1081) ("loud error instead of silent fallback"), explicitly teed up by the [previous integrator's log entry](https://github.com/wildcard/caro/blob/integrator/20260511/.claude/memory/integrator-log.md#2026-05-11-2300-pt-fire--first-real-validation-pass-remote-backend-packaging-gap-surfaced) as "the most defensible single-PR scope, ~10 LOC at `src/cli/mod.rs:402`, no policy ambiguity, restores the contract."

This PR replaces the silent `tracing::warn!`-then-fallback for `--backend {ollama,vllm,exo}` (when `remote-backends` feature is absent) with a hard `CliError::ConfigurationError` that names the requested backend, the missing feature, the exact rebuild invocation that fixes it, and the zero-setup embedded alternative.

## Verified against published binary first

Per the caro project's [claim-verification rule](https://github.com/wildcard/caro/blob/main/.claude/rules/destructive-commands.md), before touching code I re-confirmed the P1 still reproduces on `caro 1.4.0` (the published binary on crates.io as of tonight; the previous integrator's evidence was from `caro 1.3.0`):

```console
$ caro --version
caro 1.4.0 ( crates.io)

$ caro --backend ollama --dry-run -p "list pdf files"
 WARN  caro::cli: Remote backends not compiled in. Build with --features remote-backends
Command:
  ls -la
Dry Run Mode:
  ✓ This command would execute successfully
```

The user asked for `ollama`, got a static-matcher `ls -la` back, and the only indication something diverged is a single grey-on-black `WARN` line. Identical reproduction for `vllm` and `exo`.

## What changed

| File | Change |
|---|---|
| `src/cli/mod.rs` | (a) Lines 395–397: replace the `tracing::warn!` arm in `create_backend`'s `match model` block with `return Err(Self::remote_backend_unavailable_error(model))`. (b) New helper `remote_backend_unavailable_error(backend: &str) -> CliError` (gated `#[cfg_attr(feature = "remote-backends", allow(dead_code))]`) that builds the structured error message — kept as a separate function so the message content is unit-testable in isolation. (c) New unit test `test_remote_backend_unavailable_error_message` covering all four message-content assertions. |
| `.claude/memory/integrator-log.md` | Append the 2026-05-13 nightly entry per the [playbook](https://github.com/wildcard/caro/blob/main/.claude/memory/integrator-playbook.md)'s "Close the loop" step. |

Intentionally NOT touched: `.claude/memory/integrations-status.md`. The previous integrator's still-open [PR #1082](https://github.com/wildcard/caro/pull/1082) carries the row-level re-statusing for that file; touching it here would create a needless merge conflict. The two PRs are orthogonal and can land in either order.

## How to test

```bash
# Local: every check the CI gates on this PR will run.
cd <worktree>
cargo fmt --all -- --check
cargo clippy --lib --no-default-features --features embedded-cpu -- -D warnings
cargo clippy --lib --no-default-features --features "embedded-cpu remote-backends" -- -D warnings
cargo test --lib --no-default-features --features embedded-cpu cli::

# End-to-end smoke (build branch binary, exercise the new error path):
cargo build --bin caro --no-default-features --features embedded-cpu
./target/debug/caro --backend ollama --dry-run -p "list pdf files"
# → Error: Configuration error: Backend 'ollama' requires the 'remote-backends' feature, …
# → exit 1
./target/debug/caro --backend embedded --dry-run -p "list pdf files"
# → ls -la (control, exit 0 — no regression)
```

## Why this scope is the right size

- **One arm change, one helper, one test.** ~45 LOC of diff. Reviewable in 5 minutes.
- **No policy ambiguity.** The user passed `--backend ollama`; honoring the request is impossible in this build; the only correct response is to tell them. No question about whether the previous behavior was intentional — the WARN line itself proves the maintainer already knew the silent path was wrong.
- **Doesn't pre-empt the other [#1081](https://github.com/wildcard/caro/issues/1081) remediation options.** A future PR can still flip the default feature, or inject `--features remote-backends` into the release workflow. This PR makes the failure mode legible without taking that decision.
- **Embedded path is untouched.** `--backend embedded` still works in the default build, control-tested in the smoke run above.

## Dedup statement

`gh issue list --label integration --state all --search "remote-backends OR loud-error OR silent fallback"` — no matches outside [#1081](https://github.com/wildcard/caro/issues/1081) itself. Tonight's PR closes the loop on option 2 of that issue without obsoleting any of the others (3 — default-feature flip; 5 — Claude CLI wiring; etc.); the issue stays open for those follow-ups.

## Next nightly should

(a) Rebase [PR #1082](https://github.com/wildcard/caro/pull/1082) onto current `main` if it's still open — its `Lint & Format` and `MSRV Check (Rust 1.85)` failures are both pre-existing `main` issues already fixed by [#1084](https://github.com/wildcard/caro/pull/1084) (the static-matcher word-boundary fix that landed today). Trivial rebase. The only inter-PR conflict will be on the date-banner line of `integrations-status.md`, which is why I left that line alone in this PR.

(b) Pursue [#1081](https://github.com/wildcard/caro/issues/1081) option **5** (Claude CLI wiring) — `validate_backend_name` arm for `"claude"`, a new `create_backend` match arm wiring `ClaudeBackend::new(api_key)`, config-error path for missing `ANTHROPIC_API_KEY`. ~30 LOC; the heavy lifting already exists in `src/backends/remote/claude.rs`.

---

<details>
<summary>Prompt used to generate this comment</summary>

```
caro-integrator nightly 2026-05-13 pass. PR #1082 (previous integrator's docs
re-statusing) is still open with stale-CI failures. Top of the queue per the
prior log entry is option 2 of #1081 — loud error replacing silent fallback
at src/cli/mod.rs:395-400. Re-validate the bug reproduces on caro 1.4.0
(newly published, prior validation was 1.3.0), ship the ~10-LOC fix with a
unit test on the error message, smoke-test against the branch binary, leave
.claude/memory/integrations-status.md untouched to avoid conflict with #1082,
append a log entry per the playbook.
```

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the CLI fail fast when a remote backend is requested without the `remote-backends` feature, instead of silently falling back to the embedded backend. This avoids misleading results and tells users how to enable remote backends or use `embedded`. Addresses #1081 (option 2).

- **Bug Fixes**
  - Replaced warn+fallback with a `CliError::ConfigurationError` for `ollama`, `vllm`, and `exo` when `remote-backends` is not compiled. Message names the backend, the missing feature, shows the fix (`cargo install caro --features remote-backends --locked`), and suggests `caro --backend embedded`.
  - Added `remote_backend_unavailable_error()` helper (cfg-gated) and a unit test for the error text.

<sup>Written for commit ec8a42075a6791a869f8b057343699b23b48b1f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

