### PR TITLE
experiment(prompts): minimal system-prompt A/B eval — regression, not shipping as default

### DIFF
--- a/src/backends/embedded/embedded_backend.rs
+++ b/src/backends/embedded/embedded_backend.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use crate::backends::embedded::{CpuBackend, EmbeddedConfig, InferenceBackend, ModelVariant};
 use crate::backends::{BackendInfo, CommandGenerator, GeneratorError};
 use crate::models::{BackendType, CommandRequest, GeneratedCommand};
+use crate::prompts::{build_minimal_prompt, PromptStyle};
 use crate::safety::{SafetyConfig, SafetyValidator};
 use crate::ModelLoader;
 
@@ -32,6 +33,8 @@ pub struct EmbeddedModelBackend {
     config: EmbeddedConfig,
     model_loader: ModelLoader,
     safety_validator: Arc<SafetyValidator>,
+    /// Which system-prompt variant to use (default vs minimal).
+    prompt_style: PromptStyle,
 }
 
 impl EmbeddedModelBackend {
@@ -93,12 +96,23 @@ impl EmbeddedModelBackend {
             config: EmbeddedConfig::default(),
             model_loader,
             safety_validator,
+            prompt_style: PromptStyle::Default,
         })
     }
 
     /// Update the embedded configuration
     pub fn with_config(mut self, config: EmbeddedConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Select the system-prompt variant to use.
+    ///
+    /// `PromptStyle::Default` uses the full production prompt.
+    /// `PromptStyle::Minimal` uses the llm-cmd-style terse variant.
+    /// Primarily used by `caro test --prompt-style minimal` for A/B evaluation.
+    pub fn with_prompt_style(mut self, style: PromptStyle) -> Self {
+        self.prompt_style = style;
         self
     }
 
@@ -163,8 +177,14 @@ impl EmbeddedModelBackend {
             })
     }
 
-    /// Generate system prompt for shell command generation
+    /// Generate system prompt for shell command generation.
+    ///
+    /// Dispatches to the minimal variant when `self.prompt_style == PromptStyle::Minimal`.
     fn create_system_prompt(&self, request: &CommandRequest) -> String {
+        if self.prompt_style == PromptStyle::Minimal {
+            return build_minimal_prompt(request);
+        }
+
         let base_prompt = format!(
             r#"You are a shell command generator. Convert natural language to POSIX shell commands.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,6 +449,11 @@ enum Commands {
         /// Filter tests by profile ID (e.g., bt_001)
         #[arg(long)]
         profile: Option<String>,
+
+        /// System-prompt variant for embedded backend: "default" (full) or "minimal"
+        /// (llm-cmd-style terse prompt). Has no effect on the static backend.
+        #[arg(long, default_value = "default")]
+        prompt_style: String,
     },
 
     /// Generate shell completion scripts
@@ -2854,8 +2859,15 @@ async fn run_evaluation_tests(
     _verbose: bool,
     suite_path: Option<&str>,
     profile_id: Option<&str>,
+    prompt_style_str: &str,
 ) -> Result<(), String> {
+    use caro::prompts::PromptStyle;
+    let prompt_style: PromptStyle = prompt_style_str.parse().map_err(|e: String| e)?;
+
     println!("Running evaluation tests with backend: {}", backend_name);
+    if backend_name == "embedded" {
+        println!("Prompt style: {}", prompt_style);
+    }
     println!();
 
     // Create backend (boxed to allow different types)
@@ -2866,7 +2878,8 @@ async fn run_evaluation_tests(
         }
         "embedded" => Box::new(
             EmbeddedModelBackend::new()
-                .map_err(|e| format!("Failed to create embedded backend: {}", e))?,
+                .map_err(|e| format!("Failed to create embedded backend: {}", e))?
+                .with_prompt_style(prompt_style),
         ),
         _ => {
             return Err(format!(
@@ -3056,9 +3069,16 @@ async fn main() {
             verbose,
             suite,
             profile,
+            prompt_style,
         }) => {
-            match run_evaluation_tests(&backend, verbose, suite.as_deref(), profile.as_deref())
-                .await
+            match run_evaluation_tests(
+                &backend,
+                verbose,
+                suite.as_deref(),
+                profile.as_deref(),
+                &prompt_style,
+            )
+            .await
             {
                 Ok(()) => process::exit(0),
                 Err(e) => {

--- a/src/prompts/minimal.rs
+++ b/src/prompts/minimal.rs
@@ -1,0 +1,135 @@
+//! Minimal system prompt variant for the embedded backend.
+//!
+//! Modeled on Simon Willison's llm-cmd prompt design:
+//! one short instruction + one input/output example pair + a shell-specific line.
+//!
+//! Hypothesis: small models (≤3B parameters) may follow a terse prompt more
+//! reliably than a long one because they have a harder time attending to all
+//! instructions in a long context window.
+//!
+//! # Status: evaluated, NOT recommended as default (kept as opt-in experiment)
+//!
+//! Evaluated 2026-05-16 against `data/evals/default.yaml` (11 cases) using
+//! Qwen2.5-Coder-1.5B-Instruct (Q4_K_M, locally cached). Strict exact-string
+//! matcher.
+//!
+//! # Eval Results
+//!
+//! | Variant | Pass rate     | Wall-clock | Notes |
+//! |---------|---------------|------------|-------|
+//! | default | 5/11 = 45.5%  | 60.0s      | Production prompt |
+//! | minimal | 2/11 = 18.2%  | 33.9s      | This variant |
+//!
+//! Delta: **-27.3 pp** accuracy, **+43% faster**.
+//!
+//! Failure modes (minimal):
+//! 1. Semantic — model picks `git log --since='yesterday'` instead of `find`
+//!    for "files modified today/yesterday" (loses non-git-tracked files).
+//! 2. Refusal — model returns `echo 'Unable to generate command'`.
+//! 3. Strict-matcher friction — semantically-correct outputs like
+//!    `find . -name '*.py' -mtime -7` fail because expected has `-type f`
+//!    and double-quoted glob. These would pass a fuzzy matcher.
+//!
+//! # Decision
+//!
+//! **Discarded as default.** The accuracy regression (27 pp) far exceeds
+//! the 5 pp threshold set in the plan rubric, and the latency win is
+//! consumed by retry/rework cost when commands are wrong.
+//!
+//! **Kept as opt-in** via `--prompt-style minimal` for two reasons:
+//!   1. Documents the experiment so the same hypothesis isn't re-run blindly.
+//!   2. Useful as a baseline when iterating on prompt engineering — future
+//!      experiments can A/B against this minimal variant.
+//!
+//! Plausible follow-ups (out of scope here):
+//!   - Re-run against a 3B+ model (hypothesis was about ≤3B; 1.5B is below).
+//!   - Re-run with a fuzzy/semantic eval matcher to disentangle (1) and (3).
+//!   - Test prompt variants between full and minimal (e.g., drop only the
+//!     Docker/K8s tables, keep the BSD-compat + mtime rules).
+//!
+//! Plan: `~/.claude/plans/any-novel-ideas-we-floofy-rainbow.md` — Idea #3.
+
+use crate::models::CommandRequest;
+
+/// Build the minimal system prompt for shell command generation.
+///
+/// This is the llm-cmd-style variant: one line of instruction, one
+/// example, one platform note. No Docker/K8s/mtime tables, no
+/// numbered rule lists.
+pub fn build_minimal_prompt(request: &CommandRequest) -> String {
+    let shell = &request.shell;
+
+    // Base minimal prompt — mirrors llm-cmd's philosophy: "no yapping"
+    let base = format!(
+        r#"Return only the shell command to run. No explanation, no markdown, no fenced code blocks. Respond with ONLY valid JSON: {{"cmd": "your_command_here"}}
+
+Shell: {shell}. Use BSD-compatible flags (macOS). Use "." as the starting path, not "/".
+
+Example:
+User: undo last git commit
+Assistant: {{"cmd": "git reset --soft HEAD~1"}}
+
+Request: {input}"#,
+        shell = shell,
+        input = request.input,
+    );
+
+    // Append any extra context the caller provided
+    if let Some(context) = &request.context {
+        format!("{}\n\n{}", base, context)
+    } else {
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ShellType;
+
+    #[test]
+    fn test_minimal_prompt_contains_input() {
+        let request = CommandRequest::new("list files modified today", ShellType::Bash);
+        let prompt = build_minimal_prompt(&request);
+        assert!(prompt.contains("list files modified today"));
+    }
+
+    #[test]
+    fn test_minimal_prompt_contains_shell() {
+        let request = CommandRequest::new("list files", ShellType::Zsh);
+        let prompt = build_minimal_prompt(&request);
+        assert!(prompt.contains("zsh"));
+    }
+
+    #[test]
+    fn test_minimal_prompt_no_yapping_keywords() {
+        let request = CommandRequest::new("list files", ShellType::Bash);
+        let prompt = build_minimal_prompt(&request);
+        // Should not contain verbose rule lists
+        assert!(!prompt.contains("CRITICAL RULES"));
+        assert!(!prompt.contains("KUBERNETES"));
+        assert!(!prompt.contains("DOCKER COMMANDS"));
+    }
+
+    #[test]
+    fn test_minimal_prompt_includes_json_format() {
+        let request = CommandRequest::new("list files", ShellType::Bash);
+        let prompt = build_minimal_prompt(&request);
+        assert!(prompt.contains(r#"{"cmd": "your_command_here"}"#));
+    }
+
+    #[test]
+    fn test_minimal_prompt_with_context() {
+        let request =
+            CommandRequest::new("list files", ShellType::Bash).with_context("cwd: /tmp");
+        let prompt = build_minimal_prompt(&request);
+        assert!(prompt.contains("cwd: /tmp"));
+    }
+
+    #[test]
+    fn test_minimal_prompt_bsd_note() {
+        let request = CommandRequest::new("list files", ShellType::Bash);
+        let prompt = build_minimal_prompt(&request);
+        assert!(prompt.contains("BSD"));
+    }
+}

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -83,9 +83,48 @@
 pub mod capability_profile;
 pub mod command_templates;
 pub mod explainer_prompt;
+pub mod minimal;
 pub mod profiles;
 pub mod smollm_prompt;
 pub mod validation;
+
+/// Selects which system-prompt variant the embedded backend uses.
+///
+/// `Default` is the production prompt with detailed rules and examples.
+/// `Minimal` is the llm-cmd-style terse variant (one instruction + one example).
+/// Use `--prompt-style minimal` on `caro test` to A/B evaluate the two variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PromptStyle {
+    /// Full-featured prompt with numbered rules, Docker/K8s tables, mtime semantics.
+    #[default]
+    Default,
+    /// Minimal llm-cmd-style prompt: one instruction + one example pair.
+    Minimal,
+}
+
+impl std::str::FromStr for PromptStyle {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "default" | "standard" | "full" => Ok(Self::Default),
+            "minimal" | "min" | "terse" => Ok(Self::Minimal),
+            _ => Err(format!(
+                "Unknown prompt style '{}'. Valid values: default, minimal",
+                s
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for PromptStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => write!(f, "default"),
+            Self::Minimal => write!(f, "minimal"),
+        }
+    }
+}
 
 // Re-export main types for convenient access
 pub use capability_profile::{AwkType, CapabilityProfile, DetectedShell, ProfileType, StatFormat};
@@ -95,6 +134,7 @@ pub use profiles::{
     AlternativeCommand, CommandExplanation, GenerationProfile, OptionExplanation, ProfileConfig,
     UsageExample,
 };
+pub use minimal::build_minimal_prompt;
 pub use smollm_prompt::{CommandOutput, PromptResponse, RepairPromptBuilder, SmolLMPromptBuilder};
 pub use validation::{
     CommandValidator, RiskLevel, ValidationError, ValidationErrorCode, ValidationResult,


### PR DESCRIPTION
## Summary

Implements **Idea #3** from the [llm-cmd inspiration plan](https://github.com/wildcard/caro/pull/1109): an A/B test of caro's current production system prompt against an [llm-cmd](https://github.com/simonw/llm-cmd)-style terse variant for the embedded backend.

**TL;DR: hypothesis not supported. Minimal regresses by 27 pp.** Ship as opt-in experiment to document the finding and enable future iteration. **Not** shipping as default.

## Empirical results

Suite: `data/evals/default.yaml` (11 cases — website claims, natural variants, edge cases)
Model: Qwen2.5-Coder-1.5B-Instruct (Q4_K_M, locally cached)
Matcher: strict exact-string

| Variant | Pass rate | Wall-clock |
|---|---|---|
| default | 5/11 = **45.5%** | 60.0s |
| minimal | 2/11 = **18.2%** | 33.9s |

**Delta: -27.3 pp accuracy, +43% faster.**

Per the plan rubric (regression > 5 pp → don't ship), minimal is **not recommended as default**.

## Failure modes (minimal)

1. **Semantic** — model picks `git log --since='yesterday' --name-only` instead of `find` for "files modified today/yesterday" (loses non-git-tracked files).
2. **Refusal** — model returns `echo 'Unable to generate command'` instead of attempting.
3. **Strict-matcher friction** — semantically-correct outputs like `find . -name '*.py' -mtime -7` fail because expected has `-type f` and double-quoted glob. Would pass a fuzzy matcher.

(1) and (2) are real regressions. (3) is a measurement artifact — re-evaluating with a fuzzy matcher might shrink the gap, but it would have to shrink by 22 pp to clear the 5 pp threshold, which is implausible.

## Why ship the infrastructure anyway

The `PromptStyle` enum + `--prompt-style` flag + `minimal.rs` module are kept as **opt-in** rather than discarded:

1. **Documents the experiment** — the eval table is in the module doc-comment so future contributors don't repeat this exact test blindly.
2. **Baseline for future variants** — between full and minimal there's a wide design space (drop only the Docker/K8s tables, drop only mtime semantics, etc). The infrastructure makes each future variant a ~20-line addition + a one-row table update.
3. **Trivial maintenance cost** — `PromptStyle::Default` is the default everywhere; the minimal path is dead unless you opt in.

## Plausible follow-ups (out of scope)

- Re-run against a 3B+ model. The hypothesis was specifically about ≤3B; 1.5B is the small end, so this isn't a representative test.
- Re-run with a fuzzy / semantic eval matcher to disentangle failure types (1) and (3).
- Test intermediate prompt variants — drop only some sections of the production prompt.

## Test plan

- [x] `cargo build --bin caro` clean
- [x] `cargo test --lib prompts::minimal` — 6/6 green
- [x] `cargo clippy --bin caro --no-deps -- -D warnings` clean
- [x] `caro test --help` shows `--prompt-style <PROMPT_STYLE>` flag
- [x] `caro test --backend static` unaffected (static backend ignores prompt style) — 11/11 pass
- [x] `caro test --backend embedded --prompt-style default` — 5/11 (baseline above)
- [x] `caro test --backend embedded --prompt-style minimal` — 2/11 (variant above)

## Companion PR

This experiment was branched in parallel with [#1109](https://github.com/wildcard/caro/pull/1109) (editable rustyline prompt — the other idea borrowed from llm-cmd). Independent files, no merge conflict expected.

## Plan

Full ranked-ideas document: `/Users/kobik-private/.claude/plans/any-novel-ideas-we-floofy-rainbow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in minimal (llm-cmd-style) system prompt for the embedded backend and A/B evaluation via `--prompt-style`, leaving the default prompt unchanged. In evals, minimal regressed accuracy by 27.3 pp (45.5% → 18.2%) while 43% faster, so it is not shipped as default.

- New Features
  - `PromptStyle` enum and `EmbeddedModelBackend::with_prompt_style()` to select prompt variant.
  - `caro test --prompt-style <default|minimal>` (embedded only); prints selected style during runs.
  - Minimal prompt implemented in `src/prompts/minimal.rs` with docs and unit tests.
  - Default behavior unchanged; static backend ignores prompt style.

<sup>Written for commit 589fc4e8bda991d297812e0de6e1bb22b7c2d837. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

