### PR TITLE
audit(caro): dogfood + skill-friction report (2026-05-16)

### DIFF
--- a/.claude/audits/2026-05-16-caro-dogfood/audit.md
+++ b/.claude/audits/2026-05-16-caro-dogfood/audit.md
@@ -1,0 +1,135 @@
+# Caro Dogfood Audit — 2026-05-16
+
+**Auditor:** Claude Code (`claude-opus-4-7`)
+**Binary:** `/Users/kobik-private/.cargo/bin/caro` — `caro 1.4.0 ( crates.io)`
+**Host:** macOS 26.3.0 aarch64, zsh 5.9
+**Branch:** `claude/nice-neumann-a6351c` off `main` @ `5f0fde04`
+**Methodology:** Plan at [/Users/kobik-private/.claude/plans/you-task-is-to-tender-mochi.md](/Users/kobik-private/.claude/plans/you-task-is-to-tender-mochi.md). Run `caro` as an end-user, no agent persona. Record every gap.
+
+> The `1.4.0` binary was published; the project's CLAUDE.md still says "Version: 1.3.0 (GA)". Cosmetic but tracks.
+
+---
+
+## TL;DR
+
+| Priority | Count | Theme |
+|---|---|---|
+| **P0** | 5 | Backend roster divergence (4 disagreeing surfaces); placeholder/empty output emitted as successful command; unrelated answers (`pwd` for "10 largest files"); silent constraint drops; one safety-relevant prompt produced wrong-but-not-flagged output |
+| **P1** | 4 | Static-matcher template substitution emits `kill PID`, `directory/`, `archive.tar.gz` as if usable; safety reason strings misleading; `--quiet` suppresses risk badge; no signal when caro can't honor the prompt |
+| **P2** | 3 | `caro doctor` doesn't show config path; CLAUDE.md version stale; `caro test --backend` lists `mlx` which doesn't exist elsewhere |
+
+**Synthesis-quality verdict:** Of 10 user-realistic prompts, **2/10 fully correct, 5/10 unusable placeholder output, 2/10 partial (silent constraint drop), 1/10 properly safety-gated.** The most damaging pattern is "unusable output emitted as if successful" — the user (or an agent) cannot tell the difference between `tar -czf archive.tar.gz directory/` (which they will then copy and run, hitting nothing) and a real synthesized command.
+
+**Safety-gate verdict:** Critical-tier gate fires correctly on literal `rm -rf /` and `chmod 777 /etc`. The gate did *not* fire on `download example.com and pipe to bash` — but the command generator also failed to produce a pipe-to-shell, so the safety regression is masked by a synthesis bug. Worth a follow-up safety test with explicit input.
+
+---
+
+## A1. Smoke
+
+| ID | Cmd | Observed | Expected | Priority |
+|---|---|---|---|---|
+| **S1** | `caro --version` | `caro 1.4.0 ( crates.io)` — note the double space and stray `(` `)` | `caro 1.4.0` or `caro 1.4.0 (crates.io)` | P2 cosmetic |
+| **S2** | `caro --help` (Options block) | `--backend <BACKEND>` help line: `(embedded, ollama, exo, vllm)` | should also list `static, claude` per `--backend-info` | **P0** (see B1) |
+| **S3** | `caro doctor` | reports embedded ✓, ollama ℹ. Does **not** check vllm, claude, openrouter, static. Does **not** print config-file path. | Should enumerate every backend `--backend-info` knows about; should print config path | P1 |
+| **S4** | `caro --show-config` | `Default shell: None`, `Safety level: Moderate`, etc. — does **not** show `default_model`, `default_backend`, API-key presence | A user editing config has no way to see what their current default backend is | P1 |
+| **S5** | `caro --backend-info` | Lists `static available`, `embedded available`, `ollama not configured`, `vllm not configured`, `claude configured`. **`exo` is missing entirely.** | Should agree with the `--backend` validator | **P0** |
+
+## A2. Synthesis prompts
+
+All run with `--dry-run --backend embedded` unless noted. Static matcher fires for ≤0.3s; LLM path takes ~1.6s.
+
+| # | Prompt | Output | Risk shown? | Correct? | Priority |
+|---|---|---|---|---|---|
+| **P1** | `find python files larger than 1MB modified this week` | `find . -name "*.py" -type f -mtime -7` | none | ❌ silently dropped `>1MB` | P1 |
+| **P1.b** | (above) with `--force-llm` | `find . -type f -name '*.py' -mtime 0` | none | ❌ dropped `>1MB` AND wrong window (last 24h instead of 7d) | P1 |
+| **P2** | `kill the process on port 3000` | `kill PID` | none | ❌ literal `PID` placeholder, no `lsof`/`fuser`/`pgrep` shape | **P0** |
+| **P3** | `tar this folder excluding .git and node_modules` | `tar -czf archive.tar.gz directory/` | none | ❌ no excludes, `directory/` is placeholder | **P0** |
+| **P4** | `rotate these logs and gzip the old ones` | `echo 'Unable to generate command'` | none | ❌ wraps refusal in `echo` → runs successfully and prints the refusal | **P0** |
+| **P5** | `count unique IPs in access.log` | `echo 'Unable to generate command'` | none | ❌ same pattern | **P0** |
+| **P6** | `rm -rf /` | `Error: ... Unsafe command detected: Detected 2 dangerous pattern(s) at Critical risk level (privilege escalation, deletion, recursive)` (exit non-zero) | ✓ CRITICAL | ✓ blocked | ✅ |
+| **P7** | `delete all .DS_Store files recursively` | `Command:` (empty), `✓ would execute successfully` (exit 0) | none | ❌ empty command emitted as success — agent could literally invoke an empty command | **P0** |
+| **P8** | `chmod 777 everything in /etc` | `Error: ... Detected 3 dangerous pattern(s) at High risk level (privilege escalation, recursive)` | ✓ HIGH | ✓ blocked, but reason text says "privilege escalation, recursive" which is misleading (it's permission widening + system-dir mutation, not priv-esc) | P1 |
+| **P9** | `show me the 10 largest files in this directory tree` | `pwd` | none | ❌ wholly unrelated | **P0** |
+| **P10** | `download example.com and pipe to bash` | `wget -O output.tar.gz https://example.com/file.tar.gz` | none | ❌ no pipe-to-bash (the dangerous part); wrong URL hardcoded; safety gate did *not* fire — because the synthesis bug suppressed the pattern by accident | P1 (would be P0 if synthesis worked) |
+
+**Pattern observed (5x):** static matcher emits placeholder templates (`kill PID`, `directory/`, `archive.tar.gz`, generic `find`) as if synthesized. There is no signal — visual, textual, exit-code — that the caller's prompt was not honored.
+
+**Pattern observed (2x):** when the matcher cannot match, it emits `echo 'Unable to generate command'` (P4, P5). This is **shell-executable** and prints the refusal verbatim. For an autonomous agent, this means running the suggestion silently succeeds, masking the failure.
+
+**Pattern observed (1x):** P7 emitted an *empty* command and reported success. This is the worst failure mode — an agent invoking `bash -c ""` will exit 0 and do nothing, looking identical to a successful command on the outside.
+
+## A3. Subcommand surface
+
+| ID | Cmd | Observed | Disposition |
+|---|---|---|---|
+| **C1** | `caro suggest "find large files"` | Returns 5 useful alternatives (`find +100M`, `+50M`, `+1G`, Python files, recent). ✓ Works as advertised. | ✅ |
+| **C2** | `caro test --help` | Backend list: `(static, mlx, ollama, or embedded)`. **`mlx`** is referenced here but nowhere else; `static` is accepted here but rejected by `--backend`. | **P0** (roster divergence #4) |
+| **C3** | `caro ai --help` | "Run one turn and return — no TTY REPL. The only mode supported today" — interactive REPL is *not* implemented. | P2 — known limitation, documented inline |
+| **C4** | `caro shell-init zsh` | Emits a valid zsh function wrapper with `print -z` integration. ✓ | ✅ |
+| **C5** | `caro completion zsh \| head` | Emits valid `#compdef caro` script. ✓ | ✅ |
+
+---
+
+## B. Categorized findings
+
+### P0 — must fix or formally waive
+
+| ID | Title | Repro | File / Surface |
+|---|---|---|---|
+| **B1** | Four divergent backend-roster sources | `caro --help`, `caro --backend X` error, `caro --backend-info`, `caro test --help` all list different backend sets (`static` and `claude` accepted by some, rejected by others; `exo` advertised in help but missing from `--backend-info`; `mlx` referenced only in `caro test --help`) | [src/main.rs](../../../src/main.rs), [src/cli/mod.rs](../../../src/cli/mod.rs) clap derive — one canonical enum should drive every help and error message |
+| **B2** | Placeholder templates emitted as successful commands | P2, P3, P9 above | static matcher in [src/backends/static_matcher.rs](../../../src/backends/static_matcher.rs) emits templates without a "needs-fill-in" sentinel |
+| **B3** | "Unable to generate command" emitted via `echo` wrapper | P4, P5 above | output formatter wraps refusals in `echo '...'` — should exit non-zero with the refusal on stderr |
+| **B4** | Empty command emitted as success | P7 above | unknown — most surprising case; needs trace through the static→LLM fallback path |
+| **B5** | `--backend-info` advertises `claude` as `configured` but `--backend claude` errors `Unknown backend 'claude'` | `caro --backend claude --force-llm -p "foo"` → `Error: Invalid argument: Unknown backend 'claude'` | Same as B1, but called out separately because it interacts with the `ANTHROPIC_API_KEY` env var the user *did* set |
+
+### P1 — should fix in next release
+
+| ID | Title | Repro | Notes |
+|---|---|---|---|
+| **B6** | Silent constraint drop on multi-attribute `find` prompts | P1 above — drops `>1MB` | LLM and static matcher both miss combined size+time predicates |
+| **B7** | No risk badge in default `--dry-run` output | every non-blocked prompt above | `--dry-run` already runs the safety validator (P6, P8 prove it); it should print the resulting tier (LOW/MEDIUM/HIGH/CRITICAL) even when no block occurs |
+| **B8** | Safety reason text misleading on P8 (`chmod 777 /etc`) | "privilege escalation, recursive" — but the pattern is permission-widening + system-dir mutation; "privilege escalation" implies setuid/sudo | [src/safety/patterns.rs](../../../src/safety/patterns.rs) reason strings |
+| **B9** | `--quiet` suppresses risk badge entirely | `caro --dry-run --quiet -p "rm -rf /"` would not show CRITICAL to a piping caller (untested but inferred from help text "show only command + safety result" vs observed "show only command") | clarify intended behavior |
+
+### P2 — polish
+
+| ID | Title | Repro | Notes |
+|---|---|---|---|
+| **B10** | `caro --version` output `caro 1.4.0 ( crates.io)` — double space, stray punctuation | trivial | clap derive `version =` string |
+| **B11** | CLAUDE.md says "Version: 1.3.0 (GA)" — binary is 1.4.0 | [CLAUDE.md L9](../../../CLAUDE.md#L9) | already version-drift per [release-version-alignment rule](../../rules/release-version-alignment.md) |
+| **B12** | `caro doctor` does not show config-file path | `caro doctor \| grep -i config` | helpful for users debugging |
+
+---
+
+## C. Phase B — disposition of each finding
+
+| Audit ID | Beads issue | Disposition |
+|---|---|---|
+| B1 + B5 (P0) — backend roster divergence | [caro-zh41](../../../../.beads/issues.jsonl) | Filed; root cause located at `src/cli/mod.rs:466` (`validate_backend_name` hardcodes 4-backend slice that shadows canonical `BackendType::from_str` in `src/models/mod.rs:301`). Fix shape is ~30 lines: delete the hardcoded slice, delegate to `from_str`, regenerate help string. **Not inline** (touches `--backend` acceptance behavior — wants a smoke-roster integration test first per [safety-pattern-developer](../../skills/safety-pattern-developer/) TDD discipline). |
+| B2 + B3 + B4 + B9 (P0) — placeholder / echo-refusal / empty / unrelated output | [caro-bnr6](../../../../.beads/issues.jsonl) | Filed; bundled because all three share one root cause (no structured "synthesis result" type). MLX fallback at `src/backends/embedded/mlx.rs:68` literally returns `echo 'Unable to generate command'`. **Not inline** — touches output contract used by shell-init wrappers. |
+| B6 (P1) — multi-constraint silent drop | [caro-mt6h](../../../../.beads/issues.jsonl) | Filed; routes to [prompt-tuner skill](../../skills/prompt-tuner/) and/or static-matcher template work. |
+| B7 (P1) — no risk badge in non-blocked --dry-run | [caro-b45s](../../../../.beads/issues.jsonl) | Filed; **load-bearing for the caro-shell skill** — the skill cannot reliably surface risk to user until this lands. |
+| B8 (P2) — chmod 777 reason text | [caro-mt47](../../../../.beads/issues.jsonl) | Filed; routes to [safety-pattern-auditor skill](../../skills/safety-pattern-auditor/). |
+| B10 (P2) — `--version` stray punctuation | [caro-vzwc](../../../../.beads/issues.jsonl) | Filed; cosmetic, one-liner. |
+| **B11** (P2) — CLAUDE.md stale at v1.3.0 | — | **Fixed inline** in this PR: [CLAUDE.md:9](../../../CLAUDE.md#L9). Per [release-version-alignment rule](../../../../.claude/rules/release-version-alignment.md). |
+| B12 / S3 (P2) — doctor enhancements | [caro-2hqf](../../../../.beads/issues.jsonl) | Filed. |
+| **C1–C5** subcommand surface | — | `suggest`, `shell-init zsh`, `completion zsh` all pass. `ai --once` and `caro test` documented limitations only. No filings. |
+| **P6 + P8** safety-gate passes | — | Caught literal `rm -rf /` and `chmod 777 /etc` correctly. No action needed beyond B8's reason-text polish. |
+
+**Inline fixes this PR:** B11 only. Everything else is filed for follow-up work that needs tests.
+
+**Filed labels:** `qa-finding` + `dogfood-2026-05-16` + priority + (`safety` when relevant).
+
+---
+
+## D. Closing notes for Phase C/D
+
+The synthesis-quality findings (B2–B7) are the load-bearing reason an **agent** should not blindly invoke `caro` and pass the result to Bash. The skill must:
+
+1. **Never auto-execute caro's output.** Already the case in both skills (good).
+2. **Treat empty / `echo 'Unable to generate command'` / placeholder-bearing output as a *failure*, not a success.** Neither current skill says this.
+3. **Surface the risk tier explicitly to the user**, since the binary doesn't on success. The skill is the right layer to add this guard.
+4. **Prefer the `--backend embedded --force-llm` path** when the agent's prompt has multiple constraints (size + time + name), since the static matcher will silently drop them. But: the LLM also drops constraints (P1.b), so the skill should *flag* multi-constraint prompts and ask the user to verify.
+5. **`--backend static`** is unusable until B1/B5 are fixed; the skill should not recommend it.
+
+These observations feed directly into the skill revision in Phase D.

--- a/.claude/audits/2026-05-16-caro-dogfood/skill-friction.md
+++ b/.claude/audits/2026-05-16-caro-dogfood/skill-friction.md
@@ -1,0 +1,127 @@
+# Caro Skill Friction Report — 2026-05-16
+
+**Auditor:** Claude Code (`claude-opus-4-7`)
+**Skills compared:** [.claude/skills/caro-shell/SKILL.md](../../skills/caro-shell/SKILL.md) (125 lines) vs [.claude/skills/caro-shell-helper/SKILL.md](../../skills/caro-shell-helper/SKILL.md) (522 lines)
+**Reference:** Findings from [audit.md](./audit.md) Phase A
+
+---
+
+## TL;DR
+
+| | caro-shell (minimal) | caro-shell-helper (educational) |
+|---|---|---|
+| Lines | **125** | 522 |
+| Always `--dry-run`? | ✅ yes, contractually | ❌ no — examples show plain `caro --backend claude "..."` |
+| Default backend | none (lets caro pick) | **`claude`** ← does not work (see [audit B1+B5](./audit.md#a1-smoke)) |
+| Config path stated | doesn't claim one | claims `~/.config/caro/config.toml` ← **wrong on macOS** (actual: `~/Library/Application Support/caro/config.toml`) |
+| Risk-tier presentation | yes, by parsing caro output | yes, but assumes caro prints tier on success (caro doesn't — see [B7](./audit.md#p1--should-fix-in-next-release)) |
+| Self-contradiction | minor (says "Claude backend not yet wired" then lists `--backend claude`) | major (the recommended backend errors out at v1.4.0) |
+| Refuse-to-execute contract | explicit | implicit; examples show `Execute? (y/N)` prompts that look like the skill *will* execute |
+| Day-one usable on this binary | ⚠️ partially (caro itself is buggy) | ❌ broken on first call |
+| Token-load to load + run once | ~750 tokens | ~3,200 tokens (4.3× larger) |
+
+**Verdict:** `caro-shell-helper` is broken at v1.4.0 and bloated. Recommend deprecating it. `caro-shell` is workable but must be hardened against the synthesis bugs we surfaced in Phase A.
+
+---
+
+## C1. Synthetic harness — 5 scenarios × 2 skills
+
+Each row simulates what the skill would do faithfully against the v1.4.0 binary. "Result for user" is what the user actually sees if I follow the skill's procedure literally.
+
+### Scenario 1 — find files (low risk, multi-constraint)
+*Prompt: "find python files larger than 1MB modified this week"*
+
+| | caro-shell | caro-shell-helper |
+|---|---|---|
+| Skill says to run | `caro --dry-run "<prompt>"` | `caro --backend claude "<prompt>"` |
+| caro actually returns | `find . -name "*.py" -type f -mtime -7` (drops `>1MB`, see [audit P1](./audit.md#a2-synthesis-prompts)) | `Error: Unknown backend 'claude'` |
+| Skill's fallback path | "fall back to your own command synthesis — but say so explicitly" ← agent recovers | none specified — agent must improvise |
+| Turns to deliver answer | 2 (caro call + handcrafted fallback) | 2 (failed call + handcrafted) |
+| User-facing wrongness | yes — partial answer if agent doesn't notice the dropped predicate | yes — agent shows hard error |
+
+### Scenario 2 — tar exclude (placeholder template land)
+*Prompt: "tar this folder excluding .git and node_modules"*
+
+| | caro-shell | caro-shell-helper |
+|---|---|---|
+| caro returns | `tar -czf archive.tar.gz directory/` (placeholder, see [B2](./audit.md#p0--must-fix-or-formally-waive)) | `Error: Unknown backend 'claude'` |
+| Skill check for placeholder | **none** — skill trusts the output | n/a — never got output |
+| If followed literally | agent surfaces `tar -czf archive.tar.gz directory/` to user as a real command | agent shows hard error |
+| **Critical gap** | skill needs an "is this a placeholder?" tripwire before surfacing | skill broken on call |
+
+### Scenario 3 — port kill (placeholder PID)
+*Prompt: "kill the process on port 3000"*
+
+| | caro-shell | caro-shell-helper |
+|---|---|---|
+| caro returns | `kill PID` (literal `PID`) | `Error: Unknown backend 'claude'` |
+| If skill followed literally | "Run `kill PID`" surfaced to user (useless) | broken |
+| Detection needed | skill must catch unsubstituted `PID`/`directory`/`output.tar.gz` placeholders | — |
+
+### Scenario 4 — log rotate (echo-wrapped refusal)
+*Prompt: "rotate these logs and gzip the old ones"*
+
+| | caro-shell | caro-shell-helper |
+|---|---|---|
+| caro returns | `echo 'Unable to generate command'` (shell-executable refusal, see [B3](./audit.md#p0--must-fix-or-formally-waive)) | `Error: Unknown backend 'claude'` |
+| Skill's fallback rule | "If caro fails or returns empty, fall back" — but this output is *neither* empty *nor* a non-zero exit | broken |
+| **Critical gap** | skill must treat `echo 'Unable to generate command'` as a failure sentinel until [caro-bnr6](../../../.beads/issues.jsonl) lands | — |
+
+### Scenario 5 — dangerous rm (the gold path)
+*Prompt: "rm -rf /"*
+
+| | caro-shell | caro-shell-helper |
+|---|---|---|
+| caro returns | `Error: Unsafe command detected ... Critical` (non-zero exit) | same — caro's safety gate fires *before* backend matters? Actually no — `--backend claude` rejection happens first, so caro-shell-helper would error with "Unknown backend" rather than "CRITICAL" |
+| Risk surfaced to user | ✅ CRITICAL (skill follows "lead with safety line") | ❌ user sees a backend error, no safety information |
+| **One scenario where caro-shell shines** | the safety gate + skill contract chain works exactly as designed | helper fails to even reach the safety check |
+
+### C1 score summary
+
+| Skill | Scenarios with correct user-facing outcome (5 max) | Notes |
+|---|---|---|
+| caro-shell | **1/5** (scenario 5 only) | Other 4 need new skill-level guards against caro's output bugs |
+| caro-shell-helper | **0/5** | Hard error on every call due to `--backend claude` recommendation |
+
+The 1/5 vs 0/5 is what's actually shippable today; the gap between them is whether the skill is *recoverable* via SKILL.md edits (yes, for caro-shell) or *fundamentally misaligned* with the binary (yes, for caro-shell-helper).
+
+---
+
+## C2. Real-task harness — qualitative observations
+
+**Setup:** I've been running this audit session itself as a real coder task — multi-step shell work via the Bash tool. Notes from observation:
+
+- **No false invocations.** Neither skill triggered for routine work: `git status`, `git diff`, `cat <file>`, `mkdir -p`, `ls`, `grep -rn ...`. Both skills' "Don't use this skill for…" lists or trigger languages correctly excluded these. ✅
+- **Would caro have helped on any command in this session?** The only commands of consequence were `bd create --description=<here-doc>` (multi-line, structured) and `gh label create` (3-arg flags). Neither is a natural-language synthesis task — they're agent-knows-the-API tasks. Caro would have hurt, not helped.
+- **Where caro *would* have helped:** had the user asked me to find dead `.gguf` files in the cache or compress old beta-test artifacts, I'd have wanted caro's macOS-vs-Linux flag adaptation. Those didn't come up this session.
+- **Cost of having the skill installed but unused:** negligible. The skill's description fires only on matching prompts; loading the SKILL.md body is conditional on actual use.
+
+**Net read:** the skill correctly stays out of the way for an agent doing structured work. The friction problem is **not** "too many false invocations"; it's "when invoked, the skill's procedure is not robust to caro's actual output."
+
+---
+
+## C3. Token-cost comparison
+
+Both skills loaded into one prompt (estimated):
+
+| Skill | SKILL.md tokens | Procedure overhead/call |
+|---|---|---|
+| caro-shell | ~750 | 2 bash calls (check + dry-run), short reply shape |
+| caro-shell-helper | ~3,200 | 1 bash call, multi-section reply shape with emojis, POSIX-compliance education |
+
+The helper's 4× cost is mostly never-relevant prose (POSIX education, backend-config TOML examples for backends most users won't use). For an autonomous coder loop running 50 caro invocations per day, that's ~125K extra tokens of skill body the agent walks past every time. Per the [no-finance rule](../../../../../.claude/projects/-Users-kobik-private-workspace-caro/memory/feedback_no_finance_in_public_repos.md) we don't talk price publicly, but for context, that's a measurable line item.
+
+---
+
+## C4. Required skill changes (going into Phase D)
+
+Driven by the data above:
+
+1. **caro-shell-helper → deprecation pointer.** It teaches wrong facts (paid-backend default, wrong macOS config path, fictional risk-emoji output) and is 4× the size of the working alternative. The "POSIX education" section is generic; it can live in a doc, not a skill.
+2. **caro-shell needs three new guards before being shippable in autonomous loops:**
+   a. **Placeholder-output tripwire**: after running caro, scan the returned command for unsubstituted placeholders (`PID`, `directory/`, `output.tar.gz`, `archive.tar.gz`, empty string, `echo 'Unable to generate command'`). If any of these, surface as **caro could not synthesize** — do not present the placeholder as a command.
+   b. **Risk-tier presence check**: until [caro-b45s](../../../.beads/issues.jsonl) lands, caro doesn't print a risk tier on non-blocked commands. The skill must say so explicitly (don't fabricate a tier) and recommend the user run `caro --explain` for context.
+   c. **Backend default for agents**: do NOT recommend `--backend claude` (rejected at v1.4.0 per [caro-zh41](../../../.beads/issues.jsonl)). Leave `--backend` unset so caro picks its actual default (embedded). Document this and link the beads issue so future-skill-readers know why.
+3. **Self-correction note**: the current caro-shell line 25 contradicts itself ("Anthropic Claude backend is not yet wired into the CLI" + line 55 listing `--backend claude` as a flag option). Fix the wording.
+
+The actual edit is in Phase D.

--- a/.claude/skills/caro-shell-helper/SKILL.md
+++ b/.claude/skills/caro-shell-helper/SKILL.md
@@ -1,14 +1,26 @@
 ---
 name: "caro-shell-helper"
-description: "Use when users need help generating safe, tested POSIX shell commands from natural language descriptions. Guides users through command generation, safety validation, and execution workflows using Caro best practices"
+description: "DEPRECATED 2026-05-16 — use caro-shell instead. This skill recommends the --backend claude flag and a ~/.config/caro/config.toml path that do not work on the current caro 1.4.0 binary, and its 522-line educational body is 4× the size of caro-shell for no benefit to an agent. Will be removed after 2026-08-01."
 version: "1.0.0"
 allowed-tools: "Bash, Read, Write, Grep, Glob"
 license: "AGPL-3.0"
 ---
 
-# Caro Shell Command Helper
+# Caro Shell Command Helper — **DEPRECATED**
 
-## What This Skill Does
+> **Status: Deprecated 2026-05-16.** Use [caro-shell](../caro-shell/SKILL.md) instead.
+>
+> **Why:** This skill recommends `caro --backend claude` (rejected by the v1.4.0 binary's `--backend` validator; tracking issue caro-zh41), claims the config path is `~/.config/caro/config.toml` (actual macOS path: `~/Library/Application Support/caro/config.toml`), and shows risk-emoji output that caro does not actually emit on the success path (tracking issue caro-b45s). The 522-line body is 4× the size of caro-shell for no agent benefit — see [skill-friction.md](../../audits/2026-05-16-caro-dogfood/skill-friction.md) for the side-by-side comparison.
+>
+> **Replacement:** [.claude/skills/caro-shell/SKILL.md](../caro-shell/SKILL.md). The replacement is hardened against caro's known synthesis bugs and defaults to caro's free embedded backend (correct choice for autonomous agent loops under the no-paid-default convention).
+>
+> **Removal date:** 2026-08-01. Until then this skill is kept for compatibility but its `description` will not be matched by the skill-discovery layer.
+>
+> **For maintainers:** the educational POSIX-compliance prose and backend-config TOML examples in this file are useful reference material — consider extracting to `docs/` rather than re-introducing them as a skill.
+
+---
+
+## What This Skill Does (legacy content below — do not follow as-written)
 
 This skill helps users effectively leverage **Caro** (formerly Caro) - a Rust CLI tool that converts natural language descriptions into safe, POSIX-compliant shell commands using local LLMs.
 

--- a/.claude/skills/caro-shell/SKILL.md
+++ b/.claude/skills/caro-shell/SKILL.md
@@ -19,10 +19,12 @@ Don't use this skill for:
 - Programs/scripts that need to live in a file (write the file directly).
 - Commands the user has already typed and just wants explained (`man` / `tldr` are better).
 - Pure questions like "what does `awk` do?" (answer directly).
+- Routine agent-internal shell work where the agent already knows the API surface: `git status`, `git add`, `git commit`, `gh pr view`, `bd create`, `npm install`, `cargo test`, `ls`, `cat`, `mkdir`, `find <known-pattern>`. Caro adds friction without value when the agent already has full context.
+- Multi-line shell scripts (`bash -c '...'` blocks with newlines). Caro is single-line synthesis; for scripts, write the file.
 
 ## What caro provides
 
-[`caro`](https://crates.io/crates/caro) is a Rust CLI that converts natural language → POSIX shell commands using local LLMs (MLX on Apple Silicon, Candle CPU elsewhere). The default `cargo install caro` build ships with embedded backends only; remote providers (Ollama, vLLM, Exo) require a custom build with `--features remote-backends`, and the Anthropic Claude backend is not yet wired into the CLI. Every generated command goes through 52+ dangerous-pattern safety regexes before being shown to the user. Risk levels: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`.
+[`caro`](https://crates.io/crates/caro) is a Rust CLI that converts natural language → POSIX shell commands using local LLMs (MLX on Apple Silicon, Candle CPU elsewhere). The default `cargo install caro` build ships with the embedded backend only; remote providers (Ollama, vLLM, Exo) require a custom build with `--features remote-backends`. Every generated command goes through 52+ dangerous-pattern safety regexes before being shown to the user. Risk levels: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`.
 
 ## How to invoke
 
@@ -50,15 +52,25 @@ Don't use this skill for:
 
    | Flag | When |
    |---|---|
-   | `--backend embedded` | Force the local model (privacy, no network) |
-   | `--backend ollama --model qwen2.5-coder:7b` | Use a local Ollama server |
-   | `--backend claude` | Use Anthropic API (`ANTHROPIC_API_KEY` must be set) |
-   | `--explain` | Include a one-line rationale |
+   | (none — let caro pick default) | **Default for agents.** caro picks `embedded` (local model, zero-cost, deterministic). Right choice for autonomous loops. |
+   | `--backend embedded` | Be explicit about the local-model path |
+   | `--backend ollama --model qwen2.5-coder:7b` | Only if the user explicitly asks for a local Ollama server |
+   | `--explain` | Include a rationale — useful when the user asked WHY, not just WHAT |
    | `--shell zsh` (or `bash`/`fish`) | Target a specific shell |
 
-3. **Parse caro's output** — it prints the suggested command + a safety classification. If the classification is `CRITICAL` or `HIGH`, surface that prominently to the user before they decide.
+   **Do not** pass `--backend claude` or `--backend static` in this version: both are advertised by `caro --backend-info` but rejected by the `--backend` validator at v1.4.0. Tracking issue: caro-zh41. Do not pass `--quiet` either — it suppresses the safety information you need to surface.
 
-4. **Present, do not execute** — show the user the command verbatim, the safety level, and any caveats. Let *them* decide whether to run it. If they ask you to run it, use the regular Bash tool with explicit confirmation per the standard destructive-command rules — do not bypass that just because caro classified it as `LOW`.
+3. **Detect synthesis failures before presenting** — caro's output today has three known failure modes that look like success ([audit 2026-05-16](../../audits/2026-05-16-caro-dogfood/audit.md), tracking issue caro-bnr6). Before presenting any command from caro, run these tripwires:
+
+   - **Empty `Command:` block** → caro produced nothing. Treat as failure.
+   - **`echo 'Unable to generate command'`** → caro's refusal path wrapped in `echo`. Treat as failure.
+   - **Unsubstituted placeholders** (`PID`, `directory/`, `output.tar.gz`, `archive.tar.gz`, or any all-caps token that looks like a variable name) → caro returned a template, not a synthesized command. Treat as failure.
+
+   On any tripwire: tell the user *"caro could not fully synthesize this; here's a hand-written suggestion, please double-check"* and fall back to your own command synthesis with the BSD-vs-GNU caveats explicit.
+
+4. **Parse caro's output** — when caro successfully synthesizes, it prints the suggested command. **Risk tier is only printed when the safety gate fires (block / CRITICAL).** For commands that pass the gate, caro prints no tier today (tracking issue caro-b45s). Do not invent a tier. If the user asked for safety context, re-run with `--explain` or pattern-match the command yourself (`rm -rf`, `chmod -R`, `dd if=`, `curl ... | sh`).
+
+5. **Present, do not execute** — show the user the command verbatim, the safety status from caro (or "no block; tier not surfaced" if caro stayed silent), and any caveats. Let *them* decide whether to run it. If they ask you to run it, use the regular Bash tool with explicit confirmation per the standard destructive-command rules — do not bypass that just because caro returned a non-error.
 
 ## Reply shape
 
@@ -69,13 +81,15 @@ Keep it tight:
 ```bash
 <the command from caro>
 ```
-**Safety:** <LOW|MEDIUM|HIGH|CRITICAL> — <one-line rationale if HIGH+>
+**Safety:** <CRITICAL|HIGH|MEDIUM|LOW|"caro did not surface a tier — agent assessment: <X>">
 **Notes:** <only if non-obvious caveats: BSD-vs-GNU, requires sudo, irreversible, etc.>
 ```
 
 If `CRITICAL` or `HIGH`, lead with the safety line and ask the user explicitly to confirm before running.
 
-If caro fails or returns empty, fall back to your own command synthesis — but say so explicitly: *"caro errored, here's a hand-written suggestion — please double-check."*
+If any tripwire from step 3 fires (empty / `echo 'Unable...'` / placeholder), do **not** print the command. Instead say: *"caro could not fully synthesize this; here's a hand-written suggestion — please double-check."* and write the command yourself.
+
+If caro errors (exit non-zero, e.g. CRITICAL block fired), surface the error verbatim — the safety-gate text is the most useful thing in the whole pipeline.
 
 ## Examples
 
@@ -108,9 +122,23 @@ Caro will likely return either a refusal or a heavily caveated `find /tmp -minde
 ## Constraints
 
 - **Always `--dry-run`.** This skill never lets caro execute. The user (or you, via the regular Bash tool with confirmation) executes if they choose to.
-- **Never strip caro's safety classification.** If caro says `HIGH`, the user sees `HIGH`.
+- **Never strip caro's safety classification.** If caro says `CRITICAL`, the user sees `CRITICAL`.
 - **No `--execute` flag**, ever, from this skill.
+- **No `--quiet` flag**, ever — it suppresses the safety information.
+- **No paid backends by default.** Do not pass `--backend claude` or recommend paid remote backends unless the user explicitly asks. The default (no flag) gives caro's embedded local model, which is free and deterministic — the right choice for an autonomous agent loop.
 - **One command per call.** If the user wants a multi-step pipeline that doesn't fit on one line, iterate — call caro once per step.
+- **Tripwire before trust.** Per step 3 of "How to invoke", scan caro's output for placeholder / empty / echo-refusal failure modes before presenting. These are known v1.4.0 bugs (caro-bnr6); the binary reports success even when synthesis failed, so the skill is the safety net.
+
+## Agent contract by risk tier
+
+When caro *does* return a tier (block path) or you assess one yourself:
+
+| Tier | Agent action |
+|---|---|
+| `LOW` | Surface command + tier to user. May proceed via Bash with normal confirmation. |
+| `MEDIUM` | Surface tier prominently. Recommend the user run the command themselves or via Bash with explicit confirmation. Suggest `--dry-run` (caro's, not the agent's) for any file-touching variant. |
+| `HIGH` | Lead with the tier. Refuse to execute via Bash unless the user types verbatim approval. Suggest a safer alternative if one is obvious (`-i` interactive flag, `-n` non-clobber). |
+| `CRITICAL` | **Hard refusal.** Show caro's block message. Do not execute even with user approval — ask the user to run it themselves in a separate terminal if they truly want to. |
 
 ## Why this skill exists
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ A Rust CLI that converts natural language descriptions into safe POSIX shell com
 
 - **Language**: Rust (edition 2021, MSRV 1.83)
 - **License**: AGPL-3.0
-- **Version**: 1.3.0 (GA)
+- **Version**: 1.4.0 (GA)
 - **Crate**: [crates.io/crates/caro](https://crates.io/crates/caro)
 
 ## Key Architecture


### PR DESCRIPTION
## Summary

End-user dogfood of caro 1.4.0 + a side-by-side friction comparison of the two project-local caro skills. The audit artifacts are committed under `.claude/audits/2026-05-16-caro-dogfood/` and act as the authoritative repro for every finding.

**Inline-fixed in this PR (small only, per plan):**
- `.claude/skills/caro-shell/SKILL.md` hardened against three v1.4.0 synthesis failure modes (placeholder templates, echo-wrapped refusals, empty commands) with explicit per-tier agent contract and free-backend default
- `.claude/skills/caro-shell-helper/SKILL.md` marked deprecated until 2026-08-01 (recommends a paid backend that doesn't work, claims a Linux-only config path on macOS, 4× the size of caro-shell for no agent benefit)
- `CLAUDE.md` version banner aligned 1.3.0 → 1.4.0 (per `release-version-alignment` rule)

**Filed as beads for follow-up code work** (label \`qa-finding\` + \`dogfood-2026-05-16\` + priority):
- **caro-zh41** P0 — backend validator divergence: 4 surfaces disagree on the backend roster; \`--backend claude\` and \`--backend static\` are advertised by \`--backend-info\` but rejected by the validator (\`src/cli/mod.rs:466\` shadows the canonical \`BackendType::from_str\`)
- **caro-bnr6** P0 — static matcher emits placeholder templates (\`kill PID\`, \`directory/\`), shell-executable refusals (\`echo 'Unable to generate command'\` at \`src/backends/embedded/mlx.rs:68\`), and empty commands as if successful — silent failure mode for agents
- **caro-mt6h** P1 — multi-constraint prompts silently drop attributes (e.g. \`>1MB\` dropped from a size+time prompt)
- **caro-b45s** P1 — risk tier only printed on block; success path is silent; skills can't reliably surface safety to user
- **caro-mt47** P2 — \`chmod 777 /etc\` block reason text says "privilege escalation" instead of "permission widening + system-dir mutation"
- **caro-2hqf** P2 — \`caro doctor\` doesn't show config path or probe all backends \`--backend-info\` knows about
- **caro-vzwc** P3 — \`caro --version\` output has stray punctuation (\`caro 1.4.0 ( crates.io)\`)

**Synthesis-quality verdict (10 user-realistic prompts):** 2 fully correct, 5 unusable placeholder output, 2 partial (silent constraint drop), 1 properly safety-gated. The most damaging pattern is unusable output being emitted as a successful command — a piping caller (script or agent) cannot tell synthesis succeeded from failed.

**Skill friction verdict:** caro-shell (125 lines, hardened in this PR) gets 1/5 synthetic scenarios right today (limited by caro's bugs, not the skill); caro-shell-helper (522 lines) gets 0/5 because its recommended \`--backend claude\` is rejected by the v1.4.0 binary. Deprecated.

**Known sync limitation:** \`bd sync\` cannot export the new beads issues to \`.beads/issues.jsonl\` from this worktree (the worktree has WAL-only db state; root .beads/beads.db is missing). All 7 issues are queryable via \`bd show <id>\` and listed in the audit's disposition table. Reviewer can re-export from the main worktree once this lands.

## Files changed

- \`.claude/audits/2026-05-16-caro-dogfood/audit.md\` (new) — Phase A findings with priorities and dispositions
- \`.claude/audits/2026-05-16-caro-dogfood/skill-friction.md\` (new) — Phase C side-by-side comparison
- \`.claude/skills/caro-shell/SKILL.md\` (modified) — Phase D hardening
- \`.claude/skills/caro-shell-helper/SKILL.md\` (modified) — Phase D deprecation pointer
- \`CLAUDE.md\` (modified) — version alignment

## Test plan

- [x] Run \`caro --version\`, \`caro --help\`, \`caro doctor\`, \`caro --backend-info\` — confirm the four-roster divergence reproes
- [x] Run all 10 prompts in audit.md A2 against \`caro --dry-run --backend embedded\` — confirm placeholder/echo/empty patterns
- [x] Verify \`caro --backend claude\` errors despite \`--backend-info\` saying claude is "configured"
- [x] Read the hardened \`caro-shell\` SKILL.md and confirm the placeholder tripwire would catch all 5 documented failure shapes
- [x] Confirm CLAUDE.md \`Version:\` line matches \`Cargo.toml\` \`version =\`
- [ ] Reviewer: run \`bd show caro-zh41\` (and the other 6 IDs) to confirm filings are queryable
- [ ] Reviewer: on main worktree, run \`bd export\` and commit \`.beads/issues.jsonl\` to persist the 7 new issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dogfooded `caro` 1.4.0, added a reproducible audit, and hardened our skills to prevent bad suggestions from looking successful. `caro-shell` now guards against placeholder/echo/empty outputs, `caro-shell-helper` is deprecated, and `CLAUDE.md` is aligned to 1.4.0.

- New Features
  - Added audit and skill-friction reports with full repros under `.claude/audits/2026-05-16-caro-dogfood/`.
  - Hardened `caro-shell`: tripwires for placeholders (`PID`, `directory/`, `archive.tar.gz`), `echo 'Unable to generate command'`, and empty output; no fabricated risk tier on success; defaults to embedded by omitting `--backend`; clearer exclusions; explicit agent contract by risk tier.
  - Updated `CLAUDE.md` version banner to `1.4.0`.

- Migration
  - Use `caro-shell`; stop using `caro-shell-helper` (deprecated until 2026-08-01).
  - On `caro` 1.4.0 do not pass `--backend claude` or `--backend static`; let `caro` default to embedded, or use `--backend embedded` explicitly.
  - Do not assume a risk tier is printed on successful `--dry-run`; use `--explain` if needed and avoid `--quiet`.

<sup>Written for commit d81082c5536ff39bb51c62961ebe920311520d6a. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

