### PR TITLE
fix(msrv): bump Rust 1.83 to 1.85 for edition2024 deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
   # ============================================================================
 
   msrv:
-    name: MSRV Check (Rust 1.83)
+    name: MSRV Check (Rust 1.85)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
@@ -322,15 +322,16 @@ jobs:
     - name: Setup Rust
       uses: ./.github/actions/setup-rust
       with:
-        toolchain: "1.83"
+        toolchain: "1.85"
         cache-key-suffix: msrv
 
     # Note: We use --no-default-features to exclude the 'knowledge' feature
-    # because its dependencies (fastembed -> image -> aligned) require Rust 2024 edition
-    - name: Build with Rust 1.83
+    # because its dependencies (fastembed -> image -> aligned) require Rust 2024
+    # edition, only stabilized in 1.85.
+    - name: Build with Rust 1.85
       run: cargo build --release --locked --no-default-features --features embedded-cpu
 
-    - name: Run tests with Rust 1.83
+    - name: Run tests with Rust 1.85
       run: cargo test --lib --locked --no-default-features --features embedded-cpu
       env:
         RUST_BACKTRACE: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV bumped from 1.83 → 1.85** to fix CI breakage caused by transitive
+  dependencies (`lance-geo` → `i_tree`, etc.) requiring `edition2024`,
+  which Cargo only stabilized in 1.85. With MSRV 1.83, `cargo build
+  --locked` failed during dep-graph parsing even when the offending crates
+  were excluded by feature flag (e.g. the embedded-cpu MSRV CI build):
+  `--locked` parses every entry in `Cargo.lock`, including
+  feature-gated ones. Rust 1.85 was stabilized 2025-02-20, ~14 months
+  before this bump.
+
 ## [1.4.0] - 2026-05-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "caro"
 version = "1.4.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 description = "Convert natural language to shell commands using local LLMs"
 license = "AGPL-3.0"
 authors = ["Wildcard <kobi@caro.sh>", "Claude Code <noreply@anthropic.com>"]
@@ -133,7 +133,7 @@ regex = "1.10"
 tempfile = "3.10"
 serial_test = "3"
 proptest = "1"
-criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.83
+criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.85
 futures = "0.3"
 serde_yaml = "0.9"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cargo build --release
 ./target/release/caro --version
 ```
 
-**Prerequisites**: Rust 1.83+, CMake. For Apple Silicon GPU acceleration, install Xcode.
+**Prerequisites**: Rust 1.85+, CMake. For Apple Silicon GPU acceleration, install Xcode.
 
 See [BUILD.md](docs/BUILD.md) for detailed build instructions.
 
@@ -532,7 +532,7 @@ For current usage, ChromaDB works well for basic command storage and retrieval, 
 ## 🔧 Development
 
 ### Prerequisites
-- Rust 1.83+ (latest stable recommended)
+- Rust 1.85+ (latest stable recommended)
 - Cargo
 - Make (optional, for convenience commands)
 - Docker (optional, for development container)


### PR DESCRIPTION
Bumps MSRV from 1.83 to 1.85 to fix CI breakage from edition2024 dependencies.

Closes caro-chd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps MSRV from Rust 1.83 to 1.85 to fix MSRV CI failures caused by `edition2024` in transitive dependencies (`lancedb` → `lance-geo` → `geodatafusion` → `i_tree`). Updates the CI workflow, `rust-version` in `Cargo.toml`, and README references.

- **Migration**
  - Rust 1.85+ is now required.

<sup>Written for commit 1d54504c50a15dd6dc9f992ed10ac907e4e23d8b. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

