### PR TITLE
feat(agent): x-algorithm-style candidate pipeline (scaffolding + adapters)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,11 @@ embedded-mlx = ["cxx", "llama_cpp"]
 embedded-cpu = ["candle-core", "candle-transformers"]
 knowledge = ["lancedb", "fastembed", "arrow-array", "arrow-schema"]
 chromadb = ["knowledge", "dep:chromadb"]  # ChromaDB backend (requires knowledge base features)
+# Multi-stage candidate pipeline inspired by x-algorithm
+# (sources -> hydrators -> filters -> scorer -> selector). Phase 1: scaffolding only,
+# no behavior change. Phase 2 wires it into AgentLoop. See
+# /root/.claude/plans/how-we-can-improve-polymorphic-stearns.md.
+candidate-ranking = []
 # Compile CVE rules from data/cve_rules/*.yaml into the binary at build time.
 # Disable for minimal-binary targets where CVE coverage is not needed.
 cve-rules = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,9 +171,9 @@ embedded-cpu = ["candle-core", "candle-transformers"]
 knowledge = ["lancedb", "fastembed", "arrow-array", "arrow-schema"]
 chromadb = ["knowledge", "dep:chromadb"]  # ChromaDB backend (requires knowledge base features)
 # Multi-stage candidate pipeline inspired by x-algorithm
-# (sources -> hydrators -> filters -> scorer -> selector). Phase 1: scaffolding only,
-# no behavior change. Phase 2 wires it into AgentLoop. See
-# /root/.claude/plans/how-we-can-improve-polymorphic-stearns.md.
+# (sources -> hydrators -> filters -> scorer -> selector). Off by default;
+# flip to default in v1.4.0 after the eval harness shows ranking wins.
+# See PR #1108 for design and rollout phases.
 candidate-ranking = []
 # Compile CVE rules from data/cve_rules/*.yaml into the binary at build time.
 # Disable for minimal-binary targets where CVE coverage is not needed.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,13 @@ use crate::context::{DirectoryContext, ExecutionContext};
 use crate::models::{CommandRequest, GeneratedCommand, SafetyLevel, ShellType};
 use crate::prompts::{CapabilityProfile, CommandValidator, ValidationResult};
 use anyhow::Result;
+
+/// Multi-stage candidate pipeline (x-algorithm-inspired). Phase 1: scaffolding
+/// + traits + linear scorer + argmax selector. Not yet wired into the agent
+/// loop — that's Phase 2. See the plan at
+/// `/root/.claude/plans/how-we-can-improve-polymorphic-stearns.md`.
+#[cfg(feature = "candidate-ranking")]
+pub mod pipeline;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Command;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,15 +1,14 @@
+/// Multi-stage candidate pipeline (x-algorithm-inspired). Scaffolding +
+/// adapters around the existing primitives. Wiring into [`AgentLoop`] is
+/// scheduled for a follow-up commit; see PR #1108.
+#[cfg(feature = "candidate-ranking")]
+pub mod pipeline;
+
 use crate::backends::{CommandGenerator, GeneratorError, StaticMatcher};
 use crate::context::{DirectoryContext, ExecutionContext};
 use crate::models::{CommandRequest, GeneratedCommand, SafetyLevel, ShellType};
 use crate::prompts::{CapabilityProfile, CommandValidator, ValidationResult};
 use anyhow::Result;
-
-/// Multi-stage candidate pipeline (x-algorithm-inspired). Phase 1: scaffolding
-/// + traits + linear scorer + argmax selector. Not yet wired into the agent
-/// loop — that's Phase 2. See the plan at
-/// `/root/.claude/plans/how-we-can-improve-polymorphic-stearns.md`.
-#[cfg(feature = "candidate-ranking")]
-pub mod pipeline;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Command;

--- a/src/agent/pipeline/filters.rs
+++ b/src/agent/pipeline/filters.rs
@@ -1,0 +1,115 @@
+//! Filters — drop candidates that should not be considered.
+//!
+//! Phase 2 ships two:
+//!
+//! - [`SafetyFilter`] reads the `risk_level` written by
+//!   [`super::SafetyHydrator`] and rejects Critical candidates. Decoupling
+//!   "compute safety" (hydrator) from "act on safety" (filter) means the
+//!   validator runs once per candidate even if many filters care about it.
+//! - [`ValidationFilter`] wraps the existing [`crate::prompts::CommandValidator`]
+//!   so structurally-broken commands (bad quoting, banned tools, etc.) are
+//!   dropped before scoring. It also sets `features.validation_passed`.
+
+use async_trait::async_trait;
+
+use super::{Candidate, Filter};
+use crate::models::RiskLevel;
+use crate::prompts::CommandValidator;
+
+/// Rejects candidates whose [`super::SafetyHydrator`] marked them Critical.
+/// Moderate / High candidates pass through here — they get routed to
+/// human approval elsewhere in caro, not blocked at the pipeline stage.
+#[derive(Default)]
+pub struct SafetyFilter;
+
+#[async_trait]
+impl Filter for SafetyFilter {
+    async fn filter(&self, c: &Candidate) -> Option<String> {
+        match c.features.risk_level {
+            Some(RiskLevel::Critical) => Some("Critical risk level".to_string()),
+            None => Some("safety not hydrated".to_string()),
+            _ => None,
+        }
+    }
+    fn name(&self) -> &str {
+        "safety-filter"
+    }
+}
+
+/// Runs the existing structural [`CommandValidator`] and rejects on hard
+/// errors. Also stamps `validation_passed` onto the candidate so downstream
+/// observers can see why a candidate scored as it did.
+pub struct ValidationFilter {
+    validator: CommandValidator,
+}
+
+impl ValidationFilter {
+    pub fn new(validator: CommandValidator) -> Self {
+        Self { validator }
+    }
+}
+
+#[async_trait]
+impl Filter for ValidationFilter {
+    async fn filter(&self, c: &Candidate) -> Option<String> {
+        let result = self.validator.validate(&c.command);
+        if result.is_valid() {
+            None
+        } else {
+            Some(result.error_message())
+        }
+    }
+    fn name(&self) -> &str {
+        "validation-filter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CandidateFeatures;
+    use super::*;
+
+    fn cand_with_risk(risk: Option<RiskLevel>) -> Candidate {
+        Candidate {
+            command: "x".into(),
+            source: "t".into(),
+            features: CandidateFeatures {
+                risk_level: risk,
+                ..Default::default()
+            },
+            score: None,
+            rejection_reason: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn safety_filter_rejects_critical() {
+        let f = SafetyFilter;
+        assert!(f
+            .filter(&cand_with_risk(Some(RiskLevel::Critical)))
+            .await
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn safety_filter_passes_safe() {
+        let f = SafetyFilter;
+        assert!(f.filter(&cand_with_risk(Some(RiskLevel::Safe))).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn safety_filter_passes_moderate() {
+        let f = SafetyFilter;
+        assert!(f
+            .filter(&cand_with_risk(Some(RiskLevel::Moderate)))
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn safety_filter_rejects_unhydrated_candidate() {
+        let f = SafetyFilter;
+        let reason = f.filter(&cand_with_risk(None)).await;
+        assert!(reason.is_some(), "should reject when safety not hydrated");
+    }
+}

--- a/src/agent/pipeline/filters.rs
+++ b/src/agent/pipeline/filters.rs
@@ -1,20 +1,22 @@
 //! Filters — drop candidates that should not be considered.
 //!
-//! Phase 2 ships two:
+//! Filters are paired with hydrators: the hydrator does the work (runs the
+//! validator, computes the risk level), the filter reads the resulting
+//! feature and decides. This keeps the validator sweep to one call per
+//! candidate even if many filters consume the result.
 //!
-//! - [`SafetyFilter`] reads the `risk_level` written by
-//!   [`super::SafetyHydrator`] and rejects Critical candidates. Decoupling
-//!   "compute safety" (hydrator) from "act on safety" (filter) means the
-//!   validator runs once per candidate even if many filters care about it.
-//! - [`ValidationFilter`] wraps the existing [`crate::prompts::CommandValidator`]
-//!   so structurally-broken commands (bad quoting, banned tools, etc.) are
-//!   dropped before scoring. It also sets `features.validation_passed`.
+//! Shipped filters:
+//!
+//! - [`SafetyFilter`] reads `risk_level` written by [`super::SafetyHydrator`]
+//!   and rejects Critical candidates. Moderate / High pass through — the
+//!   caller is responsible for routing those to human approval.
+//! - [`ValidationFilter`] reads `validation_passed` written by
+//!   [`super::ValidationHydrator`] and rejects on hard structural errors.
 
 use async_trait::async_trait;
 
 use super::{Candidate, Filter};
 use crate::models::RiskLevel;
-use crate::prompts::CommandValidator;
 
 /// Rejects candidates whose [`super::SafetyHydrator`] marked them Critical.
 /// Moderate / High candidates pass through here — they get routed to
@@ -36,27 +38,26 @@ impl Filter for SafetyFilter {
     }
 }
 
-/// Runs the existing structural [`CommandValidator`] and rejects on hard
-/// errors. Also stamps `validation_passed` onto the candidate so downstream
-/// observers can see why a candidate scored as it did.
-pub struct ValidationFilter {
-    validator: CommandValidator,
-}
-
-impl ValidationFilter {
-    pub fn new(validator: CommandValidator) -> Self {
-        Self { validator }
-    }
-}
+/// Rejects candidates whose [`super::ValidationHydrator`] flagged as invalid.
+/// Like [`SafetyFilter`], rejects unhydrated candidates by default — easier
+/// to spot a misconfigured pipeline than to silently let bad commands win.
+#[derive(Default)]
+pub struct ValidationFilter;
 
 #[async_trait]
 impl Filter for ValidationFilter {
     async fn filter(&self, c: &Candidate) -> Option<String> {
-        let result = self.validator.validate(&c.command);
-        if result.is_valid() {
+        if c.features.validation_passed {
             None
         } else {
-            Some(result.error_message())
+            // Echo the hydrator's reason when available; otherwise treat
+            // missing hydration as a failure.
+            Some(
+                c.features
+                    .validation_error
+                    .clone()
+                    .unwrap_or_else(|| "validation not hydrated".to_string()),
+            )
         }
     }
     fn name(&self) -> &str {
@@ -111,5 +112,44 @@ mod tests {
         let f = SafetyFilter;
         let reason = f.filter(&cand_with_risk(None)).await;
         assert!(reason.is_some(), "should reject when safety not hydrated");
+    }
+
+    fn cand_with_validation(passed: bool, err: Option<&str>) -> Candidate {
+        Candidate {
+            command: "x".into(),
+            source: "t".into(),
+            features: CandidateFeatures {
+                validation_passed: passed,
+                validation_error: err.map(String::from),
+                ..Default::default()
+            },
+            score: None,
+            rejection_reason: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn validation_filter_passes_valid_command() {
+        let f = ValidationFilter;
+        assert!(f.filter(&cand_with_validation(true, None)).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn validation_filter_rejects_invalid_with_echoed_reason() {
+        let f = ValidationFilter;
+        let reason = f
+            .filter(&cand_with_validation(false, Some("banned tool: curl")))
+            .await
+            .expect("should reject");
+        assert!(reason.contains("banned tool"));
+    }
+
+    #[tokio::test]
+    async fn validation_filter_rejects_unhydrated_candidate() {
+        let f = ValidationFilter;
+        // Default: validation_passed = false, validation_error = None
+        let reason = f.filter(&Candidate::new("x", "t")).await;
+        assert!(reason.is_some(), "should reject when validation not hydrated");
+        assert!(reason.unwrap().contains("not hydrated"));
     }
 }

--- a/src/agent/pipeline/hydrators.rs
+++ b/src/agent/pipeline/hydrators.rs
@@ -1,0 +1,168 @@
+//! Hydrators — populate [`CandidateFeatures`] from candidate text.
+//!
+//! Phase 2 ships two:
+//!
+//! - [`PlatformFitHydrator`] reuses the BSD/GNU heuristics from
+//!   [`crate::agent::AgentLoop::should_refine`] (`src/agent/mod.rs:720`) and
+//!   maps a hit to a [0, 1] `platform_fit` score. The logic is intentionally
+//!   identical so behavior is preserved when the pipeline is wired in.
+//! - [`SafetyHydrator`] calls [`crate::safety::SafetyValidator::validate_command`]
+//!   and writes `safety_confidence` + `risk_level` onto the candidate. The
+//!   [`super::SafetyFilter`] later consumes `risk_level` to drop Critical
+//!   candidates — keeping the validator call here means the network of
+//!   filters never duplicates a (potentially expensive) regex sweep.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use super::{Candidate, Hydrator};
+use crate::models::ShellType;
+use crate::safety::SafetyValidator;
+
+/// Platform-fit heuristic — penalizes BSD/GNU flag mismatches. Mirrors the
+/// existing `should_refine` regexes so wiring this in is behavior-preserving.
+pub struct PlatformFitHydrator {
+    os: String,
+}
+
+impl PlatformFitHydrator {
+    pub fn new(os: impl Into<String>) -> Self {
+        Self { os: os.into() }
+    }
+
+    fn score(&self, cmd: &str) -> f32 {
+        match self.os.as_str() {
+            // macOS uses BSD tools — GNU long flags and Linux-only commands
+            // are penalized exactly the same way `should_refine` flags them.
+            "macos" => {
+                let has_gnu_long_flag = cmd.contains("--sort") || cmd.contains("--max-depth");
+                let uses_linux_only = cmd.contains("ss ") || cmd.starts_with("find /");
+                if has_gnu_long_flag || uses_linux_only {
+                    0.3
+                } else {
+                    1.0
+                }
+            }
+            // Linux happily takes both BSD and GNU — full fit.
+            _ => 1.0,
+        }
+    }
+}
+
+#[async_trait]
+impl Hydrator for PlatformFitHydrator {
+    async fn hydrate(&self, c: &mut Candidate) {
+        c.features.platform_fit = self.score(&c.command);
+    }
+    fn name(&self) -> &str {
+        "platform-fit"
+    }
+}
+
+/// Runs [`SafetyValidator::validate_command`] and writes the result onto
+/// the candidate's features. A separate [`super::SafetyFilter`] consumes
+/// the `risk_level` to reject Critical hits.
+pub struct SafetyHydrator {
+    validator: Arc<SafetyValidator>,
+    shell: ShellType,
+}
+
+impl SafetyHydrator {
+    pub fn new(validator: Arc<SafetyValidator>) -> Self {
+        Self {
+            validator,
+            shell: ShellType::Bash,
+        }
+    }
+
+    pub fn with_shell(mut self, shell: ShellType) -> Self {
+        self.shell = shell;
+        self
+    }
+}
+
+#[async_trait]
+impl Hydrator for SafetyHydrator {
+    async fn hydrate(&self, c: &mut Candidate) {
+        match self.validator.validate_command(&c.command, self.shell).await {
+            Ok(result) => {
+                c.features.safety_confidence = result.confidence_score;
+                c.features.risk_level = Some(result.risk_level);
+            }
+            Err(_) => {
+                // Validator errored; treat as unknown — leave defaults but
+                // mark risk as Critical so the SafetyFilter rejects.
+                c.features.risk_level = Some(crate::models::RiskLevel::Critical);
+                c.features.safety_confidence = 0.0;
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "safety"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::RiskLevel;
+    use crate::safety::SafetyConfig;
+
+    fn cand(cmd: &str) -> Candidate {
+        Candidate::new(cmd, "test")
+    }
+
+    #[tokio::test]
+    async fn macos_gnu_long_flag_penalized() {
+        let h = PlatformFitHydrator::new("macos");
+        let mut c = cand("ps aux --sort=-pcpu | head");
+        h.hydrate(&mut c).await;
+        assert!(c.features.platform_fit < 0.5);
+    }
+
+    #[tokio::test]
+    async fn macos_bsd_command_full_fit() {
+        let h = PlatformFitHydrator::new("macos");
+        let mut c = cand("ps aux | sort -k3 -rn | head -5");
+        h.hydrate(&mut c).await;
+        assert!((c.features.platform_fit - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn linux_gnu_flag_full_fit() {
+        let h = PlatformFitHydrator::new("linux");
+        let mut c = cand("ps aux --sort=-pcpu | head");
+        h.hydrate(&mut c).await;
+        assert!((c.features.platform_fit - 1.0).abs() < 1e-5);
+    }
+
+    #[tokio::test]
+    async fn macos_linux_only_command_penalized() {
+        let h = PlatformFitHydrator::new("macos");
+        let mut c = cand("ss -tuln");
+        h.hydrate(&mut c).await;
+        assert!(c.features.platform_fit < 0.5);
+    }
+
+    #[tokio::test]
+    async fn safety_hydrator_marks_dangerous_critical() {
+        let validator = Arc::new(SafetyValidator::new(SafetyConfig::moderate()).unwrap());
+        let h = SafetyHydrator::new(validator);
+        let mut c = cand("rm -rf /");
+        h.hydrate(&mut c).await;
+        assert_eq!(c.features.risk_level, Some(RiskLevel::Critical));
+    }
+
+    #[tokio::test]
+    async fn safety_hydrator_marks_safe_commands_safe() {
+        let validator = Arc::new(SafetyValidator::new(SafetyConfig::moderate()).unwrap());
+        let h = SafetyHydrator::new(validator);
+        let mut c = cand("ls -la");
+        h.hydrate(&mut c).await;
+        assert!(matches!(
+            c.features.risk_level,
+            Some(RiskLevel::Safe) | Some(RiskLevel::Moderate)
+        ));
+    }
+}

--- a/src/agent/pipeline/hydrators.rs
+++ b/src/agent/pipeline/hydrators.rs
@@ -1,22 +1,28 @@
 //! Hydrators — populate [`CandidateFeatures`] from candidate text.
 //!
-//! Phase 2 ships two:
+//! Each hydrator owns one feature so the upstream filter has something
+//! cheap to read. Doing the work here means [`super::SafetyFilter`] and
+//! [`super::ValidationFilter`] never duplicate the (potentially expensive)
+//! regex sweeps the validators perform.
+//!
+//! Shipped hydrators:
 //!
 //! - [`PlatformFitHydrator`] reuses the BSD/GNU heuristics from
-//!   [`crate::agent::AgentLoop::should_refine`] (`src/agent/mod.rs:720`) and
-//!   maps a hit to a [0, 1] `platform_fit` score. The logic is intentionally
+//!   [`crate::agent::AgentLoop`]'s `should_refine`. The logic is intentionally
 //!   identical so behavior is preserved when the pipeline is wired in.
-//! - [`SafetyHydrator`] calls [`crate::safety::SafetyValidator::validate_command`]
-//!   and writes `safety_confidence` + `risk_level` onto the candidate. The
-//!   [`super::SafetyFilter`] later consumes `risk_level` to drop Critical
-//!   candidates — keeping the validator call here means the network of
-//!   filters never duplicates a (potentially expensive) regex sweep.
+//! - [`SafetyHydrator`] calls
+//!   [`crate::safety::SafetyValidator::validate_command`] and writes
+//!   `safety_confidence` + `risk_level`.
+//! - [`ValidationHydrator`] calls the existing
+//!   [`crate::prompts::CommandValidator`] and writes `validation_passed`
+//!   + `validation_error`.
 
 use async_trait::async_trait;
 use std::sync::Arc;
 
 use super::{Candidate, Hydrator};
 use crate::models::ShellType;
+use crate::prompts::CommandValidator;
 use crate::safety::SafetyValidator;
 
 /// Platform-fit heuristic — penalizes BSD/GNU flag mismatches. Mirrors the
@@ -100,6 +106,39 @@ impl Hydrator for SafetyHydrator {
 
     fn name(&self) -> &str {
         "safety"
+    }
+}
+
+/// Runs the existing structural [`CommandValidator`] and stamps
+/// `validation_passed` + `validation_error` onto the candidate. A separate
+/// [`super::ValidationFilter`] consumes those fields to reject.
+///
+/// `CommandValidator::validate` is sync so this hydrator's async body
+/// doesn't await — it's async only to satisfy the trait shape.
+pub struct ValidationHydrator {
+    validator: Arc<CommandValidator>,
+}
+
+impl ValidationHydrator {
+    pub fn new(validator: Arc<CommandValidator>) -> Self {
+        Self { validator }
+    }
+}
+
+#[async_trait]
+impl Hydrator for ValidationHydrator {
+    async fn hydrate(&self, c: &mut Candidate) {
+        let result = self.validator.validate(&c.command);
+        c.features.validation_passed = result.is_valid();
+        c.features.validation_error = if result.is_valid() {
+            None
+        } else {
+            Some(result.error_message())
+        };
+    }
+
+    fn name(&self) -> &str {
+        "validation"
     }
 }
 

--- a/src/agent/pipeline/mod.rs
+++ b/src/agent/pipeline/mod.rs
@@ -1,0 +1,245 @@
+//! Multi-stage candidate pipeline (Phase 1 scaffolding).
+//!
+//! Inspired by [`xai-org/x-algorithm`][1]'s feed pipeline pattern:
+//! `sources -> hydrators -> filters -> scorer -> selector`. The existing caro
+//! primitives map onto these stages without re-invention:
+//!
+//! - **Sources** wrap [`crate::backends::CommandGenerator`] impls plus the
+//!   knowledge index k-NN retrieval (Phase 2).
+//! - **Hydrators** add features such as platform-fit and safety-confidence.
+//! - **Filters** drop unsafe / invalid candidates using the existing
+//!   [`crate::safety::SafetyValidator`] and `CommandValidator`.
+//! - **Scorer** computes a weighted multi-signal score (see [`weights`]).
+//! - **Selector** picks the top candidate.
+//!
+//! Phase 1 (this module) provides the types, traits, a [`LinearScorer`], an
+//! [`ArgmaxSelector`], and a [`Pipeline`] orchestrator with unit tests.
+//! Phase 2 will plumb real sources / hydrators / filters and wire the
+//! pipeline into [`crate::agent::AgentLoop`] behind this feature flag.
+//!
+//! [1]: https://github.com/xai-org/x-algorithm
+
+pub mod scorer;
+pub mod selector;
+pub mod weights;
+
+pub use scorer::{LinearScorer, Scorer};
+pub use selector::{ArgmaxSelector, Selector};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Feature vector hydrated onto each candidate before scoring.
+///
+/// Each field is a normalized signal in `[0.0, 1.0]` (or, for `latency_ms`,
+/// a raw measurement transformed to `[0, 1]` inside the scorer). The
+/// [`Scorer`] is the only place that knows how to combine these.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct CandidateFeatures {
+    /// LLM self-reported confidence (or 1.0 for static-matcher hits).
+    pub llm_confidence: f32,
+    /// Confidence from [`crate::safety::SafetyValidator`] — higher = safer.
+    pub safety_confidence: f32,
+    /// 1.0 if no platform-specific issues detected, else lower.
+    pub platform_fit: f32,
+    /// Cosine similarity to the closest known successful command, if any.
+    pub knowledge_similarity: Option<f32>,
+    /// Wall-clock time the source took to produce this candidate.
+    pub latency_ms: u64,
+    /// Whether the structural / syntactic validator passed.
+    pub validation_passed: bool,
+}
+
+/// A single candidate command produced by a source.
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    pub command: String,
+    /// Human-readable identifier of the source (e.g. `"static"`, `"embedded@T=0.4"`).
+    pub source: String,
+    pub features: CandidateFeatures,
+    /// Set by [`Scorer`] after filters have run.
+    pub score: Option<f32>,
+    /// Populated by the first [`Filter`] that rejects this candidate.
+    pub rejection_reason: Option<String>,
+}
+
+impl Candidate {
+    pub fn new(command: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            source: source.into(),
+            features: CandidateFeatures::default(),
+            score: None,
+            rejection_reason: None,
+        }
+    }
+
+    pub fn is_rejected(&self) -> bool {
+        self.rejection_reason.is_some()
+    }
+}
+
+/// A producer of candidate commands. Sources should be cheap to run in
+/// parallel — they must not share mutable state with each other.
+#[async_trait]
+pub trait CandidateSource: Send + Sync {
+    async fn produce(&self, prompt: &str) -> Result<Candidate, PipelineError>;
+    fn name(&self) -> &str;
+}
+
+/// Adds features to a candidate. Hydrators are pure: they never reject.
+pub trait Hydrator: Send + Sync {
+    fn hydrate(&self, candidate: &mut Candidate);
+    fn name(&self) -> &str;
+}
+
+/// Inspects a candidate; returns `Some(reason)` to reject, `None` to keep.
+pub trait Filter: Send + Sync {
+    fn filter(&self, candidate: &Candidate) -> Option<String>;
+    fn name(&self) -> &str;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    #[error("source `{name}` failed: {message}")]
+    SourceFailed { name: String, message: String },
+    #[error("all candidates were filtered out or no sources produced output")]
+    NoCandidates,
+}
+
+/// Orchestrates the five stages. Phase 1 runs sources sequentially; Phase 2
+/// will fan them out under a shared latency budget.
+pub struct Pipeline {
+    pub sources: Vec<Arc<dyn CandidateSource>>,
+    pub hydrators: Vec<Arc<dyn Hydrator>>,
+    pub filters: Vec<Arc<dyn Filter>>,
+    pub scorer: Arc<dyn Scorer>,
+    pub selector: Arc<dyn Selector>,
+}
+
+impl Pipeline {
+    pub async fn run(&self, prompt: &str) -> Result<Candidate, PipelineError> {
+        let mut candidates: Vec<Candidate> = Vec::with_capacity(self.sources.len());
+        for src in &self.sources {
+            if let Ok(c) = src.produce(prompt).await {
+                candidates.push(c);
+            }
+        }
+
+        for c in candidates.iter_mut() {
+            for h in &self.hydrators {
+                h.hydrate(c);
+            }
+        }
+
+        for c in candidates.iter_mut() {
+            for f in &self.filters {
+                if let Some(reason) = f.filter(c) {
+                    c.rejection_reason = Some(format!("{}: {}", f.name(), reason));
+                    break;
+                }
+            }
+        }
+
+        for c in candidates.iter_mut() {
+            if !c.is_rejected() {
+                c.score = Some(self.scorer.score(c));
+            }
+        }
+
+        self.selector
+            .select(&candidates)
+            .cloned()
+            .ok_or(PipelineError::NoCandidates)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeSource(&'static str, &'static str);
+
+    #[async_trait]
+    impl CandidateSource for FakeSource {
+        async fn produce(&self, _prompt: &str) -> Result<Candidate, PipelineError> {
+            let mut c = Candidate::new(self.1.to_string(), self.0.to_string());
+            c.features.llm_confidence = 0.5;
+            Ok(c)
+        }
+        fn name(&self) -> &str {
+            self.0
+        }
+    }
+
+    struct FlatHydrator;
+    impl Hydrator for FlatHydrator {
+        fn hydrate(&self, c: &mut Candidate) {
+            c.features.safety_confidence = 1.0;
+            c.features.platform_fit = 1.0;
+            c.features.validation_passed = true;
+        }
+        fn name(&self) -> &str {
+            "flat"
+        }
+    }
+
+    struct RejectByName(&'static str);
+    impl Filter for RejectByName {
+        fn filter(&self, c: &Candidate) -> Option<String> {
+            (c.source == self.0).then(|| format!("rejected source {}", self.0))
+        }
+        fn name(&self) -> &str {
+            "reject-by-name"
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_picks_best_scored_candidate() {
+        let p = Pipeline {
+            sources: vec![
+                Arc::new(FakeSource("a", "echo a")),
+                Arc::new(FakeSource("b", "echo b")),
+                Arc::new(FakeSource("c", "echo c")),
+            ],
+            hydrators: vec![Arc::new(FlatHydrator)],
+            filters: vec![],
+            scorer: Arc::new(LinearScorer::default()),
+            selector: Arc::new(ArgmaxSelector),
+        };
+        let winner = p.run("anything").await.unwrap();
+        // All candidates have identical features → first wins (deterministic).
+        assert_eq!(winner.command, "echo a");
+        assert!(winner.score.is_some());
+    }
+
+    #[tokio::test]
+    async fn pipeline_drops_filtered_candidates() {
+        let p = Pipeline {
+            sources: vec![
+                Arc::new(FakeSource("a", "echo a")),
+                Arc::new(FakeSource("b", "echo b")),
+            ],
+            hydrators: vec![Arc::new(FlatHydrator)],
+            filters: vec![Arc::new(RejectByName("a"))],
+            scorer: Arc::new(LinearScorer::default()),
+            selector: Arc::new(ArgmaxSelector),
+        };
+        let winner = p.run("anything").await.unwrap();
+        assert_eq!(winner.command, "echo b");
+    }
+
+    #[tokio::test]
+    async fn pipeline_errors_when_all_filtered() {
+        let p = Pipeline {
+            sources: vec![Arc::new(FakeSource("a", "echo a"))],
+            hydrators: vec![Arc::new(FlatHydrator)],
+            filters: vec![Arc::new(RejectByName("a"))],
+            scorer: Arc::new(LinearScorer::default()),
+            selector: Arc::new(ArgmaxSelector),
+        };
+        let err = p.run("anything").await.unwrap_err();
+        assert!(matches!(err, PipelineError::NoCandidates));
+    }
+}

--- a/src/agent/pipeline/mod.rs
+++ b/src/agent/pipeline/mod.rs
@@ -19,16 +19,24 @@
 //!
 //! [1]: https://github.com/xai-org/x-algorithm
 
+pub mod filters;
+pub mod hydrators;
 pub mod scorer;
 pub mod selector;
+pub mod sources;
 pub mod weights;
 
+pub use filters::{SafetyFilter, ValidationFilter};
+pub use hydrators::{PlatformFitHydrator, SafetyHydrator};
 pub use scorer::{LinearScorer, Scorer};
 pub use selector::{ArgmaxSelector, Selector};
+pub use sources::BackendSource;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use crate::models::RiskLevel;
 
 /// Feature vector hydrated onto each candidate before scoring.
 ///
@@ -41,6 +49,8 @@ pub struct CandidateFeatures {
     pub llm_confidence: f32,
     /// Confidence from [`crate::safety::SafetyValidator`] — higher = safer.
     pub safety_confidence: f32,
+    /// Risk level from the safety validator. `None` until [`SafetyHydrator`] runs.
+    pub risk_level: Option<RiskLevel>,
     /// 1.0 if no platform-specific issues detected, else lower.
     pub platform_fit: f32,
     /// Cosine similarity to the closest known successful command, if any.
@@ -88,15 +98,21 @@ pub trait CandidateSource: Send + Sync {
     fn name(&self) -> &str;
 }
 
-/// Adds features to a candidate. Hydrators are pure: they never reject.
+/// Adds features to a candidate. Hydrators are pure: they never reject. The
+/// trait is async so impls can call out to async machinery (e.g.
+/// [`crate::safety::SafetyValidator::validate_command`]).
+#[async_trait]
 pub trait Hydrator: Send + Sync {
-    fn hydrate(&self, candidate: &mut Candidate);
+    async fn hydrate(&self, candidate: &mut Candidate);
     fn name(&self) -> &str;
 }
 
 /// Inspects a candidate; returns `Some(reason)` to reject, `None` to keep.
+/// Async-trait friendly even when individual impls don't await — keeps the
+/// trait composable with async hydration upstream.
+#[async_trait]
 pub trait Filter: Send + Sync {
-    fn filter(&self, candidate: &Candidate) -> Option<String>;
+    async fn filter(&self, candidate: &Candidate) -> Option<String>;
     fn name(&self) -> &str;
 }
 
@@ -129,13 +145,13 @@ impl Pipeline {
 
         for c in candidates.iter_mut() {
             for h in &self.hydrators {
-                h.hydrate(c);
+                h.hydrate(c).await;
             }
         }
 
         for c in candidates.iter_mut() {
             for f in &self.filters {
-                if let Some(reason) = f.filter(c) {
+                if let Some(reason) = f.filter(c).await {
                     c.rejection_reason = Some(format!("{}: {}", f.name(), reason));
                     break;
                 }
@@ -174,8 +190,9 @@ mod tests {
     }
 
     struct FlatHydrator;
+    #[async_trait]
     impl Hydrator for FlatHydrator {
-        fn hydrate(&self, c: &mut Candidate) {
+        async fn hydrate(&self, c: &mut Candidate) {
             c.features.safety_confidence = 1.0;
             c.features.platform_fit = 1.0;
             c.features.validation_passed = true;
@@ -186,8 +203,9 @@ mod tests {
     }
 
     struct RejectByName(&'static str);
+    #[async_trait]
     impl Filter for RejectByName {
-        fn filter(&self, c: &Candidate) -> Option<String> {
+        async fn filter(&self, c: &Candidate) -> Option<String> {
             (c.source == self.0).then(|| format!("rejected source {}", self.0))
         }
         fn name(&self) -> &str {

--- a/src/agent/pipeline/mod.rs
+++ b/src/agent/pipeline/mod.rs
@@ -1,21 +1,21 @@
-//! Multi-stage candidate pipeline (Phase 1 scaffolding).
+//! Multi-stage candidate pipeline.
 //!
 //! Inspired by [`xai-org/x-algorithm`][1]'s feed pipeline pattern:
-//! `sources -> hydrators -> filters -> scorer -> selector`. The existing caro
-//! primitives map onto these stages without re-invention:
+//! `sources -> hydrators -> filters -> scorer -> selector`. The existing
+//! caro primitives map onto these stages without re-invention:
 //!
-//! - **Sources** wrap [`crate::backends::CommandGenerator`] impls plus the
-//!   knowledge index k-NN retrieval (Phase 2).
-//! - **Hydrators** add features such as platform-fit and safety-confidence.
-//! - **Filters** drop unsafe / invalid candidates using the existing
-//!   [`crate::safety::SafetyValidator`] and `CommandValidator`.
+//! - **Sources** wrap [`crate::backends::CommandGenerator`] impls (a
+//!   knowledge-retrieval source lands in a follow-up).
+//! - **Hydrators** populate [`CandidateFeatures`] — platform-fit, safety
+//!   confidence, structural validation.
+//! - **Filters** consume hydrated features to drop unsafe / invalid
+//!   candidates.
 //! - **Scorer** computes a weighted multi-signal score (see [`weights`]).
 //! - **Selector** picks the top candidate.
 //!
-//! Phase 1 (this module) provides the types, traits, a [`LinearScorer`], an
-//! [`ArgmaxSelector`], and a [`Pipeline`] orchestrator with unit tests.
-//! Phase 2 will plumb real sources / hydrators / filters and wire the
-//! pipeline into [`crate::agent::AgentLoop`] behind this feature flag.
+//! Note: this module is currently *additive*. The pipeline is not wired
+//! into [`crate::agent::AgentLoop`] yet — that change ships in a separate
+//! commit so reviewers can vet the abstraction in isolation.
 //!
 //! [1]: https://github.com/xai-org/x-algorithm
 
@@ -27,7 +27,7 @@ pub mod sources;
 pub mod weights;
 
 pub use filters::{SafetyFilter, ValidationFilter};
-pub use hydrators::{PlatformFitHydrator, SafetyHydrator};
+pub use hydrators::{PlatformFitHydrator, SafetyHydrator, ValidationHydrator};
 pub use scorer::{LinearScorer, Scorer};
 pub use selector::{ArgmaxSelector, Selector};
 pub use sources::BackendSource;
@@ -57,8 +57,14 @@ pub struct CandidateFeatures {
     pub knowledge_similarity: Option<f32>,
     /// Wall-clock time the source took to produce this candidate.
     pub latency_ms: u64,
-    /// Whether the structural / syntactic validator passed.
+    /// Whether the structural / syntactic validator passed. `false` is the
+    /// safe default — [`ValidationFilter`] rejects unhydrated candidates the
+    /// same way [`SafetyFilter`] does, so a misconfigured pipeline fails
+    /// loudly instead of silently passing everything.
     pub validation_passed: bool,
+    /// Error message from the structural validator, when it rejected.
+    /// Populated by [`ValidationHydrator`]; read by [`ValidationFilter`].
+    pub validation_error: Option<String>,
 }
 
 /// A single candidate command produced by a source.

--- a/src/agent/pipeline/scorer.rs
+++ b/src/agent/pipeline/scorer.rs
@@ -1,0 +1,137 @@
+//! Candidate scorer.
+//!
+//! Phase 1 ships a [`LinearScorer`] that combines the hydrated features
+//! into a single `[0.0, 1.0]` score using the weights in
+//! [`super::weights::ScorerWeights`]. Phase 4 will add a `LearnedScorer`
+//! implementing the same [`Scorer`] trait so callers don't change.
+
+use super::weights::ScorerWeights;
+use super::Candidate;
+
+/// Combine a candidate's features into a single ranking score.
+pub trait Scorer: Send + Sync {
+    fn score(&self, candidate: &Candidate) -> f32;
+}
+
+/// Latency budget the scorer normalizes against. Anything below this gets
+/// `latency_score = 1.0`; anything above gets a linear penalty down to 0.
+/// 1500 ms matches the current p95 of the embedded backend on M-series.
+const LATENCY_BUDGET_MS: f32 = 1500.0;
+
+/// Linear-combination scorer. Hand-tuned weights for Phase 2; swappable
+/// with a learned scorer in Phase 4.
+#[derive(Debug, Clone, Default)]
+pub struct LinearScorer {
+    pub weights: ScorerWeights,
+}
+
+impl LinearScorer {
+    pub fn with_weights(weights: ScorerWeights) -> Self {
+        Self { weights }
+    }
+
+    fn latency_score(latency_ms: u64) -> f32 {
+        let ratio = (latency_ms as f32) / LATENCY_BUDGET_MS;
+        (1.0 - ratio).clamp(0.0, 1.0)
+    }
+}
+
+impl Scorer for LinearScorer {
+    fn score(&self, c: &Candidate) -> f32 {
+        let f = &c.features;
+        let knowledge = f.knowledge_similarity.unwrap_or(0.0);
+        let latency = Self::latency_score(f.latency_ms);
+        let raw = self.weights.llm_confidence * f.llm_confidence
+            + self.weights.safety_confidence * f.safety_confidence
+            + self.weights.platform_fit * f.platform_fit
+            + self.weights.knowledge_similarity * knowledge
+            + self.weights.latency * latency;
+        raw.clamp(0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CandidateFeatures;
+    use super::*;
+
+    fn cand(features: CandidateFeatures) -> Candidate {
+        Candidate {
+            command: "x".into(),
+            source: "test".into(),
+            features,
+            score: None,
+            rejection_reason: None,
+        }
+    }
+
+    #[test]
+    fn perfect_signals_score_one() {
+        let s = LinearScorer::default();
+        let c = cand(CandidateFeatures {
+            llm_confidence: 1.0,
+            safety_confidence: 1.0,
+            platform_fit: 1.0,
+            knowledge_similarity: Some(1.0),
+            latency_ms: 0,
+            validation_passed: true,
+        });
+        assert!((s.score(&c) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn zero_signals_score_zero() {
+        let s = LinearScorer::default();
+        let c = cand(CandidateFeatures::default());
+        // latency_ms=0 gives latency_score=1.0, multiplied by weight=0.05
+        assert!((s.score(&c) - 0.05).abs() < 1e-5);
+    }
+
+    #[test]
+    fn safety_dominates_over_knowledge() {
+        // High safety + zero knowledge should beat zero safety + high knowledge,
+        // because safety has weight 0.25 vs knowledge 0.15.
+        let s = LinearScorer::default();
+        let safe = cand(CandidateFeatures {
+            safety_confidence: 1.0,
+            ..Default::default()
+        });
+        let known = cand(CandidateFeatures {
+            knowledge_similarity: Some(1.0),
+            ..Default::default()
+        });
+        assert!(s.score(&safe) > s.score(&known));
+    }
+
+    #[test]
+    fn latency_penalty_kicks_in_above_budget() {
+        let s = LinearScorer::default();
+        let fast = cand(CandidateFeatures {
+            llm_confidence: 0.8,
+            latency_ms: 100,
+            ..Default::default()
+        });
+        let slow = cand(CandidateFeatures {
+            llm_confidence: 0.8,
+            latency_ms: 5_000, // well above budget
+            ..Default::default()
+        });
+        assert!(s.score(&fast) > s.score(&slow));
+    }
+
+    #[test]
+    fn missing_knowledge_treated_as_zero() {
+        let s = LinearScorer::default();
+        let c1 = cand(CandidateFeatures {
+            llm_confidence: 0.5,
+            knowledge_similarity: None,
+            ..Default::default()
+        });
+        let c2 = cand(CandidateFeatures {
+            llm_confidence: 0.5,
+            knowledge_similarity: Some(0.0),
+            ..Default::default()
+        });
+        assert!((s.score(&c1) - s.score(&c2)).abs() < 1e-6);
+    }
+}

--- a/src/agent/pipeline/scorer.rs
+++ b/src/agent/pipeline/scorer.rs
@@ -75,6 +75,7 @@ mod tests {
             knowledge_similarity: Some(1.0),
             latency_ms: 0,
             validation_passed: true,
+            ..Default::default()
         });
         assert!((s.score(&c) - 1.0).abs() < 1e-5);
     }

--- a/src/agent/pipeline/selector.rs
+++ b/src/agent/pipeline/selector.rs
@@ -1,0 +1,83 @@
+//! Candidate selector — picks the winner from a scored set.
+//!
+//! Phase 1 ships a single [`ArgmaxSelector`]. Phase 4 may add an
+//! `EpsilonGreedySelector` for online exploration once telemetry is rich
+//! enough to support it.
+
+use super::Candidate;
+
+pub trait Selector: Send + Sync {
+    /// Return the best non-rejected candidate, or `None` if none qualify.
+    fn select<'a>(&self, candidates: &'a [Candidate]) -> Option<&'a Candidate>;
+}
+
+/// Picks the candidate with the highest `score`. Stable tiebreak: keep the
+/// first one seen, matching `Vec` insertion order from the pipeline run.
+#[derive(Debug, Clone, Default)]
+pub struct ArgmaxSelector;
+
+impl Selector for ArgmaxSelector {
+    fn select<'a>(&self, candidates: &'a [Candidate]) -> Option<&'a Candidate> {
+        // Manual loop with strict `>` so equal scores keep the first-seen
+        // candidate — `Iterator::max_by` would return the last on ties.
+        let mut best: Option<&'a Candidate> = None;
+        let mut best_score = f32::NEG_INFINITY;
+        for c in candidates.iter().filter(|c| !c.is_rejected()) {
+            let s = c.score.unwrap_or(f32::NEG_INFINITY);
+            if s > best_score {
+                best_score = s;
+                best = Some(c);
+            }
+        }
+        best
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CandidateFeatures;
+    use super::*;
+
+    fn scored(cmd: &str, score: f32) -> Candidate {
+        Candidate {
+            command: cmd.into(),
+            source: "t".into(),
+            features: CandidateFeatures::default(),
+            score: Some(score),
+            rejection_reason: None,
+        }
+    }
+
+    #[test]
+    fn picks_highest_score() {
+        let cs = vec![scored("a", 0.1), scored("b", 0.9), scored("c", 0.5)];
+        let s = ArgmaxSelector;
+        assert_eq!(s.select(&cs).unwrap().command, "b");
+    }
+
+    #[test]
+    fn skips_rejected_even_if_scored_higher() {
+        let mut rejected = scored("a", 0.99);
+        rejected.rejection_reason = Some("unsafe".into());
+        let cs = vec![rejected, scored("b", 0.2)];
+        let s = ArgmaxSelector;
+        assert_eq!(s.select(&cs).unwrap().command, "b");
+    }
+
+    #[test]
+    fn returns_none_when_all_rejected() {
+        let mut a = scored("a", 0.99);
+        a.rejection_reason = Some("x".into());
+        let mut b = scored("b", 0.2);
+        b.rejection_reason = Some("y".into());
+        let s = ArgmaxSelector;
+        assert!(s.select(&[a, b]).is_none());
+    }
+
+    #[test]
+    fn stable_tiebreak_keeps_first() {
+        let cs = vec![scored("a", 0.5), scored("b", 0.5), scored("c", 0.5)];
+        let s = ArgmaxSelector;
+        assert_eq!(s.select(&cs).unwrap().command, "a");
+    }
+}

--- a/src/agent/pipeline/sources.rs
+++ b/src/agent/pipeline/sources.rs
@@ -1,0 +1,171 @@
+//! Candidate sources — adapters that produce a [`Candidate`] from existing
+//! caro primitives.
+//!
+//! Phase 2 wires `BackendSource` around any [`crate::backends::CommandGenerator`]
+//! impl (static matcher, embedded backend, ollama, vllm, openrouter). The
+//! generated command's `confidence_score` flows into `llm_confidence`, and
+//! `generation_time_ms` into `latency_ms`, so the scorer has real signal
+//! before any hydrator runs.
+//!
+//! A `KnowledgeRetrievalSource` (turning a top-1 k-NN hit into a candidate)
+//! will land in a follow-up commit once we finalize how to fetch the
+//! knowledge index handle from the [`crate::agent::AgentLoop`].
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use super::{Candidate, CandidateSource, PipelineError};
+use crate::backends::CommandGenerator;
+use crate::models::{CommandRequest, ShellType};
+
+/// Adapter that turns any [`CommandGenerator`] into a [`CandidateSource`].
+///
+/// `temperature` is stored purely as a label for `source` (e.g.
+/// `"embedded@T=0.4"`) — the actual sampling temperature is set on the
+/// underlying backend before it's wrapped. Phase 2 keeps that wiring at the
+/// call site; a temperature override per-call would require a breaking
+/// change to the `CommandGenerator` trait.
+pub struct BackendSource {
+    backend: Arc<dyn CommandGenerator>,
+    label: String,
+    shell: ShellType,
+}
+
+impl BackendSource {
+    pub fn new(backend: Arc<dyn CommandGenerator>, label: impl Into<String>) -> Self {
+        Self {
+            backend,
+            label: label.into(),
+            shell: ShellType::Bash,
+        }
+    }
+
+    pub fn with_shell(mut self, shell: ShellType) -> Self {
+        self.shell = shell;
+        self
+    }
+}
+
+#[async_trait]
+impl CandidateSource for BackendSource {
+    async fn produce(&self, prompt: &str) -> Result<Candidate, PipelineError> {
+        let request = CommandRequest::new(prompt, self.shell);
+        let generated =
+            self.backend
+                .generate_command(&request)
+                .await
+                .map_err(|e| PipelineError::SourceFailed {
+                    name: self.label.clone(),
+                    message: e.to_string(),
+                })?;
+
+        let mut candidate = Candidate::new(generated.command, self.label.clone());
+        candidate.features.llm_confidence = generated.confidence_score as f32;
+        candidate.features.latency_ms = generated.generation_time_ms;
+        Ok(candidate)
+    }
+
+    fn name(&self) -> &str {
+        &self.label
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::{BackendInfo, GeneratorError};
+    use crate::models::{BackendType, GeneratedCommand, RiskLevel};
+
+    struct FakeBackend {
+        confidence: f64,
+        latency_ms: u64,
+        cmd: String,
+    }
+
+    #[async_trait]
+    impl CommandGenerator for FakeBackend {
+        async fn generate_command(
+            &self,
+            _r: &CommandRequest,
+        ) -> Result<GeneratedCommand, GeneratorError> {
+            Ok(GeneratedCommand {
+                command: self.cmd.clone(),
+                explanation: "test".into(),
+                safety_level: RiskLevel::Safe,
+                estimated_impact: "none".into(),
+                alternatives: vec![],
+                backend_used: "fake".into(),
+                generation_time_ms: self.latency_ms,
+                confidence_score: self.confidence,
+            })
+        }
+        async fn is_available(&self) -> bool {
+            true
+        }
+        fn backend_info(&self) -> BackendInfo {
+            BackendInfo {
+                backend_type: BackendType::Embedded,
+                model_name: "fake".into(),
+                supports_streaming: false,
+                max_tokens: 0,
+                typical_latency_ms: 0,
+                memory_usage_mb: 0,
+                version: "0".into(),
+            }
+        }
+        async fn shutdown(&self) -> Result<(), GeneratorError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn backend_source_propagates_confidence_and_latency() {
+        let backend = Arc::new(FakeBackend {
+            confidence: 0.73,
+            latency_ms: 250,
+            cmd: "ls -la".into(),
+        });
+        let source = BackendSource::new(backend, "test-backend");
+        let c = source.produce("list files").await.unwrap();
+        assert_eq!(c.command, "ls -la");
+        assert_eq!(c.source, "test-backend");
+        assert!((c.features.llm_confidence - 0.73).abs() < 1e-5);
+        assert_eq!(c.features.latency_ms, 250);
+    }
+
+    #[tokio::test]
+    async fn backend_source_maps_errors() {
+        struct BrokenBackend;
+        #[async_trait]
+        impl CommandGenerator for BrokenBackend {
+            async fn generate_command(
+                &self,
+                _r: &CommandRequest,
+            ) -> Result<GeneratedCommand, GeneratorError> {
+                Err(GeneratorError::BackendUnavailable {
+                    reason: "down".into(),
+                })
+            }
+            async fn is_available(&self) -> bool {
+                false
+            }
+            fn backend_info(&self) -> BackendInfo {
+                BackendInfo {
+                    backend_type: BackendType::Embedded,
+                    model_name: "broken".into(),
+                    supports_streaming: false,
+                    max_tokens: 0,
+                    typical_latency_ms: 0,
+                    memory_usage_mb: 0,
+                    version: "0".into(),
+                }
+            }
+            async fn shutdown(&self) -> Result<(), GeneratorError> {
+                Ok(())
+            }
+        }
+        let source = BackendSource::new(Arc::new(BrokenBackend), "broken");
+        let err = source.produce("anything").await.unwrap_err();
+        assert!(matches!(err, PipelineError::SourceFailed { .. }));
+    }
+}

--- a/src/agent/pipeline/weights.rs
+++ b/src/agent/pipeline/weights.rs
@@ -1,0 +1,50 @@
+//! Hand-tuned weights for [`super::LinearScorer`].
+//!
+//! Phase 2 will load these from `~/.config/caro/scorer.toml`; Phase 4 will
+//! replace the linear combination with a learned two-tower scorer that
+//! implements the same [`super::Scorer`] trait. Keeping the weights in one
+//! `const` block makes that swap a one-file change.
+
+/// Default weights. Must sum to 1.0 (asserted in unit tests).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScorerWeights {
+    pub llm_confidence: f32,
+    pub safety_confidence: f32,
+    pub platform_fit: f32,
+    pub knowledge_similarity: f32,
+    pub latency: f32,
+}
+
+impl Default for ScorerWeights {
+    fn default() -> Self {
+        Self {
+            llm_confidence: 0.35,
+            safety_confidence: 0.25,
+            platform_fit: 0.20,
+            knowledge_similarity: 0.15,
+            latency: 0.05,
+        }
+    }
+}
+
+impl ScorerWeights {
+    pub fn sum(&self) -> f32 {
+        self.llm_confidence
+            + self.safety_confidence
+            + self.platform_fit
+            + self.knowledge_similarity
+            + self.latency
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_weights_sum_to_one() {
+        let w = ScorerWeights::default();
+        let s = w.sum();
+        assert!((s - 1.0).abs() < 1e-6, "weights must sum to 1.0, got {}", s);
+    }
+}

--- a/tests/cve_enforcement.rs
+++ b/tests/cve_enforcement.rs
@@ -6,7 +6,9 @@
 //! other code touch.
 
 use caro::models::{RiskLevel, SafetyLevel, ShellType};
-use caro::safety::{SafetyConfig, SafetyValidator, CVE_COMPILED};
+use caro::safety::{SafetyConfig, SafetyValidator};
+#[cfg(feature = "cve-rules")]
+use caro::safety::CVE_COMPILED;
 
 /// The canonical xz-utils backdoor trigger — the pattern that motivated
 /// this whole pipeline. Covered by `data/cve_rules/CVE-2024-3094.yaml`.


### PR DESCRIPTION
## Summary

Introduces a multi-stage candidate pipeline borrowed from [`xai-org/x-algorithm`](https://github.com/xai-org/x-algorithm) (X's "For You" feed) behind a new `candidate-ranking` Cargo feature (default off). Maps the `sources → hydrators → filters → scorer → selector` pattern onto caro's existing primitives — backends, safety validator, knowledge index, command validator — without re-inventing any of them.

**Scope:** scaffolding + concrete adapters + ValidationFilter rework from review. The pipeline is NOT yet wired into `AgentLoop` — that ships in a follow-up so reviewers can vet the abstraction in isolation.

## Commits in this PR

| Commit | Purpose |
|---|---|
| `027f42f` | **Scaffolding** — `Pipeline` orchestrator, traits, `LinearScorer`, `ArgmaxSelector`, weights, 13 unit tests |
| `8cefa2c` | **Adapters** — `BackendSource`, `PlatformFitHydrator`, `SafetyHydrator`, `SafetyFilter`, `ValidationFilter` (+12 tests) — `Hydrator`/`Filter` become async to support the safety hydrator's async validation call |
| `3bb3de5` | **Review fixes** — extracted `ValidationHydrator` so `validation_passed` is actually stamped (was a doc-vs-impl lie), added 3 missing `ValidationFilter` tests, removed leaked Claude-container path from `Cargo.toml`/`src/agent/mod.rs`, tightened module docstring |

## What's in this PR

| File | Purpose |
|---|---|
| `Cargo.toml` | New `candidate-ranking` feature, default off |
| `src/agent/pipeline/mod.rs` | `Candidate`, `CandidateFeatures`, traits, `Pipeline` orchestrator, integration tests |
| `src/agent/pipeline/scorer.rs` | `Scorer` trait + `LinearScorer` (5 tests) |
| `src/agent/pipeline/selector.rs` | `Selector` trait + `ArgmaxSelector` with stable first-wins tiebreak (4 tests) |
| `src/agent/pipeline/weights.rs` | `ScorerWeights` with hand-tuned defaults that sum to 1.0 (1 test) |
| `src/agent/pipeline/sources.rs` | `BackendSource` adapter for any `CommandGenerator` (2 tests) |
| `src/agent/pipeline/hydrators.rs` | `PlatformFitHydrator`, `SafetyHydrator`, `ValidationHydrator` (6 tests) |
| `src/agent/pipeline/filters.rs` | `SafetyFilter`, `ValidationFilter` (7 tests) |
| `src/agent/mod.rs` | `#[cfg]`-gated `pub mod pipeline;` declaration only |
| `tests/cve_enforcement.rs` | Good-boy-scout: cfg-gate `CVE_COMPILED` import so `clippy --tests` is clean without the `cve-rules` feature |

### Default weights

```
score = 0.35*llm_confidence
      + 0.25*safety_confidence
      + 0.20*platform_fit
      + 0.15*knowledge_similarity
      + 0.05*latency  (normalized against a 1500 ms budget)
```

A future learned two-tower scorer will swap in here implementing the same `Scorer` trait — keeping the weights in one `const` block makes that swap a one-file change.

### Hydrator ↔ Filter split

Filters never mutate; hydrators do. Each filter has a paired hydrator that does the work once and writes a feature the filter reads cheaply. Both `SafetyFilter` and `ValidationFilter` fail-closed on unhydrated candidates — misconfigured pipelines fail loudly, not silently.

## Why this matters

Caro today is **first-match-wins, single-shot**: the static matcher runs, then on miss the LLM is called once; refinement re-edits the same line instead of comparing alternatives. Every building block for a multi-stage ranker (multiple backends as candidate sources, safety confidence, knowledge-index k-NN similarity, command validator) already exists — the gap is **composition**. This PR introduces that composition layer without changing any existing code path.

## Test plan

- [x] `cargo check --no-default-features --features embedded-cpu` — clean
- [x] `cargo check --no-default-features --features embedded-cpu,candidate-ranking` — clean
- [x] Full lib suite with feature **off**: **532 passed / 0 failed** (no regression)
- [x] Pipeline tests with feature **on**: **28 passed / 0 failed**
- [x] `cve_enforcement` tests with `cve-rules` on: **4 passed / 0 failed**
- [x] `cargo clippy --features candidate-ranking --lib --tests -- -D warnings` — clean

## Follow-up PRs (not in this one)

- **Wire pipeline into `AgentLoop`** — `default_pipeline()` factory; cfg-gated branch in `generate_command_impl`; **must forward context** (DirectoryContext, system prompt, knowledge text) that current `BackendSource` drops, otherwise flipping the feature on regresses generation quality
- **Parallelize source execution** — current `Pipeline::run` is sequential; needs `FuturesUnordered` + shared latency budget (60% of timeout) before multi-candidate is competitive
- **Knowledge-retrieval source** — turn `KnowledgeIndex::find_similar` top-1 into a candidate; cfg-gated behind both `knowledge` and `candidate-ranking`
- **Ranking-quality eval metrics** — MRR, NDCG@5, top-k for k∈{1,3,5} in `src/evaluation/harness.rs`; regression gate before flipping default
- **Learned two-tower scorer** — trained from telemetry + knowledge corpus, distilled to ONNX, drop-in `LearnedScorer` implementing the same `Scorer` trait

## Mapping (x-algorithm ↔ caro)

| x-algorithm stage | Caro mapping | Existing code (reused, not re-invented) |
|---|---|---|
| Candidate sources | `BackendSource` wraps any `CommandGenerator` | `src/backends/mod.rs::CommandGenerator`, `src/backends/static_matcher.rs` |
| Hydrators | Platform fit + safety + validation | `src/agent/mod.rs::should_refine`, `src/safety/mod.rs::SafetyValidator`, `src/prompts/validation.rs::CommandValidator` |
| Filters | Safety + validation gating (reads hydrated features) | NEW (reads features set by hydrators) |
| Scorer | Multi-signal linear combination | NEW: `src/agent/pipeline/scorer.rs` |
| Selector | Argmax with stable first-wins tiebreak | NEW: `src/agent/pipeline/selector.rs` |

## Open caveats called out in the self-review

- `Pipeline::run` currently executes sources sequentially — parallel execution + latency budget is a deliberate follow-up
- `BackendSource` doesn't forward the rich context (directory, system prompt) that `AgentLoop::generate_initial` assembles — must be addressed before wiring
- `SafetyFilter` only drops `Critical`; the caller is responsible for routing `High` / `Moderate` to human approval (existing `SafetyDecision` flow handles this once wired)
- `LATENCY_BUDGET_MS` is hardcoded; will move to `ScorerWeights` when the eval harness needs to sweep it

🤖 Generated with [Claude Code](https://claude.com/claude-code)