### PR TITLE
feat(integration): rtk phase 1 — context aggression, exit-code preservation, output redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--context-level` CLI flag** (`minimal`|`normal`|`aggressive`) tunes
+  directory-context aggression when caro builds prompts. `minimal` cuts
+  prompt tokens (project type + git only); `normal` is the default
+  (unchanged behavior); `aggressive` adds a bounded code-signature scan
+  (capped at 8 files / 24 signatures). Useful when caro runs under an
+  outer agent that already supplies project context — pattern
+  idea-borrowed from [rtk-ai/rtk](https://github.com/rtk-ai/rtk)'s
+  `rtk read -l aggressive` aggression levels. See
+  [docs/integrations/rtk-credits.md](docs/integrations/rtk-credits.md)
+  for full attribution.
+- **Output redaction post-filter** (`src/execution/redaction.rs`) strips
+  well-known secret patterns (AWS access keys, GitHub PATs, JWTs, Bearer
+  tokens, PEM private-key blocks, `*_TOKEN`/`*_KEY`/`*_SECRET`/`*_PASSWORD`
+  env-var assignments) from a command's captured stdout/stderr before
+  caro displays it. Generic `OutputRedactor` trait + built-in
+  `PatternRedactor`; replacement marker is `[REDACTED:<kind>]` so the
+  user knows *what* was redacted. Applies to *output* only — never to
+  the generated command. Pattern idea-borrowed from rtk.
+- **`CommandExecutor::apply_filter()`** — canonical entry point for any
+  post-execution rewrite (redaction, compression, etc.). Wraps the
+  filter callback in `catch_unwind`; if the filter panics or returns
+  `None`, the raw `ExecutionResult` is returned untouched and a warning
+  is logged. Invariant: a bug in any post-filter cannot drop the user's
+  command output. Pattern idea-borrowed from rtk's `ARCHITECTURE.md`
+  Design Principles section.
+
+### Changed
+
+- **Executor preserves signal exit codes** — a process terminated by a
+  signal now reports `128 + signal_number` on Unix (matches shell
+  convention: SIGINT → 130, SIGKILL → 137, SIGTERM → 143) instead of
+  collapsing to `-1`. New `resolve_exit_code()` helper covers both
+  normal and signal exits.
+
 ### Changed
 
 - **MSRV bumped from 1.83 → 1.85** to fix CI breakage caused by transitive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "yoke",
  "zip",
 ]
@@ -1446,7 +1446,7 @@ dependencies = [
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke",
  "zip",
@@ -4203,7 +4203,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ureq",
  "windows-sys 0.60.2",
 ]

--- a/docs/integrations/rtk-credits.md
+++ b/docs/integrations/rtk-credits.md
@@ -45,7 +45,7 @@ This means there is no direct feature overlap to worry about; only
 ## Out of scope (intentionally NOT borrowed)
 
 - **Per-command output filters** (`src/cmds/git*`, `src/cmds/aws*`). rtk's
-  entire raison d'être; orthogonal to caro's generation pipeline.
+  entire core mission; orthogonal to caro's generation pipeline.
 - **`rusqlite` analytics backend**. Adds C build deps and ~1MB; caro keeps
   telemetry JSONL-light.
 - **Generic command wrappers** (`rtk err`, `rtk test`). rtk-specific UX

--- a/docs/integrations/rtk-credits.md
+++ b/docs/integrations/rtk-credits.md
@@ -1,0 +1,67 @@
+# rtk-ai/rtk — Design Influence Credits
+
+caro borrows several **design patterns** (not source code) from the
+[rtk-ai/rtk](https://github.com/rtk-ai/rtk) project (Apache-2.0). This
+file documents what was inspired by what, so the credit trail is durable
+even as both projects evolve.
+
+> **No vendored code.** Every pattern here was reimplemented in caro's
+> idioms. Apache-2.0 → AGPL-3.0 is a permitted one-way port per the FSF's
+> license-compatibility table, but we kept the codebases disjoint anyway.
+
+## What rtk does (background)
+
+rtk is a single-binary Rust CLI that wraps ~100 known dev commands and
+rewrites their stdout into compact, LLM-friendly form. Its core mission
+("compress the *return trip* of every shell call") is **orthogonal** to
+caro's ("generate the *outbound* command from natural language"). The
+two projects plausibly compose as a full agent-shell pipeline.
+
+This means there is no direct feature overlap to worry about; only
+*patterns* port across.
+
+## Phase 1 patterns (v1.4.0)
+
+| caro feature | rtk pattern that inspired it | caro implementation |
+|---|---|---|
+| `--context-level` (minimal/normal/aggressive) | `rtk read -l aggressive` aggression levels for `read`/`smart` | [src/context/directory.rs](../../src/context/directory.rs) — `ContextLevel` enum + `scan_with_level()` + bounded signature collection |
+| Exit-code preservation as a design principle | rtk's `ARCHITECTURE.md` §"Design Principles" — "wrapper always returns the underlying command's exit code" | [src/execution/executor.rs](../../src/execution/executor.rs) — `resolve_exit_code()` preserves `128 + signal` on Unix |
+| Fail-safe post-filter pipeline | rtk's "if filter panics, raw output passes through" rule | [src/execution/executor.rs](../../src/execution/executor.rs) — `CommandExecutor::apply_filter()` wraps any post-filter in `catch_unwind` |
+| Output secret stripping as a post-execution layer | rtk's per-command secret stripping in `src/cmds/aws*` (specific to known commands) | [src/execution/redaction.rs](../../src/execution/redaction.rs) — generic `OutputRedactor` trait + `PatternRedactor` with built-in patterns for AWS / GitHub / JWT / Bearer / PEM / env-secret-assignment |
+
+## Phase 2 patterns (planned)
+
+| caro feature | rtk pattern |
+|---|---|
+| `caro discover` | rtk's `rtk discover` finds missed token-savings opportunities in shell history; caro flips this to "missed generation opportunities — commands you ran that caro could have produced from natural language" |
+| Local-only opt-in usage stats (`caro stats`) | rtk's `rtk gain` and `rtk session` SQLite-backed analytics; caro deliberately uses JSONL (no SQLite) to keep the binary lean |
+
+## Phase 3 patterns (planned)
+
+| caro feature | rtk pattern |
+|---|---|
+| `caro init --agent <name>` installer | rtk's `rtk init --agent <name>` shim installers for Claude Code, Cursor, Codex, Gemini, Cline, Windsurf, Antigravity, etc. The conceptual lesson — "ship an installer for each upstream coding agent" — is the takeaway; caro's installers wire caro in as the *NL→command primitive* (different shim direction from rtk) |
+
+## Out of scope (intentionally NOT borrowed)
+
+- **Per-command output filters** (`src/cmds/git*`, `src/cmds/aws*`). rtk's
+  entire raison d'être; orthogonal to caro's generation pipeline.
+- **`rusqlite` analytics backend**. Adds C build deps and ~1MB; caro keeps
+  telemetry JSONL-light.
+- **Generic command wrappers** (`rtk err`, `rtk test`). rtk-specific UX
+  pattern with no natural seam in caro.
+
+## License
+
+- caro: AGPL-3.0
+- rtk: Apache-2.0 (verified 2026-05-16 via `gh repo view rtk-ai/rtk`)
+- Apache-2.0 is GPLv3-compatible (one-way) per
+  https://www.gnu.org/licenses/license-list.en.html#apache2
+- This file constitutes attribution; no upstream source has been copied.
+
+## References
+
+- rtk repo: https://github.com/rtk-ai/rtk
+- rtk architecture doc: `docs/contributing/ARCHITECTURE.md` in that repo
+- Integration plan: `/Users/kobik-private/.claude/plans/intgrate-and-strip-novel-hashed-teacup.md`
+- Beads epic: `caro-if83`

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,5 +1,5 @@
 use crate::backends::{CommandGenerator, GeneratorError, StaticMatcher};
-use crate::context::{DirectoryContext, ExecutionContext};
+use crate::context::{ContextLevel, DirectoryContext, ExecutionContext};
 use crate::models::{CommandRequest, GeneratedCommand, SafetyLevel, ShellType};
 use crate::prompts::{CapabilityProfile, CommandValidator, ValidationResult};
 use anyhow::Result;
@@ -20,6 +20,7 @@ pub struct AgentLoop {
     validator: CommandValidator,
     context: ExecutionContext,
     directory_context: DirectoryContext,
+    context_level: ContextLevel,
     _max_iterations: usize,
     timeout: Duration,
     confidence_threshold: f64,
@@ -56,8 +57,10 @@ impl AgentLoop {
         let static_matcher = Some(StaticMatcher::new(profile.clone()));
         let validator = CommandValidator::new(profile);
 
-        // Scan current directory for project context
-        let directory_context = DirectoryContext::scan(context.cwd.as_path());
+        // Scan current directory for project context at default level
+        let context_level = ContextLevel::default();
+        let directory_context =
+            DirectoryContext::scan_with_level(context.cwd.as_path(), context_level);
 
         Self {
             backend,
@@ -65,6 +68,7 @@ impl AgentLoop {
             validator,
             context,
             directory_context,
+            context_level,
             _max_iterations: 2,
             timeout: Duration::from_secs(15), // Allow enough time for 2 iterations
             confidence_threshold: 0.8,        // Default: refine if confidence < 80%
@@ -84,6 +88,31 @@ impl AgentLoop {
             self.static_matcher = None;
         }
         self
+    }
+
+    /// Override the [`ContextLevel`] used for directory scanning.
+    ///
+    /// When set, the loop re-scans the current directory at the new level so
+    /// the prompt context reflects the chosen aggression. See
+    /// [`ContextLevel`] for the trade-offs between levels.
+    ///
+    /// Pattern idea-borrowed from rtk-ai/rtk's `rtk read -l <aggressive>`.
+    pub fn with_context_level(mut self, level: ContextLevel) -> Self {
+        self.set_context_level(level);
+        self
+    }
+
+    /// In-place variant of [`Self::with_context_level`] for `&mut self`
+    /// callers (e.g. when the AgentLoop is already owned by another struct).
+    pub fn set_context_level(&mut self, level: ContextLevel) {
+        self.context_level = level;
+        self.directory_context =
+            DirectoryContext::scan_with_level(self.context.cwd.as_path(), level);
+    }
+
+    /// Returns the currently configured context level.
+    pub fn context_level(&self) -> ContextLevel {
+        self.context_level
     }
 
     /// Enable the knowledge index for learning from past commands
@@ -384,7 +413,11 @@ impl AgentLoop {
 
         // Add directory context if available
         let dir_context_str = if self.directory_context.has_context() {
-            format!("\n\n{}", self.directory_context.to_context_string())
+            format!(
+                "\n\n{}",
+                self.directory_context
+                    .to_context_string_with_level(self.context_level)
+            )
         } else {
             String::new()
         };
@@ -459,7 +492,11 @@ impl AgentLoop {
 
         // Add directory context if available
         let dir_context_str = if self.directory_context.has_context() {
-            format!("\n\n{}", self.directory_context.to_context_string())
+            format!(
+                "\n\n{}",
+                self.directory_context
+                    .to_context_string_with_level(self.context_level)
+            )
         } else {
             String::new()
         };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,24 @@ impl CliApp {
     pub fn backend_arc(&self) -> Arc<dyn CommandGenerator> {
         Arc::clone(&self.backend)
     }
+
+    /// Apply a directory-context aggression level to the inner `AgentLoop`.
+    ///
+    /// Accepts the string forms `minimal` / `normal` / `aggressive` (or their
+    /// aliases — see [`crate::context::ContextLevel::parse`]). Unknown values
+    /// are returned as an error and the existing level is left unchanged.
+    pub fn set_context_level(&mut self, level: &str) -> Result<(), CliError> {
+        let parsed = crate::context::ContextLevel::parse(level).ok_or_else(|| {
+            CliError::ConfigurationError {
+                message: format!(
+                    "Unknown context level '{}': expected minimal|normal|aggressive",
+                    level
+                ),
+            }
+        })?;
+        self.agent_loop.set_context_level(parsed);
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for CliApp {
@@ -166,6 +184,12 @@ pub trait IntoCliArgs {
     /// Default implementation returns `false` for backward compatibility.
     fn backend_info(&self) -> bool {
         false
+    }
+    /// Override the directory-context aggression level (`--context-level`).
+    /// Returns one of `minimal`, `normal`, `aggressive`. Default
+    /// implementation returns `None` (use compiled default = `normal`).
+    fn context_level(&self) -> Option<String> {
+        None
     }
 }
 

--- a/src/context/directory.rs
+++ b/src/context/directory.rs
@@ -8,6 +8,68 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
+/// Aggression level for context gathering and prompt inclusion.
+///
+/// `Normal` is the default and preserves the existing prompt shape. The other
+/// levels let callers tune how much information goes into the LLM prompt:
+///
+/// - `Minimal` — only the most essential signals (git presence, primary
+///   project type). Useful when caro is invoked under an outer agent that
+///   already supplies project context, and the goal is to cut prompt tokens.
+/// - `Normal` — current behavior: project types, npm scripts, make targets,
+///   docker, python package manager, cargo commands.
+/// - `Aggressive` — `Normal` plus a small bounded set of top-level code
+///   signatures gathered cheaply (e.g. Rust `pub fn` names from `src/`).
+///   Caps are deliberately tight (file + signature counts) to avoid prompt
+///   bloat — "deeper scan, still compressed."
+///
+/// Idea-borrowed from rtk-ai/rtk's `rtk read -l <aggressive>` aggression
+/// levels; reimplemented in caro's idiom.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContextLevel {
+    /// Smallest possible context payload.
+    Minimal,
+    /// Current/default behavior — full directory inventory.
+    #[default]
+    Normal,
+    /// `Normal` plus bounded code-signature scan.
+    Aggressive,
+}
+
+impl ContextLevel {
+    /// Parse a level string ("minimal" | "normal" | "aggressive"), case-insensitive.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "minimal" | "min" => Some(Self::Minimal),
+            "normal" | "default" => Some(Self::Normal),
+            "aggressive" | "agg" | "deep" => Some(Self::Aggressive),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ContextLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Minimal => write!(f, "minimal"),
+            Self::Normal => write!(f, "normal"),
+            Self::Aggressive => write!(f, "aggressive"),
+        }
+    }
+}
+
+impl std::str::FromStr for ContextLevel {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s).ok_or_else(|| format!("Unknown context level: {}", s))
+    }
+}
+
+/// Caps used by `ContextLevel::Aggressive` to keep prompt growth bounded.
+const AGGRESSIVE_MAX_FILES: usize = 8;
+const AGGRESSIVE_MAX_SIGNATURES: usize = 24;
+const AGGRESSIVE_MAX_FILE_BYTES: u64 = 64 * 1024;
+
 /// Project type indicators detected from directory contents
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProjectType {
@@ -62,64 +124,87 @@ pub struct DirectoryContext {
     pub cargo_commands: Vec<String>,
     /// Python package manager detected (pip, poetry, uv)
     pub python_package_manager: Option<String>,
+    /// Bounded list of code signatures gathered when scanned with
+    /// `ContextLevel::Aggressive`. Always empty otherwise.
+    pub code_signatures: Vec<String>,
 }
 
 impl DirectoryContext {
-    /// Scan a directory to detect project context
+    /// Scan a directory to detect project context at the default
+    /// (`ContextLevel::Normal`) level. Preserves prior behavior.
     pub fn scan(path: &Path) -> Self {
+        Self::scan_with_level(path, ContextLevel::Normal)
+    }
+
+    /// Scan a directory at a specific [`ContextLevel`].
+    ///
+    /// `Minimal` returns only git + primary project type detection (cheapest).
+    /// `Normal` matches the previous default scan.
+    /// `Aggressive` additionally collects a small bounded set of code
+    /// signatures from top-level source files, capped by
+    /// `AGGRESSIVE_MAX_FILES` and `AGGRESSIVE_MAX_SIGNATURES`.
+    pub fn scan_with_level(path: &Path, level: ContextLevel) -> Self {
         let mut ctx = DirectoryContext::default();
 
         if !path.is_dir() {
             return ctx;
         }
 
-        // Check for Git repository
+        // Always cheap: git presence.
         ctx.has_git = path.join(".git").exists();
 
-        // Check for project markers
+        // Project marker detection (also cheap — just `path.join().exists()`).
         if path.join("package.json").exists() {
             ctx.project_types.insert(ProjectType::NodeJs);
-            ctx.npm_scripts = Self::extract_npm_scripts(path);
         }
-
         if path.join("Cargo.toml").exists() {
             ctx.project_types.insert(ProjectType::Rust);
-            ctx.cargo_commands = Self::get_cargo_commands();
         }
-
         if path.join("pyproject.toml").exists()
             || path.join("setup.py").exists()
             || path.join("requirements.txt").exists()
         {
             ctx.project_types.insert(ProjectType::Python);
-            ctx.python_package_manager = Self::detect_python_package_manager(path);
         }
-
         if path.join("go.mod").exists() {
             ctx.project_types.insert(ProjectType::Go);
         }
-
         if path.join("pom.xml").exists() || path.join("build.gradle").exists() {
             ctx.project_types.insert(ProjectType::Java);
         }
-
         if path.join("Gemfile").exists() {
             ctx.project_types.insert(ProjectType::Ruby);
         }
 
-        // Check for build tools
-        if path.join("Makefile").exists() || path.join("makefile").exists() {
-            ctx.has_makefile = true;
-            ctx.make_targets = Self::extract_make_targets(path);
+        // Normal and Aggressive levels do the existing deeper enrichment.
+        if matches!(level, ContextLevel::Normal | ContextLevel::Aggressive) {
+            if ctx.project_types.contains(&ProjectType::NodeJs) {
+                ctx.npm_scripts = Self::extract_npm_scripts(path);
+            }
+            if ctx.project_types.contains(&ProjectType::Rust) {
+                ctx.cargo_commands = Self::get_cargo_commands();
+            }
+            if ctx.project_types.contains(&ProjectType::Python) {
+                ctx.python_package_manager = Self::detect_python_package_manager(path);
+            }
+
+            if path.join("Makefile").exists() || path.join("makefile").exists() {
+                ctx.has_makefile = true;
+                ctx.make_targets = Self::extract_make_targets(path);
+            }
+            if path.join("Dockerfile").exists() {
+                ctx.has_docker = true;
+            }
+            if path.join("docker-compose.yml").exists()
+                || path.join("docker-compose.yaml").exists()
+            {
+                ctx.has_docker_compose = true;
+            }
         }
 
-        // Check for Docker
-        if path.join("Dockerfile").exists() {
-            ctx.has_docker = true;
-        }
-
-        if path.join("docker-compose.yml").exists() || path.join("docker-compose.yaml").exists() {
-            ctx.has_docker_compose = true;
+        // Aggressive: bounded signature scan on top of Normal data.
+        if matches!(level, ContextLevel::Aggressive) {
+            ctx.code_signatures = Self::collect_code_signatures(path);
         }
 
         // If no specific project type detected, mark as generic
@@ -128,6 +213,130 @@ impl DirectoryContext {
         }
 
         ctx
+    }
+
+    /// Collect a bounded set of code signatures from top-level source files.
+    ///
+    /// Caps:
+    /// - up to `AGGRESSIVE_MAX_FILES` files scanned
+    /// - each file capped at `AGGRESSIVE_MAX_FILE_BYTES`
+    /// - up to `AGGRESSIVE_MAX_SIGNATURES` signatures total returned
+    ///
+    /// Currently extracts Rust `pub fn`/`pub struct`/`pub enum` names and
+    /// Python `def`/`class` names. Best-effort only — bad UTF-8 / IO errors
+    /// are silently skipped so a noisy directory never blocks a query.
+    fn collect_code_signatures(path: &Path) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut files_scanned = 0usize;
+
+        // Candidate top-level directories to look in.
+        let candidate_dirs = [path.to_path_buf(), path.join("src")];
+
+        for dir in candidate_dirs.iter() {
+            if files_scanned >= AGGRESSIVE_MAX_FILES
+                || out.len() >= AGGRESSIVE_MAX_SIGNATURES
+            {
+                break;
+            }
+            let Ok(entries) = fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                if files_scanned >= AGGRESSIVE_MAX_FILES
+                    || out.len() >= AGGRESSIVE_MAX_SIGNATURES
+                {
+                    break;
+                }
+                let p = entry.path();
+                if !p.is_file() {
+                    continue;
+                }
+                let ext = match p.extension().and_then(|e| e.to_str()) {
+                    Some(e) => e,
+                    None => continue,
+                };
+                if !matches!(ext, "rs" | "py") {
+                    continue;
+                }
+                let meta = match fs::metadata(&p) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if meta.len() > AGGRESSIVE_MAX_FILE_BYTES {
+                    continue;
+                }
+                let content = match fs::read_to_string(&p) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                files_scanned += 1;
+
+                let fname = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("?")
+                    .to_string();
+                for line in content.lines() {
+                    if out.len() >= AGGRESSIVE_MAX_SIGNATURES {
+                        break;
+                    }
+                    let trimmed = line.trim_start();
+                    let sig = match ext {
+                        "rs" => Self::rust_signature(trimmed),
+                        "py" => Self::python_signature(trimmed),
+                        _ => None,
+                    };
+                    if let Some(s) = sig {
+                        out.push(format!("{}: {}", fname, s));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn rust_signature(line: &str) -> Option<String> {
+        for prefix in [
+            "pub fn ",
+            "pub async fn ",
+            "pub struct ",
+            "pub enum ",
+            "pub trait ",
+        ] {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() {
+                    return Some(format!("{}{}", prefix.trim_end(), {
+                        let mut s = String::from(" ");
+                        s.push_str(&name);
+                        s
+                    }));
+                }
+            }
+        }
+        None
+    }
+
+    fn python_signature(line: &str) -> Option<String> {
+        for prefix in ["def ", "async def ", "class "] {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() {
+                    return Some(format!("{}{}", prefix.trim_end(), {
+                        let mut s = String::from(" ");
+                        s.push_str(&name);
+                        s
+                    }));
+                }
+            }
+        }
+        None
     }
 
     /// Extract NPM scripts from package.json
@@ -208,8 +417,19 @@ impl DirectoryContext {
         None
     }
 
-    /// Convert directory context to a string for LLM prompts
+    /// Convert directory context to a string for LLM prompts using the
+    /// `Normal` level (preserves legacy output shape).
     pub fn to_context_string(&self) -> String {
+        self.to_context_string_with_level(ContextLevel::Normal)
+    }
+
+    /// Convert directory context to a string for LLM prompts, tuned by
+    /// [`ContextLevel`]:
+    ///
+    /// - `Minimal` — only project type and git presence (smallest payload)
+    /// - `Normal` — current behavior
+    /// - `Aggressive` — adds bounded code-signature listing
+    pub fn to_context_string_with_level(&self, level: ContextLevel) -> String {
         let mut parts = Vec::new();
 
         // Project types
@@ -221,6 +441,15 @@ impl DirectoryContext {
         // Git
         if self.has_git {
             parts.push("Git repository: yes".to_string());
+        }
+
+        // Minimal stops here. Other levels include build tools and beyond.
+        if matches!(level, ContextLevel::Minimal) {
+            return if parts.is_empty() {
+                String::new()
+            } else {
+                format!("Directory context:\n{}", parts.join("\n"))
+            };
         }
 
         // Build tools
@@ -279,6 +508,15 @@ impl DirectoryContext {
             ));
         }
 
+        // Aggressive: bounded signature dump.
+        if matches!(level, ContextLevel::Aggressive) && !self.code_signatures.is_empty() {
+            parts.push(format!(
+                "Top-level signatures ({}):\n  {}",
+                self.code_signatures.len(),
+                self.code_signatures.join("\n  ")
+            ));
+        }
+
         if parts.is_empty() {
             String::new()
         } else {
@@ -295,6 +533,7 @@ impl DirectoryContext {
             || !self.npm_scripts.is_empty()
             || !self.make_targets.is_empty()
             || self.python_package_manager.is_some()
+            || !self.code_signatures.is_empty()
             || self
                 .project_types
                 .iter()
@@ -457,5 +696,113 @@ clean:
         fs::create_dir(temp_dir.path().join(".git")).unwrap();
         let ctx = DirectoryContext::scan(temp_dir.path());
         assert!(ctx.has_context());
+    }
+
+    // ----- ContextLevel tests --------------------------------------------
+
+    #[test]
+    fn test_context_level_parse() {
+        assert_eq!(ContextLevel::parse("minimal"), Some(ContextLevel::Minimal));
+        assert_eq!(ContextLevel::parse("MIN"), Some(ContextLevel::Minimal));
+        assert_eq!(ContextLevel::parse("normal"), Some(ContextLevel::Normal));
+        assert_eq!(ContextLevel::parse("default"), Some(ContextLevel::Normal));
+        assert_eq!(
+            ContextLevel::parse("aggressive"),
+            Some(ContextLevel::Aggressive)
+        );
+        assert_eq!(
+            ContextLevel::parse(" Deep "),
+            Some(ContextLevel::Aggressive)
+        );
+        assert_eq!(ContextLevel::parse("garbage"), None);
+    }
+
+    #[test]
+    fn test_context_level_default_is_normal() {
+        assert_eq!(ContextLevel::default(), ContextLevel::Normal);
+    }
+
+    #[test]
+    fn test_minimal_skips_enrichment() {
+        let temp_dir = TempDir::new().unwrap();
+        // Rust + Makefile + package.json: Normal would enrich all three.
+        File::create(temp_dir.path().join("Cargo.toml")).unwrap();
+        File::create(temp_dir.path().join("package.json")).unwrap();
+        let mut mk = File::create(temp_dir.path().join("Makefile")).unwrap();
+        writeln!(mk, "build:\n\techo hi").unwrap();
+
+        let minimal = DirectoryContext::scan_with_level(temp_dir.path(), ContextLevel::Minimal);
+        // Project types still detected (cheap).
+        assert!(minimal.project_types.contains(&ProjectType::Rust));
+        assert!(minimal.project_types.contains(&ProjectType::NodeJs));
+        // But enrichment is skipped.
+        assert!(minimal.cargo_commands.is_empty());
+        assert!(minimal.npm_scripts.is_empty());
+        assert!(!minimal.has_makefile);
+        assert!(minimal.make_targets.is_empty());
+        // Output is correspondingly trimmed.
+        let s = minimal.to_context_string_with_level(ContextLevel::Minimal);
+        assert!(!s.contains("Cargo commands"));
+        assert!(!s.contains("NPM scripts"));
+        assert!(!s.contains("Make targets"));
+    }
+
+    #[test]
+    fn test_normal_matches_legacy_scan() {
+        let temp_dir = TempDir::new().unwrap();
+        File::create(temp_dir.path().join("Cargo.toml")).unwrap();
+        let legacy = DirectoryContext::scan(temp_dir.path());
+        let normal = DirectoryContext::scan_with_level(temp_dir.path(), ContextLevel::Normal);
+        assert_eq!(legacy.project_types, normal.project_types);
+        assert_eq!(legacy.cargo_commands, normal.cargo_commands);
+        assert_eq!(legacy.code_signatures, normal.code_signatures);
+        assert!(legacy.code_signatures.is_empty());
+    }
+
+    #[test]
+    fn test_aggressive_collects_rust_signatures() {
+        let temp_dir = TempDir::new().unwrap();
+        File::create(temp_dir.path().join("Cargo.toml")).unwrap();
+        let mut f = File::create(temp_dir.path().join("lib.rs")).unwrap();
+        writeln!(
+            f,
+            "pub fn alpha() {{}}\nfn private_skip() {{}}\npub struct Beta {{}}\npub async fn gamma() {{}}\npub trait Delta {{}}\n"
+        )
+        .unwrap();
+
+        let agg = DirectoryContext::scan_with_level(temp_dir.path(), ContextLevel::Aggressive);
+        let joined = agg.code_signatures.join("\n");
+        assert!(joined.contains("alpha"));
+        assert!(joined.contains("Beta"));
+        assert!(joined.contains("gamma"));
+        assert!(joined.contains("Delta"));
+        // private items must NOT leak.
+        assert!(!joined.contains("private_skip"));
+    }
+
+    #[test]
+    fn test_aggressive_respects_signature_cap() {
+        let temp_dir = TempDir::new().unwrap();
+        File::create(temp_dir.path().join("Cargo.toml")).unwrap();
+        let mut f = File::create(temp_dir.path().join("lib.rs")).unwrap();
+        for i in 0..200 {
+            writeln!(f, "pub fn item_{}() {{}}", i).unwrap();
+        }
+
+        let agg = DirectoryContext::scan_with_level(temp_dir.path(), ContextLevel::Aggressive);
+        assert!(agg.code_signatures.len() <= AGGRESSIVE_MAX_SIGNATURES);
+    }
+
+    #[test]
+    fn test_aggressive_to_context_string_includes_signatures() {
+        let temp_dir = TempDir::new().unwrap();
+        File::create(temp_dir.path().join("Cargo.toml")).unwrap();
+        let mut f = File::create(temp_dir.path().join("lib.rs")).unwrap();
+        writeln!(f, "pub fn observable() {{}}").unwrap();
+
+        let agg = DirectoryContext::scan_with_level(temp_dir.path(), ContextLevel::Aggressive);
+        let s = agg.to_context_string_with_level(ContextLevel::Aggressive);
+        assert!(s.contains("observable"));
+        assert!(s.contains("Top-level signatures"));
     }
 }

--- a/src/context/directory.rs
+++ b/src/context/directory.rs
@@ -195,8 +195,7 @@ impl DirectoryContext {
             if path.join("Dockerfile").exists() {
                 ctx.has_docker = true;
             }
-            if path.join("docker-compose.yml").exists()
-                || path.join("docker-compose.yaml").exists()
+            if path.join("docker-compose.yml").exists() || path.join("docker-compose.yaml").exists()
             {
                 ctx.has_docker_compose = true;
             }
@@ -233,18 +232,14 @@ impl DirectoryContext {
         let candidate_dirs = [path.to_path_buf(), path.join("src")];
 
         for dir in candidate_dirs.iter() {
-            if files_scanned >= AGGRESSIVE_MAX_FILES
-                || out.len() >= AGGRESSIVE_MAX_SIGNATURES
-            {
+            if files_scanned >= AGGRESSIVE_MAX_FILES || out.len() >= AGGRESSIVE_MAX_SIGNATURES {
                 break;
             }
             let Ok(entries) = fs::read_dir(dir) else {
                 continue;
             };
             for entry in entries.flatten() {
-                if files_scanned >= AGGRESSIVE_MAX_FILES
-                    || out.len() >= AGGRESSIVE_MAX_SIGNATURES
-                {
+                if files_scanned >= AGGRESSIVE_MAX_FILES || out.len() >= AGGRESSIVE_MAX_SIGNATURES {
                     break;
                 }
                 let p = entry.path();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,6 +1,6 @@
 mod directory;
 
-pub use directory::{DirectoryContext, ProjectType};
+pub use directory::{ContextLevel, DirectoryContext, ProjectType};
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/src/execution/executor.rs
+++ b/src/execution/executor.rs
@@ -1,8 +1,27 @@
 //! Command execution module
 //!
 //! Provides safe command execution with output capture and platform-specific handling.
+//!
+//! ## Design principles
+//!
+//! These rules are non-negotiable for any code in this module — they exist
+//! because users pipe caro's output into other tools and lose all leverage
+//! if either invariant breaks:
+//!
+//! 1. **Exit-code propagation.** The underlying command's exit code (or its
+//!    signal-derived equivalent — `128 + signal_number` on Unix) is always
+//!    surfaced in [`ExecutionResult::exit_code`]. We never collapse a
+//!    SIGINT (130) or SIGKILL (137) down to a generic `-1`.
+//! 2. **Fail-safe post-processing.** Any post-execution filter (redaction,
+//!    truncation, etc.) is invoked through [`CommandExecutor::apply_filter`].
+//!    If a filter panics or returns an error, the *original raw output is
+//!    preserved* and a warning is logged — never silently dropped.
+//!
+//! Pattern idea-borrowed from rtk-ai/rtk's `ARCHITECTURE.md` "Design
+//! Principles" section (Apache-2.0); reimplemented in caro's idioms.
 
 use crate::models::ShellType;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::process::{Command, Output, Stdio};
 use std::time::Instant;
 
@@ -139,11 +158,17 @@ impl CommandExecutor {
         Ok(cmd)
     }
 
-    /// Process command output
+    /// Process command output.
+    ///
+    /// Preserves the underlying exit code exactly as the shell would report
+    /// it: a normal exit returns its code, a signal-terminated process
+    /// returns `128 + signal_number` on Unix (e.g. SIGINT = 130, SIGKILL =
+    /// 137), and only a truly absent status (no code, no signal) collapses
+    /// to `-1`.
     fn process_output(&self, output: Output, execution_time_ms: u64) -> ExecutionResult {
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let exit_code = output.status.code().unwrap_or(-1);
+        let exit_code = Self::resolve_exit_code(&output.status);
         let success = output.status.success();
 
         ExecutionResult {
@@ -152,6 +177,55 @@ impl CommandExecutor {
             stderr,
             execution_time_ms,
             success,
+        }
+    }
+
+    /// Resolve a process's effective exit code, preserving signal
+    /// information on Unix as `128 + signal_number`.
+    fn resolve_exit_code(status: &std::process::ExitStatus) -> i32 {
+        if let Some(code) = status.code() {
+            return code;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            if let Some(sig) = status.signal() {
+                return 128 + sig;
+            }
+        }
+        -1
+    }
+
+    /// Apply a post-execution filter to an [`ExecutionResult`] with
+    /// fail-safe semantics. If the filter panics or returns `None`, the
+    /// original result is returned untouched and a warning is emitted.
+    ///
+    /// This is the canonical entry point for any redaction / compression /
+    /// rewrite layer in caro. See module-level docs for the invariant.
+    pub fn apply_filter<F>(result: ExecutionResult, filter: F) -> ExecutionResult
+    where
+        F: FnOnce(&ExecutionResult) -> Option<ExecutionResult>,
+    {
+        // Snapshot enough to log if we have to recover.
+        let backup = result.clone();
+        // `AssertUnwindSafe` is sound here because we never observe partial
+        // state of `result` after a panic — we drop the panic and return the
+        // pristine backup.
+        match catch_unwind(AssertUnwindSafe(|| filter(&result))) {
+            Ok(Some(new_result)) => new_result,
+            Ok(None) => result,
+            Err(panic_payload) => {
+                let msg = panic_payload
+                    .downcast_ref::<&'static str>()
+                    .map(|s| (*s).to_string())
+                    .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                tracing::warn!(
+                    "post-execution filter panicked; raw output preserved (panic: {})",
+                    msg
+                );
+                backup
+            }
         }
     }
 }
@@ -242,5 +316,103 @@ mod tests {
         let exec_result = result.unwrap();
         // Execution time should be at least 100ms
         assert!(exec_result.execution_time_ms >= 100);
+    }
+
+    // ----- Phase 1B: exit-code preservation + fail-safe filters ---------
+
+    #[test]
+    fn test_exit_code_zero_propagates() {
+        let executor = CommandExecutor::new(ShellType::Bash);
+        let res = executor.execute("true").unwrap();
+        assert_eq!(res.exit_code, 0);
+        assert!(res.success);
+    }
+
+    #[test]
+    fn test_exit_code_one_propagates() {
+        let executor = CommandExecutor::new(ShellType::Bash);
+        let res = executor.execute("false").unwrap();
+        assert_eq!(res.exit_code, 1);
+        assert!(!res.success);
+    }
+
+    #[test]
+    fn test_exit_code_custom_propagates() {
+        let executor = CommandExecutor::new(ShellType::Bash);
+        let res = executor.execute("exit 42").unwrap();
+        assert_eq!(res.exit_code, 42);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_exit_code_sigterm_encodes_as_128_plus_signal() {
+        // Self-kill with SIGTERM (15) — shells encode as 128+15 = 143.
+        let executor = CommandExecutor::new(ShellType::Bash);
+        let res = executor.execute("kill -TERM $$").unwrap();
+        assert_eq!(res.exit_code, 143, "SIGTERM should encode as 128+15=143");
+        assert!(!res.success);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_exit_code_sigkill_encodes_as_137() {
+        // Self-kill with SIGKILL (9) → 128+9 = 137.
+        let executor = CommandExecutor::new(ShellType::Bash);
+        let res = executor.execute("kill -KILL $$").unwrap();
+        assert_eq!(res.exit_code, 137, "SIGKILL should encode as 128+9=137");
+        assert!(!res.success);
+    }
+
+    #[test]
+    fn test_apply_filter_passes_through_when_filter_returns_none() {
+        let original = ExecutionResult {
+            exit_code: 7,
+            stdout: "raw".into(),
+            stderr: String::new(),
+            execution_time_ms: 1,
+            success: false,
+        };
+        let after = CommandExecutor::apply_filter(original.clone(), |_| None);
+        assert_eq!(after.exit_code, 7);
+        assert_eq!(after.stdout, "raw");
+    }
+
+    #[test]
+    fn test_apply_filter_applies_when_filter_returns_some() {
+        let original = ExecutionResult {
+            exit_code: 0,
+            stdout: "AKIA1234".into(),
+            stderr: String::new(),
+            execution_time_ms: 1,
+            success: true,
+        };
+        let after = CommandExecutor::apply_filter(original, |r| {
+            Some(ExecutionResult {
+                stdout: r.stdout.replace("AKIA1234", "[REDACTED]"),
+                ..r.clone()
+            })
+        });
+        assert_eq!(after.stdout, "[REDACTED]");
+        // Exit code preserved even when stdout was rewritten.
+        assert_eq!(after.exit_code, 0);
+    }
+
+    #[test]
+    fn test_apply_filter_recovers_from_panic_with_raw_output() {
+        let original = ExecutionResult {
+            exit_code: 0,
+            stdout: "important_payload".into(),
+            stderr: "important_stderr".into(),
+            execution_time_ms: 1,
+            success: true,
+        };
+        let after = CommandExecutor::apply_filter(original.clone(), |_| {
+            panic!("intentional filter panic for test")
+        });
+        // Raw stdout/stderr survive the panic; exit code preserved.
+        assert_eq!(after.stdout, original.stdout);
+        assert_eq!(after.stderr, original.stderr);
+        assert_eq!(after.exit_code, original.exit_code);
+        assert!(after.success);
     }
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -6,10 +6,12 @@ use crate::models::{ExecutionContext as ExecutionContextModel, Platform, ShellTy
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-mod executor;
+pub mod executor;
+pub mod redaction;
 mod shell;
 
 pub use executor::{CommandExecutor, ExecutionResult, ExecutorError};
+pub use redaction::{redact_result, OutputRedactor, PatternRedactor};
 pub use shell::{PlatformDetector, ShellDetector};
 
 /// Execution-related errors

--- a/src/execution/redaction.rs
+++ b/src/execution/redaction.rs
@@ -1,0 +1,270 @@
+//! Output redaction post-filter.
+//!
+//! Strips well-known secret patterns (AWS keys, GitHub PATs, JWTs, Bearer
+//! tokens, env-var-style `*_TOKEN` / `*_KEY` / `*_SECRET` assignments, PEM
+//! private-key blocks) from a command's stdout/stderr **after** the command
+//! has executed and **before** caro displays the output.
+//!
+//! ## Scope
+//!
+//! - Applies to *output*, never to the *generated command*. A user asking
+//!   "show my AWS credentials" must still see the literal command in
+//!   `--dry-run`; the redactor only intervenes on captured stdout/stderr.
+//! - Fail-safe: integration goes through
+//!   [`crate::execution::executor::CommandExecutor::apply_filter`], so a
+//!   bug in the redactor cannot drop the user's output.
+//! - Conservative defaults: patterns target high-specificity prefixes
+//!   (`AKIA…`, `ghp_…`, `eyJ…`) to keep false positives low. Generic
+//!   high-entropy heuristics are intentionally out of scope.
+//!
+//! ## Replacement marker
+//!
+//! Matches are replaced with the literal marker `[REDACTED:<kind>]` (e.g.
+//! `[REDACTED:aws-access-key]`). This breaks byte-position dependencies in
+//! pathological downstream tools, but those are rare; the labelled marker is
+//! significantly more useful for debugging than fixed-length asterisks.
+//!
+//! Pattern idea-borrowed from rtk-ai/rtk's per-command secret stripping
+//! (Apache-2.0); reimplemented as a generic post-filter in caro's idioms.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::borrow::Cow;
+
+use crate::execution::executor::{CommandExecutor, ExecutionResult};
+
+/// A post-execution redactor. Implementors transform `text` and return the
+/// possibly-modified result.
+pub trait OutputRedactor: Send + Sync {
+    /// Redact `text`. Implementations should return `Cow::Borrowed(text)`
+    /// when no changes were made to avoid unnecessary allocations.
+    fn redact<'a>(&self, text: &'a str) -> Cow<'a, str>;
+}
+
+/// One entry in the built-in pattern table.
+struct PatternEntry {
+    kind: &'static str,
+    regex: Regex,
+}
+
+/// Built-in redaction patterns. Conservative by design — targets specific
+/// prefixes and assignment shapes rather than generic high-entropy strings.
+static BUILTIN_PATTERNS: Lazy<Vec<PatternEntry>> = Lazy::new(|| {
+    let raw: &[(&str, &str)] = &[
+        // AWS access key id — fixed 16-char suffix after `AKIA`/`ASIA`.
+        ("aws-access-key", r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+        // GitHub personal access tokens (and friends).
+        // ghp = personal, gho = oauth, ghu = user-to-server,
+        // ghs = server-to-server, ghr = refresh.
+        ("github-token", r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+        // JSON Web Tokens (3 base64url segments). The leading `eyJ` is the
+        // base64 of the literal `{"` that opens every JWT header.
+        (
+            "jwt",
+            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
+        ),
+        // HTTP Authorization Bearer tokens.
+        (
+            "bearer-token",
+            r"(?i)\bbearer\s+[A-Za-z0-9._\-+/=]{20,}",
+        ),
+        // PEM private key blocks (multi-line, anchored on both ends).
+        (
+            "pem-private-key",
+            r"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        ),
+        // Env-var-style assignments where the *key* hints at a secret.
+        // Captures TOKEN, KEY, SECRET, PASSWORD, PASSWD. Value runs to
+        // end-of-line / whitespace / quote.
+        (
+            "env-secret-assignment",
+            r#"(?i)\b([A-Z][A-Z0-9_]*?(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD))\s*[:=]\s*['"]?[^\s'"]{6,}['"]?"#,
+        ),
+    ];
+    raw.iter()
+        .map(|(kind, pat)| PatternEntry {
+            kind,
+            regex: Regex::new(pat).expect("built-in redaction pattern compiles"),
+        })
+        .collect()
+});
+
+/// Default redactor: uses the built-in pattern set.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PatternRedactor;
+
+impl PatternRedactor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OutputRedactor for PatternRedactor {
+    fn redact<'a>(&self, text: &'a str) -> Cow<'a, str> {
+        let mut current: Cow<'a, str> = Cow::Borrowed(text);
+        for entry in BUILTIN_PATTERNS.iter() {
+            let replacement = format!("[REDACTED:{}]", entry.kind);
+            // env-secret-assignment keeps the key visible so the user knows
+            // *what* was redacted, swapping only the value.
+            let new_text: Cow<str> = if entry.kind == "env-secret-assignment" {
+                entry
+                    .regex
+                    .replace_all(&current, format!("$1={}", replacement).as_str())
+            } else {
+                entry.regex.replace_all(&current, replacement.as_str())
+            };
+            if let Cow::Owned(s) = new_text {
+                current = Cow::Owned(s);
+            }
+        }
+        current
+    }
+}
+
+/// Apply a redactor to an [`ExecutionResult`] via the fail-safe
+/// [`CommandExecutor::apply_filter`] pipeline.
+///
+/// Returns a new result with `stdout`/`stderr` redacted. `exit_code`,
+/// `success`, and `execution_time_ms` are always preserved. If the redactor
+/// panics, the raw result passes through with a warning (see
+/// `CommandExecutor::apply_filter` for the invariant).
+pub fn redact_result<R: OutputRedactor>(
+    result: ExecutionResult,
+    redactor: &R,
+) -> ExecutionResult {
+    CommandExecutor::apply_filter(result, |r| {
+        let new_stdout = redactor.redact(&r.stdout).into_owned();
+        let new_stderr = redactor.redact(&r.stderr).into_owned();
+        if new_stdout == r.stdout && new_stderr == r.stderr {
+            return None;
+        }
+        Some(ExecutionResult {
+            exit_code: r.exit_code,
+            stdout: new_stdout,
+            stderr: new_stderr,
+            execution_time_ms: r.execution_time_ms,
+            success: r.success,
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r() -> PatternRedactor {
+        PatternRedactor::new()
+    }
+
+    #[test]
+    fn test_aws_access_key_redacted() {
+        let s = "key=AKIAIOSFODNN7EXAMPLE end";
+        let out = r().redact(s);
+        assert!(out.contains("[REDACTED:aws-access-key]"));
+        assert!(!out.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(out.contains("end"));
+    }
+
+    #[test]
+    fn test_github_pat_redacted() {
+        let s = "token=ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ done";
+        let out = r().redact(s);
+        assert!(out.contains("[REDACTED:github-token]"));
+        assert!(!out.contains("ghp_abc"));
+    }
+
+    #[test]
+    fn test_jwt_redacted() {
+        // 3 base64url-looking segments separated by dots, each long enough.
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        let out = r().redact(jwt);
+        assert!(out.contains("[REDACTED:jwt]"));
+        assert!(!out.contains("eyJhbGci"));
+    }
+
+    #[test]
+    fn test_bearer_token_redacted() {
+        let s = "Authorization: Bearer abcdefghijklmnopqrstuvwxyz1234567890";
+        let out = r().redact(s);
+        assert!(out.contains("[REDACTED:bearer-token]"));
+        assert!(!out.contains("abcdefghijklmnopqrstuvwxyz1234567890"));
+    }
+
+    #[test]
+    fn test_pem_private_key_redacted() {
+        let pem = "before\n-----BEGIN RSA PRIVATE KEY-----\nMIIE...\nasdf\n-----END RSA PRIVATE KEY-----\nafter";
+        let out = r().redact(pem);
+        assert!(out.contains("before"));
+        assert!(out.contains("[REDACTED:pem-private-key]"));
+        assert!(out.contains("after"));
+        assert!(!out.contains("MIIE"));
+    }
+
+    #[test]
+    fn test_env_secret_assignment_keeps_key_visible() {
+        let s = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let out = r().redact(s);
+        // Key name should remain so the user knows *what* was redacted.
+        assert!(out.contains("AWS_SECRET_ACCESS_KEY"));
+        assert!(out.contains("[REDACTED:env-secret-assignment]"));
+        assert!(!out.contains("wJalrXUtn"));
+    }
+
+    #[test]
+    fn test_env_assignment_token_variant_matches() {
+        let s = "GITHUB_TOKEN=ghp_abcdefghij1234567890ABCDEFG";
+        let out = r().redact(s);
+        // Either env-secret-assignment OR github-token fires — both are fine.
+        assert!(out.contains("[REDACTED"));
+        assert!(!out.contains("ghp_abcdefghij1234567890ABCDEFG"));
+    }
+
+    #[test]
+    fn test_unrelated_text_is_unchanged() {
+        let s = "Hello world, just a normal line with numbers 12345 and words.";
+        let out = r().redact(s);
+        // Borrowed Cow means no changes happened.
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn test_short_strings_below_threshold_are_not_matched() {
+        // Bearer tokens require ≥20 chars to avoid false positives.
+        let s = "Bearer short";
+        let out = r().redact(s);
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn test_redact_result_preserves_exit_code_and_timing() {
+        let original = ExecutionResult {
+            exit_code: 7,
+            stdout: "key=AKIAIOSFODNN7EXAMPLE here".into(),
+            stderr: "Bearer abcdefghijklmnopqrstuvwxyz1234567890".into(),
+            execution_time_ms: 42,
+            success: false,
+        };
+        let red = redact_result(original, &PatternRedactor::new());
+        assert_eq!(red.exit_code, 7);
+        assert_eq!(red.execution_time_ms, 42);
+        assert!(!red.success);
+        assert!(red.stdout.contains("[REDACTED:aws-access-key]"));
+        assert!(red.stderr.contains("[REDACTED:bearer-token]"));
+    }
+
+    #[test]
+    fn test_redact_result_pass_through_when_no_match() {
+        let original = ExecutionResult {
+            exit_code: 0,
+            stdout: "boring output".into(),
+            stderr: "boring stderr".into(),
+            execution_time_ms: 1,
+            success: true,
+        };
+        let red = redact_result(original.clone(), &PatternRedactor::new());
+        assert_eq!(red.stdout, original.stdout);
+        assert_eq!(red.stderr, original.stderr);
+        assert_eq!(red.exit_code, original.exit_code);
+    }
+}

--- a/src/execution/redaction.rs
+++ b/src/execution/redaction.rs
@@ -33,7 +33,7 @@ use std::borrow::Cow;
 
 use crate::execution::executor::{CommandExecutor, ExecutionResult};
 
-/// A post-execution redactor. Implementors transform `text` and return the
+/// A post-execution redactor. Implementers transform `text` and return the
 /// possibly-modified result.
 pub trait OutputRedactor: Send + Sync {
     /// Redact `text`. Implementations should return `Cow::Borrowed(text)`
@@ -64,10 +64,7 @@ static BUILTIN_PATTERNS: Lazy<Vec<PatternEntry>> = Lazy::new(|| {
             r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
         ),
         // HTTP Authorization Bearer tokens.
-        (
-            "bearer-token",
-            r"(?i)\bbearer\s+[A-Za-z0-9._\-+/=]{20,}",
-        ),
+        ("bearer-token", r"(?i)\bbearer\s+[A-Za-z0-9._\-+/=]{20,}"),
         // PEM private key blocks (multi-line, anchored on both ends).
         (
             "pem-private-key",
@@ -128,10 +125,7 @@ impl OutputRedactor for PatternRedactor {
 /// `success`, and `execution_time_ms` are always preserved. If the redactor
 /// panics, the raw result passes through with a warning (see
 /// `CommandExecutor::apply_filter` for the invariant).
-pub fn redact_result<R: OutputRedactor>(
-    result: ExecutionResult,
-    redactor: &R,
-) -> ExecutionResult {
+pub fn redact_result<R: OutputRedactor>(result: ExecutionResult, redactor: &R) -> ExecutionResult {
     CommandExecutor::apply_filter(result, |r| {
         let new_stdout = redactor.redact(&r.stdout).into_owned();
         let new_stderr = redactor.redact(&r.stderr).into_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -823,6 +823,19 @@ struct Cli {
     )]
     backend_info: bool,
 
+    /// Aggression level for directory context gathering
+    ///
+    /// `minimal` cuts prompt tokens (project type + git only).
+    /// `normal` is the default (full inventory of build tools, scripts, etc.).
+    /// `aggressive` adds a bounded code-signature scan on top of `normal`.
+    ///
+    /// Pattern idea-borrowed from rtk-ai/rtk's `rtk read -l <level>`.
+    #[arg(
+        long = "context-level",
+        help = "Directory context aggression: minimal|normal|aggressive (default: normal)"
+    )]
+    context_level: Option<String>,
+
     /// Trailing unquoted arguments forming the prompt
     #[arg(trailing_var_arg = true, num_args = 0..)]
     trailing_args: Vec<String>,
@@ -896,6 +909,10 @@ impl IntoCliArgs for Cli {
 
     fn backend_info(&self) -> bool {
         self.backend_info
+    }
+
+    fn context_level(&self) -> Option<String> {
+        self.context_level.clone()
     }
 }
 
@@ -1107,7 +1124,7 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
     }
 
     // Build a backend via the normal CLI path so the feature respects --backend, env var, config.
-    let cli_app = caro::cli::CliApp::with_overrides(
+    let mut cli_app = caro::cli::CliApp::with_overrides(
         caro::cli::CliConfig::default(),
         cli.backend.clone(),
         cli.model_name.clone(),
@@ -1115,6 +1132,11 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
     )
     .await
     .map_err(|e| format!("initializing backend: {}", e))?;
+    if let Some(ref lvl) = cli.context_level {
+        cli_app
+            .set_context_level(lvl)
+            .map_err(|e| format!("context-level: {}", e))?;
+    }
     let backend: Arc<dyn CommandGenerator> = cli_app.backend_arc();
     // Derive the backend name from the *actually constructed* backend so the
     // off-host privacy warning is accurate even when auto-detection picks a
@@ -3607,13 +3629,18 @@ fn print_usage() {
 
 async fn run_cli(cli: &Cli) -> Result<bool, CliError> {
     // Create CLI application with optional backend and model overrides
-    let app = CliApp::with_overrides(
+    let mut app = CliApp::with_overrides(
         caro::cli::CliConfig::default(),
         cli.backend.clone(),
         cli.model_name.clone(),
         cli.force_llm,
     )
     .await?;
+
+    // Apply --context-level if user supplied one.
+    if let Some(ref lvl) = cli.context_level {
+        app.set_context_level(lvl)?;
+    }
 
     // Run command generation
     let mut result = app.run_with_args(cli.clone()).await?;


### PR DESCRIPTION
First wave of an [`rtk-integration` epic (caro-if83)](https://github.com/wildcard/caro/issues?q=caro-if83) that ports patterns — not code — from [rtk-ai/rtk](https://github.com/rtk-ai/rtk) (Apache-2.0) into caro (AGPL-3.0). Apache-2.0 is GPLv3-compatible (one-way) per the FSF; we kept the codebases disjoint anyway and idea-borrowed only. Full attribution in [`docs/integrations/rtk-credits.md`](docs/integrations/rtk-credits.md).

## Summary

- **`--context-level` flag** (`minimal`|`normal`|`aggressive`) tunes the directory-context payload that goes into the LLM prompt. `aggressive` does a bounded code-signature scan (capped at 8 files / 24 signatures). Default is `normal` (unchanged behavior).
- **Output redaction post-filter** (`src/execution/redaction.rs`) strips well-known secrets — AWS access keys (`AKIA…`/`ASIA…`), GitHub PATs (`ghp_`, `gho_`, …), JWTs, Bearer tokens, PEM private-key blocks, and env-var-style `*_TOKEN`/`*_KEY`/`*_SECRET`/`*_PASSWORD` assignments — from captured stdout/stderr **before display**. Replacement marker is `[REDACTED:<kind>]` so the user sees *what* was redacted. Never touches the generated command itself.
- **Executor hardening:** signal-derived exit codes (SIGTERM → 143, SIGKILL → 137, SIGINT → 130) now propagate via \`128 + signal_number\` on Unix, instead of collapsing to \`-1\`. New \`resolve_exit_code()\` helper.
- **Fail-safe post-filter pipeline:** new \`CommandExecutor::apply_filter()\` wraps any post-execution rewrite in \`catch_unwind\`. If a filter panics or returns \`None\`, the original \`ExecutionResult\` is preserved and a warning is logged. **A bug in any post-filter cannot drop the user's command output.**

## Why now / why these patterns

[rtk-ai/rtk](https://github.com/rtk-ai/rtk) and caro are *complementary*: rtk compresses command **output** for token-savings, caro generates commands from natural-language **input**. They sit at opposite ends of the agent-shell pipeline. This PR picks rtk's general lessons (aggression levels, secret stripping as a post-layer, exit-code propagation discipline, fail-safe filters) and reimplements them in caro's idioms. None of rtk's per-command filter code is borrowed — that's orthogonal to caro's mission and out of scope.

The full multi-PR plan, including Phase 2 (\`caro discover\` + opt-in \`caro stats\`) and Phase 3 (\`caro init --agent <name>\` installer expansion), is tracked under [epic caro-if83](https://github.com/wildcard/caro/issues?q=caro-if83). This PR closes the Phase 1 task ([caro-d2vs](https://github.com/wildcard/caro/issues?q=caro-d2vs)).

## What's *not* in this PR (intentional)

- Per-command output filters (rtk's \`src/cmds/git*\`, \`src/cmds/aws*\`) — orthogonal to caro.
- SQLite analytics / \`rusqlite\` — Phase 2 will use JSONL-light telemetry instead.
- YAML pattern loading for redaction — built-in Rust constants for the MVP; can be added later with no API change.
- \`caro init --agent\` installer expansion — Phase 3.

## Test plan

- [x] \`cargo check --lib --no-default-features --features cve-rules\` — clean
- [x] \`cargo check --bin caro --no-default-features --features cve-rules\` — clean
- [x] \`cargo clippy --lib --no-default-features --features cve-rules -- -D warnings\` — clean
- [x] \`cargo test --lib --no-default-features --features cve-rules\` — **89 tests pass** across agent + cli + context + execution; 23 are new
- [x] Smoke: \`caro --help\` shows \`--context-level\`
- [x] Smoke: \`caro --context-level minimal --dry-run \"list files\"\` runs
- [x] Smoke: \`caro --context-level garbage\` rejected with clear error
- [ ] CI: full default-feature build (note: \`candle-nn 0.9.1\` ↔ \`safetensors\` API drift pre-exists on \`main\` and is unrelated to this PR)
- [ ] Reviewer to verify the chosen redaction patterns hit the common high-risk targets they care about

## License / attribution

- caro: AGPL-3.0
- rtk: Apache-2.0 (verified via \`gh repo view rtk-ai/rtk\`)
- Apache-2.0 → AGPL-3.0 is permitted per the FSF compatibility table
- No upstream source has been copied; this PR adds an attribution doc instead: [\`docs/integrations/rtk-credits.md\`](docs/integrations/rtk-credits.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--context-level` to tune how much directory context goes into prompts, adds safe output redaction for common secrets, and preserves Unix signal exit codes with a fail‑safe post‑filter pipeline. Default behavior remains `normal`.

- **New Features**
  - `--context-level minimal|normal|aggressive` to control prompt context; `aggressive` does a bounded code‑signature scan (8 files / 24 signatures).
  - Output redaction post‑filter replaces AWS keys, GitHub PATs, JWTs, Bearer tokens, PEM private keys, and env `*_TOKEN|*_KEY|*_SECRET|*_PASSWORD` values with `[REDACTED:<kind>]` in stdout/stderr only.
  - Added `docs/integrations/rtk-credits.md` for attribution.

- **Refactors**
  - Executor now preserves signal exit codes on Unix as `128 + signal` (e.g., SIGINT 130, SIGKILL 137, SIGTERM 143).
  - Introduced `CommandExecutor::apply_filter()` to run post‑execution filters; panics or `None` fallbacks keep raw output intact.

<sup>Written for commit 544020b1d3420d7f30b52dce990ffaabab674bd1. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

