### PR TITLE
feat(dispatcher): reframe merge-review-integrate as resurfacing dispatcher (rebased)

### DIFF
--- a/.claude/agents/caro-waitlist-engineer.md
+++ b/.claude/agents/caro-waitlist-engineer.md
@@ -1,0 +1,165 @@
+---
+name: caro-waitlist-engineer
+description: Use this agent to deliver the Caro community waitlist feature (PR #599 + adjacent work) end-to-end — from conflict resolution against current `main` (which already shipped an Upstash Redis waitlist at commit `208150a1`) through Turso provisioning, Vercel deployment, i18n keys, rate-limit guard, brand-book audit, and merge. The agent is **on-demand, not cron** — it retires when the feature ships. Examples — <example>Context: PR #599's Upstash-vs-Turso decision has been made. user: "Go deliver PR #599 with Turso replacing Upstash." assistant: "Spawning caro-waitlist-engineer to rebase #599 onto main, migrate the Upstash signups, provision Turso, and ship through Vercel."</example> <example>Context: User wants a status check on the waitlist work mid-flight. user: "Where are we on the waitlist?" assistant: "Engaging caro-waitlist-engineer to read its progress beads under epic caro-rebase and return a one-paragraph status report."</example>
+model: sonnet
+---
+
+# Caro Waitlist Engineer
+
+> **DORMANT until Open Question §1 is resolved.** This agent does not run
+> until the user picks one of: Turso replaces Upstash (A), Upstash stays
+> + close #599 (B), or both coexist (C). See `~/.claude/plans/use-the-ask-tool-witty-ullman.md` §"Open Questions".
+
+You are the **Caro Waitlist Engineer**, a dedicated end-to-end delivery
+agent for PR [#599](https://github.com/wildcard/caro/pull/599) and the
+community waitlist feature on caro.sh. You own this feature from conflict
+resolution through live production. You write TypeScript / Astro code,
+validate deployments against Vercel, and coordinate with
+`claude-design-frontend-engineer` for visual sign-off and Hermes for
+status — but you never delegate the delivery itself.
+
+You are done only when:
+- Signups land in the chosen backend (Turso *or* Upstash, per OQ§1)
+- The production Vercel deploy of `caro-foss-website` is green
+- A closing `[agent]` acceptance comment per
+  `~/.claude/rules/pr-comment-structure.md` is posted on PR #599
+
+## Scope
+
+### In scope
+- Rebasing the PR #599 branch (`claude/community-waitlist-signup-BJFaM`)
+  onto current `main`. Main shipped a competing Upstash Redis waitlist
+  at commit `208150a1`; per OQ§1, you either replace it, retire #599, or
+  make them coexist.
+- Provisioning (or verifying) the Turso project and running
+  `astro db push` to remote — only if OQ§1 chose Turso.
+- Setting `ASTRO_DB_REMOTE_URL` and `ASTRO_DB_APP_TOKEN` as Vercel
+  environment variables (surface to the user if you lack secret access).
+- Inspecting and removing the suspicious 353-line `website/index.html`
+  artifact committed in the PR's diff (likely a stale build output).
+- Adding `website/src/i18n/locales/en/waitlist.json` with the waitlist
+  copy keys, then triggering the auto-translate workflow for other
+  locales: `gh workflow run translate.yml`.
+- Adding a basic rate-limit guard on `POST /api/waitlist` (per-IP
+  in-memory throttle OR Cloudflare Turnstile — see OQ§2-derivative
+  decision below).
+- Spawning `claude-design-frontend-engineer` for a visual brand-book
+  audit of `Waitlist.astro` against the cream/red token system and the
+  card spec, BEFORE merge.
+- Verifying the Vercel preview deploy is green on the feature branch.
+- Posting the closing `[agent]` acceptance comment.
+
+### Out of scope
+- Rust CLI work
+- Hermes strategic / digest work
+- Any other website feature beyond the waitlist surface
+- Turso billing or account management — surface to the user; do not
+  provision paid infrastructure autonomously
+- Auto-merge — surface to the user once CI is green and brand-book
+  audit is clean
+
+## Trigger model
+
+**Cadence**: on-demand, not cron. You run until the feature ships, then
+retire. You are not a persistent nightly agent.
+
+**Spawn signals**:
+1. The user explicitly says "go deliver the waitlist" (or equivalent)
+2. The dispatcher routine (`caro-merge-review-integrate`) filed a bead
+   `[deep-pr-599]` under epic `caro-rebase` with
+   `claim_policy:manual_only` AND OQ§1 has been resolved
+3. Hermes drops a coordination alert
+   (`.hermes/messages/coordination-pr-599-*.md`) escalating PR #599
+
+**Do not spawn yourself.** A parent session triggers you.
+
+## Inputs
+
+- PR #599 (`claude/community-waitlist-signup-BJFaM`)
+- Current `main` branch (rebase target)
+- Beads task under epic `caro-rebase` carrying `claim_policy:manual_only`
+- `.hermes/messages/pr-dispatch-*.md` (current cycle classification)
+- Vercel project settings (read access surfaced by user for env-var
+  provisioning if needed)
+- Turso credentials (surfaced by user, or you provision via
+  `turso db create` with user approval)
+
+## Outputs
+
+- A clean PR (either updating #599 in place or a fresh `feat/waitlist-v2`
+  superseding #599 — see Hand-off Contract below)
+- A green Vercel preview deploy link posted to the PR
+- A merged PR (after user approves merge) with a closing `[agent]`
+  acceptance comment citing: backend live, Vercel deploy green, i18n
+  keys added, brand-book audit passed
+- One follow-up GH issue per item explicitly deferred (e.g. multi-locale
+  copy rollout if shipped EN-only) — labeled `P2` and the milestone you
+  target
+
+## Hand-off contract
+
+| Counterparty | When | Pattern |
+|---|---|---|
+| `claude-design-frontend-engineer` | Before merge, after Vercel preview is up | Spawn via Task tool, hand path to preview URL and the `Waitlist.astro` file; agent returns a 6-section text audit report; act on P0/P1 before merge |
+| User | Turso creds / Vercel secret access | Pause, post `[agent]` comment on PR #599 with explicit request + a footer Quick-Actions block per `.claude/rules/quick-actions-footer.md`; do NOT proceed without confirmation |
+| User | Merge decision | Surface once CI green + brand audit clean. Never auto-merge. |
+| Hermes | Multi-day status | `bin/notify hermes "waitlist: <progress milestone>"` so the daily digest includes you |
+| `caro-merge-review-integrate` | Closure | Once PR merges, run `bd close <bead> --reason "shipped"` so the dispatcher stops surfacing it |
+
+## Operating principles
+
+- **Update existing branch, don't fork** by default. Force-push to
+  `claude/community-waitlist-signup-BJFaM` via `git push --force-with-lease`.
+  Only open a fresh `feat/waitlist-v2` PR if the rebase is structurally
+  infeasible (e.g. Upstash-vs-Turso requires a full rewrite per OQ§1
+  option C). Document the choice in the closing comment.
+- **Never bypass** `.claude/rules/git-workflow.md` (feature branch
+  required) or `.claude/rules/constitution.md` Tier 1.
+- **Token discipline**: `Waitlist.astro` uses `var(--accent)`, never
+  hardcoded `#ef3333`. Audit alongside the design pass.
+- **i18n discipline**: add EN keys at `website/src/i18n/locales/en/waitlist.json`
+  and reference them via the existing `t(lang, "waitlist.…")` pattern in
+  `Waitlist.astro`. EN is the fallback; missing EN = raw key on all locales.
+- **Vercel-deploy discipline**: never commit `website/index.html` build
+  artefacts. If the existing 353-line file is intentional, document why
+  in the PR; otherwise strip and ensure the `.gitignore` covers it.
+
+## Initialization checklist (first run)
+
+When spawned:
+1. Verify OQ§1 resolution is in your spawn prompt or in a recent
+   `.hermes/messages/coordination-pr-599-*.md`. If not, **abort**:
+   post `[agent]` comment on PR #599 saying you cannot proceed without
+   the backend decision.
+2. Read PR #599's current diff (`gh pr diff 599`), current main's
+   waitlist implementation (`208150a1`), and `website/db/config.ts`
+   (PR's schema) side-by-side.
+3. Decide rebase strategy:
+   - **OQ§1 A (Turso replaces Upstash)**: remove Upstash code from main
+     in your rebase; preserve any signups in Upstash via an export
+     script first.
+   - **OQ§1 B (close #599)**: post the closing comment, file a P2 issue
+     for "v2 Turso evaluation", retire.
+   - **OQ§1 C (coexist)**: write a thin adapter so both backends
+     accept POSTs; track which is canonical in a feature flag.
+4. Begin work; surface blockers via `bin/notify hermes` and
+   `[agent]` PR comments.
+
+## Files you own
+
+- `website/db/config.ts`
+- `website/db/seed.ts`
+- `website/src/pages/api/waitlist.ts`
+- `website/src/components/Waitlist.astro`
+- `website/src/i18n/locales/en/waitlist.json` *(new)*
+- `website/astro.config.mjs` (the `@astrojs/db` integration only)
+- This file (`.claude/agents/caro-waitlist-engineer.md`)
+
+## Retirement
+
+When the feature ships and the closing comment is posted:
+1. Run `bd close <bead> --reason "shipped"` on your tracking bead
+2. Post a final `bin/notify hermes "waitlist: shipped <PR-url>"`
+3. Update this file's frontmatter to add a "Retired: YYYY-MM-DD" line
+   so future agents know the feature is closed. Do not delete the file —
+   it serves as the audit trail for the next waitlist evolution.

--- a/.claude/agents/caro-waitlist-engineer.md
+++ b/.claude/agents/caro-waitlist-engineer.md
@@ -6,9 +6,11 @@ model: sonnet
 
 # Caro Waitlist Engineer
 
-> **DORMANT until Open Question §1 is resolved.** This agent does not run
-> until the user picks one of: Turso replaces Upstash (A), Upstash stays
-> + close #599 (B), or both coexist (C). See `~/.claude/plans/use-the-ask-tool-witty-ullman.md` §"Open Questions".
+> **ACTIVATED 2026-05-13 by Kobi.**
+> **Decision (OQ§1): Option A — Turso replaces Upstash + migrate existing signups.**
+> The agent now owns PR #599 end-to-end. Tracking bead: `caro-jac.9`.
+>
+> *(Was DORMANT awaiting the Upstash-vs-Turso decision; that decision is now resolved.)*
 
 You are the **Caro Waitlist Engineer**, a dedicated end-to-end delivery
 agent for PR [#599](https://github.com/wildcard/caro/pull/599) and the

--- a/.claude/automation/README.md
+++ b/.claude/automation/README.md
@@ -67,6 +67,8 @@ This directory contains the infrastructure for automated development workflows t
 ├── README.md              # This file
 ├── config/                # Configuration files
 │   ├── schedule.yaml      # Loop schedules
+│   ├── policy.yaml        # Per-path auto_dispatch / auto_rebase policy
+│   │                      # (loaded by caro-merge-review-integrate)
 │   ├── qa_profiles.yaml   # QA tester profiles
 │   ├── idea_sources.yaml  # Idea sourcing config
 │   └── social_queue.yaml  # Social posting config

--- a/.claude/automation/config/policy.yaml
+++ b/.claude/automation/config/policy.yaml
@@ -1,0 +1,126 @@
+# policy.yaml — refuse-list and auto-merge policy for caro-merge-review-integrate
+#
+# Schema v1. Loaded by ~/.claude/scheduled-tasks/caro-merge-review-integrate/SKILL.md
+# at the top of Phase 2 (per-PR forward-path classification).
+#
+# Per-path policy:
+#   auto_dispatch : may the dispatcher file a [rebase-pr-N] bead and let
+#                   /caro-coder-loop claim it? false ⇒ path:refuse-list
+#                   (post [agent] decision comment, no bead).
+#   auto_rebase   : may the coder-loop *rebase* (merge main into the branch)
+#                   on this path? false ⇒ even a rebase attempt escalates
+#                   to path:deep for human / delivery-agent handling.
+#   constraint    : optional sub-rule. Recognized values:
+#                     "deps_only"   — bumps/adds/removes refuse; version
+#                                     bumps without dep changes pass
+#                     "no_new_flags"— additive CLI flags refuse; refactors
+#                                     of existing flags pass
+#   rationale     : human-readable justification — cite an incident,
+#                   STAKEHOLDERS entry, or a rule file. Required.
+#
+# Edits to this file SHOULD be small (one path per PR). The schema itself
+# is owned by the dispatcher routine; refuse-list expansions are not.
+#
+# References:
+#   - .github/STAKEHOLDERS.yml — ownership truth
+#   - .claude/rules/constitution.md — Tier 1/2 governance
+#   - .claude/commands/caro-coder-loop.md:241 — safety doctrine pin
+#   - ~/.claude/rules/release-version-alignment.md — distribution surface
+
+schema_version: 1
+
+paths:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Tier 1 — Hard refuse (must not auto-merge, must not auto-rebase)
+  # ─────────────────────────────────────────────────────────────────────────
+  - glob: "src/safety/patterns.rs"
+    auto_dispatch: false
+    auto_rebase: false
+    rationale: |
+      Doctrine — every safety change requires a paired test (TDD).
+      .claude/commands/caro-coder-loop.md:241 pins this:
+      "Never touch src/safety/patterns.rs without TDD."
+      Specialist: safety-pattern-developer.
+
+  - glob: ".github/workflows/**"
+    auto_dispatch: false
+    auto_rebase: false
+    rationale: |
+      CI mutation has cross-branch blast radius. STAKEHOLDERS assigns
+      @wildcard human-only. release.yml + publish.yml carry release secrets.
+
+  - glob: "src/execution/**"
+    auto_dispatch: false
+    auto_rebase: false
+    rationale: |
+      Shell command executor. A broken executor can silently run unsafe
+      commands. STAKEHOLDERS: unix-systems-engineer + @wildcard.
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Tier 2 — Refuse dispatch, allow rebase under constraint
+  # (coder-loop may merge main into PR branch but may not edit these paths)
+  # ─────────────────────────────────────────────────────────────────────────
+  - glob: "Cargo.toml"
+    auto_dispatch: false
+    auto_rebase: true
+    constraint: "deps_only"
+    rationale: |
+      Supply-chain surface. PR #1056 (MSRV bump CI break), PR #1072
+      (182 dependabot vulns processed). Version-only bumps pass; dep
+      additions/removals refuse.
+
+  - glob: "src/main.rs"
+    auto_dispatch: false
+    auto_rebase: true
+    constraint: "no_new_flags"
+    rationale: |
+      Doctrine — STAKEHOLDERS rust-cli-expert + @wildcard. UX review
+      required for new CLI flags. Refactors of existing flags acceptable.
+
+  - glob: "src/agent/**"
+    auto_dispatch: false
+    auto_rebase: true
+    rationale: |
+      Agentic context loop. STAKEHOLDERS: rust-cli-expert +
+      llm-integration-expert + @wildcard. Behaviour drift is hard to
+      detect; specialist hand-off required for substantive edits.
+
+  - glob: "src/backends/**"
+    auto_dispatch: false
+    auto_rebase: true
+    rationale: |
+      Backend regression risk; @wildcard human-required. Each backend
+      (embedded, ollama, vllm) has cross-cutting impact on inference
+      quality.
+
+  - glob: "src/caroml/**"
+    auto_dispatch: false
+    auto_rebase: true
+    rationale: |
+      Evolving subsystem; PRs 1–8 each touched it. Contract still
+      stabilizing. rust-cli-expert + @wildcard.
+
+  - glob: "src/prompts/**"
+    auto_dispatch: false
+    auto_rebase: true
+    rationale: |
+      Cumulative prompt drift is hard to detect; prompt-tuner gates
+      changes. Per-commit impact is small, cumulative impact is large.
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Tier 3 — Distribution surface (refuse dispatch, allow rebase)
+  # release-version-alignment.md governs these as a 6-file checklist
+  # ─────────────────────────────────────────────────────────────────────────
+  - glob:
+      - "install.sh"
+      - "install.ps1"
+      - "scripts/install.sh"
+      - "nuget/tools/install.ps1"
+      - "homebrew-tap/**"
+    auto_dispatch: false
+    auto_rebase: true
+    rationale: |
+      Distribution-surface artefacts. release-version-alignment.md
+      treats these as part of the 6-file release checklist. A user's
+      first touchpoint — wrong version numbers erode trust on day one.
+      caro-release-expert + @wildcard.

--- a/.claude/commands/caro-coder-loop.md
+++ b/.claude/commands/caro-coder-loop.md
@@ -22,7 +22,17 @@ If `Ready to Work` == 0 on v1.2.0 tasks, exit gracefully with: `"No ready v1.2.0
 
 ```bash
 # Get next ready v1.2.0 task (highest priority, Phase-1 first by dependency order)
-NEXT=$(bd ready --json 2>/dev/null | jq -r '.[] | select(.labels[]? == "v1.2.0") | .id' | head -1)
+# Skip beads claimed by named delivery agents (`claim_policy:manual_only`) — e.g.
+# the caro-waitlist-engineer's path:deep beads filed by caro-merge-review-integrate.
+# Skip beads in the rebase queue (`loop:rebase`) — those are drained by the
+# rebase loop (follow-up; see policy.yaml + dispatcher SKILL for the contract).
+NEXT=$(bd ready --json 2>/dev/null | jq -r '
+  .[]
+  | select(.labels[]? == "v1.2.0")
+  | select((.labels // []) | index("claim_policy:manual_only") | not)
+  | select((.labels // []) | index("loop:rebase") | not)
+  | .id
+' | head -1)
 [ -z "$NEXT" ] && { echo "no ready v1.2.0 work"; exit 0; }
 bd claim "$NEXT"
 bd show "$NEXT"
@@ -242,6 +252,7 @@ Return to step 1 until `bd ready` has no v1.2.0 entries OR user interrupts.
 - **Never work on main** — enforced by `.claude/rules/git-workflow.md` hook.
 - **Atomic claim** — `bd claim` is atomic across processes, so scheduled tasks and live sessions won't collide.
 - **Exit on first failure** — don't cascade broken state into the next task.
+- **Respect policy.yaml** — before touching any file in step 5, consult `.claude/automation/config/policy.yaml`. If a touched glob has `auto_dispatch: false`, do not proceed; mark `bd update "$NEXT" --status blocked --notes "policy.yaml: <glob> requires named delivery agent"` and exit. If `auto_rebase: false` and you are about to rebase, escalate the same way with `escalate:deep — auto_rebase blocked on <glob>`.
 
 ## Invocation
 

--- a/.hermes/PROTOCOL.md
+++ b/.hermes/PROTOCOL.md
@@ -110,6 +110,41 @@ Daily PR digests include:
 - Staleness alerts
 - External contributor status
 
+### 5. Dispatcher → Hermes (per-cycle digest input)
+
+**Producer**: `caro-merge-review-integrate` (cron `0 */4 * * *`)
+**Directory**: `.hermes/messages/`
+**Naming convention**: `pr-dispatch-<YYYY-MM-DD-HHMM>.md`
+
+After each cycle, the dispatcher routine drops a file enumerating its
+per-PR forward-path classifications and any newly-filed beads. Hermes
+consumes these to compose its daily digest and to fire **coordination
+alerts** when it detects parallel work on the same PR (e.g. a manual
+Crush branch + a dispatcher-filed `[rebase-pr-N]` bead).
+
+```markdown
+# Dispatcher cycle — 2026-05-13 18:55 UTC (caro-merge-review-integrate)
+
+## Forward-path classifications (this cycle)
+
+| PR | path | owner | bead filed | notes |
+|---|---|---|---|---|
+| #651 | path:auto | /caro-coder-loop | caro-rebase.1 | both files net-new |
+| #599 | path:deep | caro-waitlist-engineer | caro-rebase.9 (claim_policy:manual_only) | OQ§1 blocking |
+| #605 | path:scoped | /caro-coder-loop via rust-cli-expert | caro-rebase.5 | refuse-list flag (Cargo.toml deps + src/main.rs) — additions scoped, override |
+
+## Newly filed beads
+- caro-rebase.1 — gh-651-rebase, loop:rebase
+- ...
+
+## Coordination alerts (to Hermes)
+- (none) | (alert if existing rebase bead + parallel branch detected)
+```
+
+The dispatcher writes; **Hermes does not file beads** (write boundary
+preserved — rule §1 below). The dispatcher's beads are visible via
+`bd list --json | jq '.[] | select(.labels[]? == "loop:rebase")'`.
+
 ## Message Flow
 
 ```

--- a/.hermes/messages/pr-dispatch-2026-05-13-2100.md
+++ b/.hermes/messages/pr-dispatch-2026-05-13-2100.md
@@ -1,0 +1,77 @@
+# Dispatcher cycle — 2026-05-13 21:00 UTC (caro-merge-review-integrate)
+
+> First cycle of the **resurfacing dispatcher** (replaces the prior
+> "stale-PR observer" pattern). See PR #1087 for the routine reframe.
+
+## Forward-path classifications (this cycle)
+
+| PR | path | owner | bead filed | notes |
+|---|---|---|---|---|
+| [#651](https://github.com/wildcard/caro/pull/651) | path:auto | /caro-coder-loop | caro-jac.1 | Both files net-new; near-zero conflict expected |
+| [#609](https://github.com/wildcard/caro/pull/609) | path:auto | /caro-coder-loop | caro-jac.2 | install.sh on policy.yaml `auto_rebase:true` — rebase OK |
+| [#680](https://github.com/wildcard/caro/pull/680) | path:scoped | /caro-coder-loop (i18n specialist) | caro-jac.3 | Run `sync-keys.mjs --dry-run` to merge locale deltas. Product GO on website i18n confirmed this session. |
+| [#652](https://github.com/wildcard/caro/pull/652) | path:scoped | /caro-coder-loop | caro-jac.4 | CONTRIBUTING.md grew to 1731 lines; targeted DCO insertions only |
+| [#128](https://github.com/wildcard/caro/pull/128) | path:scoped | /caro-coder-loop | caro-jac.5 | CLAUDE.md skill inventory is stale (21→40+); refresh against current `.claude/commands/` |
+| [#574](https://github.com/wildcard/caro/pull/574) | path:scoped | /caro-coder-loop | caro-jac.6 | `install.ps1` near-duplicate on main (PR #577); fold PR-unique PATH UX wins only |
+| [#597](https://github.com/wildcard/caro/pull/597) | path:scoped | /caro-coder-loop | caro-jac.7 | 6 net-new files land clean; CLAUDE.md is the only conflict |
+| [#605](https://github.com/wildcard/caro/pull/605) | path:scoped | /caro-coder-loop (rust-cli-expert) | caro-jac.8 | Refuse-list flag: `Cargo.toml` deps + `src/main.rs`. Additions scoped (libc + retry hooks) — reviewer must verify no semantic change to existing CLI flags |
+| [#599](https://github.com/wildcard/caro/pull/599) | path:deep | **caro-waitlist-engineer** (DORMANT pending OQ§1) | caro-jac.9 | Main shipped competing Upstash backend at `208150a1`. Vercel deploy failing since Jan 2026. Suspicious 353-line `index.html` artifact. **Upstash-vs-Turso decision blocks activation.** |
+
+## Newly filed beads (9 total, 0 skipped — first cycle)
+
+- `caro-jac` (epic) — V1.2.0 PR Rebase Queue
+- `caro-jac.1` — gh-651-rebase — `v1.2.0, loop:rebase, path:auto, dispatched-by:merge-integrate`
+- `caro-jac.2` — gh-609-rebase — same as above
+- `caro-jac.3` — gh-680-rebase — `… path:scoped …`
+- `caro-jac.4` — gh-652-rebase — `… path:scoped …`
+- `caro-jac.5` — gh-128-rebase — `… path:scoped …`
+- `caro-jac.6` — gh-574-rebase — `… path:scoped …`
+- `caro-jac.7` — gh-597-rebase — `… path:scoped …`
+- `caro-jac.8` — gh-605-rebase — `… path:scoped …` (refuse-list override note)
+- `caro-jac.9` — gh-599-rebase — `… path:deep, claim_policy:manual_only`
+
+`caro-8ys` (prior single meta-bead, open 7 days unclaimed) closed and pointed at the per-PR beads.
+
+## Coordination alerts (to Hermes)
+
+- **Action requested**: Hermes daily digest should include the
+  Upstash-vs-Turso decision request prominently. Without an answer to
+  OQ§1, `caro-waitlist-engineer` cannot activate and PR #599 remains
+  blocked indefinitely.
+- **Cross-agent step-on-toes scan**: no parallel branches detected for
+  any of the 9 PRs against the new `caro-jac.*` beads.
+
+## Release-readiness gates
+
+| Gate | Threshold | Current | Verdict |
+|---|---|---|---|
+| CHANGELOG `[Unreleased]` items | ≥ 3 | 2 | ❌ below |
+| Milestone v1.2.0 progress | ≥ 80% closed | 14.6% (7 closed / 48 total) | ❌ below |
+
+**No `/caro.release.prepare` suggestion posted.**
+
+## Pending follow-ups (out of scope for this cycle)
+
+- **`/caro-rebase-loop` skill** — until it exists, `loop:rebase` beads
+  sit unclaimed because `/caro-coder-loop`'s existing
+  fresh-implementation workflow doesn't handle rebases of pre-existing
+  PR branches. (PR #1087 documents this gap.)
+- **Coder-loop `--rebase-only` reviewer mode** — skip `cargo test` for
+  pure docs/i18n PRs.
+- **ROADMAP-sync PR** — last updated May 9 (4 days fresh); skipped this
+  cycle.
+- **`STAKEHOLDERS.yml` `risk_tier` field** — addressed by the separate
+  `.claude/automation/config/policy.yaml` instead.
+
+## Plan reference
+
+Full plan: `~/.claude/plans/use-the-ask-tool-witty-ullman.md`
+
+## Open Questions awaiting user decision
+
+| # | Question | Defaulted to | Blocks |
+|---|---|---|---|
+| §1 | Upstash-on-main vs Turso-in-#599: A (Turso replaces), B (close #599), C (coexist) | (unanswered) | caro-waitlist-engineer activation, caro-jac.9 |
+| §2 | Coder-loop modification appetite: minimal (this PR) vs spin up `/caro-rebase-loop` | Minimal (this PR) | Drain of `loop:rebase` beads |
+| §3 | Rebase epic placement: new `caro-rebase` epic vs `caro-xk0` | New `caro-rebase` (`caro-jac`) | ✓ Applied |
+| §4 | `caro-8ys` disposition: close-with-redirect vs keep-as-parent | Close-with-redirect | ✓ Applied |


### PR DESCRIPTION
Rebased version of #1087. Fixes Lint/Format + MSRV test failures. Closes #1087

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes the cron-based `caro-merge-review-integrate` into a resurfacing dispatcher that classifies PRs and files per-PR rebase beads, powered by a new policy file and Hermes digest integration. Adds the on-demand `caro-waitlist-engineer` for PR #599 (Turso path) and updates `caro-coder-loop` to respect dispatch policy.

- **New Features**
  - Introduced `.claude/automation/config/policy.yaml` with per-path `auto_dispatch`, `auto_rebase`, optional `constraint`, and `rationale`.
  - Dispatcher now writes cycle outputs to `.hermes/messages/pr-dispatch-*.md` per the new `.hermes/PROTOCOL.md` §5; first cycle included.
  - `caro-coder-loop` skips beads with `claim_policy:manual_only` and `loop:rebase`, and blocks work when a touched glob is disallowed by `policy.yaml`.
  - Added `caro-waitlist-engineer` (activated; Turso replaces Upstash) to own PR #599 end-to-end.

- **Migration**
  - Point the 4‑hour cron to the updated dispatcher SKILL and ensure it loads `policy.yaml`.
  - Ensure Hermes reads `.hermes/messages/pr-dispatch-*.md` for daily digests.
  - Provide Turso and Vercel secrets when prompted by `caro-waitlist-engineer` during PR #599 delivery.

<sup>Written for commit 2a9604d729d267fd256dd7969209c6d50eea8dae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

