### PR TITLE
docs: reposition Caro as execution safety primitive for guardian agent stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ This project is **generally available** with all core features implemented, test
 - 🌐 **Cross-platform** - Full support for macOS (including Apple Silicon), Linux, and Windows
 - 🎬 **Safe execution** - Optional command execution with shell-aware handling
 
+
+## How Caro fits in the guardian agent architecture
+
+In 2026, Gartner named **Guardian Agents** as a formal market category: autonomous oversight layers that monitor, constrain, and govern AI agent behavior in production. Microsoft's Agent Governance Toolkit (OWASP + EU AI Act compliance) and Orchid Security's zero-trust identity layer are two early category leaders.
+
+Most guardian agent products focus on **policy, identity, and observability** — *who* is the agent, *what* permissions does it have, *what did it do*. Caro occupies a complementary but distinct layer: **execution safety for shell and tool calls**. It sits at the exact point where a prompt becomes a command, applying deterministic validation before anything reaches the OS.
+
+| Guardian concern | Caro's contribution |
+|---|---|
+| Prompt injection → RCE | Deterministic regex + CVE rule validation breaks the injection→execution chain (see CVE-2026-25592, CVE-2026-26030) |
+| Tool-call governance | Every shell command passes through `SafetyValidator` regardless of which agent or backend produced it |
+| Risk-tiered approval | CRITICAL / HIGH / MEDIUM / LOW risk levels map directly onto tiered human-in-the-loop approval patterns |
+| Auditability | Structured JSON output and telemetry hooks give guardian orchestrators a machine-readable safety signal |
+| Defense in depth | 5-layer validation pipeline (allowlist → built-in patterns → CVE rules → custom patterns → user confirmation) — no single bypass produces execution |
+
+**In short:** if your guardian agent stack needs a safety primitive that sits between "the LLM decided to run a command" and "the command hits the shell", Caro is that layer.
+
+See [`docs/GUARDIAN_AGENT.md`](docs/GUARDIAN_AGENT.md) for the full explainer.
+
 ## Installation
 
 ### macOS

--- a/docs/GUARDIAN_AGENT.md
+++ b/docs/GUARDIAN_AGENT.md
@@ -1,0 +1,113 @@
+# Guardian Agents and Caro's Role
+
+> *Caro is the execution safety primitive for guardian agent stacks — the
+> deterministic layer that sits between an LLM's intent and a shell's power.*
+
+---
+
+## What are guardian agents?
+
+In March 2026, Gartner introduced **Guardian Agents** as a formal market
+category: autonomous oversight layers that monitor, constrain, and govern AI
+agent behavior in production environments. The category emerged because
+enterprise deployments of agentic AI hit a hard reliability and safety wall —
+agents that act autonomously need something watching them that is *not itself
+an LLM*.
+
+A guardian agent stack typically has three layers:
+
+1. **Identity and access** — *Who* is this agent? What permissions does it hold?
+   Orchid Security and similar products address this layer.
+2. **Policy and observability** — *What is the agent doing?* Microsoft's Agent
+   Governance Toolkit (OWASP + EU AI Act compliance), LangSmith, and Temporal
+   operate here.
+3. **Execution safety** — *Should this specific action proceed?* This is where
+   Caro lives.
+
+## Why execution safety is a distinct layer
+
+The 2026 Microsoft Security Blog disclosure of CVE-2026-25592 and
+CVE-2026-26030 demonstrated that prompt injection can become host-level RCE
+in a single step when an agent has shell or tool access. Identity and policy
+layers cannot prevent this class of attack — they define *who* can act, not
+*whether a specific action is safe*. The gap between an agent having permission
+to run commands and a specific command being safe to run requires a
+deterministic, sub-millisecond validator that does not depend on the LLM
+itself.
+
+Caro fills that gap.
+
+## What Caro provides
+
+| Capability | How it works |
+|---|---|
+| **Command validation** | 62+ pre-compiled regex patterns + CVE rule pipeline. Every command is validated regardless of source backend. |
+| **Risk classification** | CRITICAL / HIGH / MEDIUM / LOW levels map onto the tiered approval pattern (auto-approve / async log / sync human gate) the market is converging on. |
+| **Defense in depth** | 5-layer pipeline: allowlist, built-in patterns, CVE rules, custom patterns, user confirmation. No single bypass produces execution. |
+| **Backend symmetry** | The `SafetyValidator` is backend-agnostic. An embedded model, Ollama, vLLM, or any future backend all pass through the same code path. |
+| **Structured output** | JSON and YAML output modes give guardian orchestrators a machine-readable signal to consume. |
+| **CVE rule pipeline** | Weekly automated sync with NVD + CISA KEV + GHSA for shell-invocation CVEs (CVSS >= 7.0). Rules compiled into the binary with zero runtime network calls. |
+
+## Integration patterns
+
+Caro can be wired into a guardian agent stack in three ways:
+
+### 1. CLI invocation (available today)
+
+    caro --output json "delete all files older than 30 days"
+
+The JSON output includes the generated command, risk level, and safety
+verdict. A guardian orchestrator can parse this and apply its own approval
+policy.
+
+### 2. MCP server (in progress)
+
+    caro mcp serve
+
+Exposes `generate_command`, `validate_command`, and `explain_safety` over the
+Model Context Protocol. Any MCP-aware agent framework (LangChain, CrewAI,
+Semantic Kernel, Google ADK) can call Caro as a tool.
+
+### 3. OpenAI-compatible endpoint (in progress)
+
+    caro serve --openai
+
+An OpenAI Chat Completions endpoint backed by Caro's safety validator.
+Drop-in for any agent that uses OpenAI-style tool calls.
+
+## Where Caro fits in the stack
+
+    +---------------------------------------------+
+    |         Guardian Agent Orchestrator           |
+    | (policy, identity, observability, approval)  |
+    +---------------------------------------------+
+    |              CARO (you are here)              |
+    | (execution safety: validate before shell)     |
+    +---------------------------------------------+
+    |              Shell / OS / Tool                |
+    | (bash, zsh, fish, PowerShell, etc.)           |
+    +---------------------------------------------+
+
+Caro does not replace identity, policy, or observability layers. It completes
+the stack by adding deterministic safety at the last mile — the point where
+an agent's intent becomes an operating system action.
+
+## What Caro does NOT claim to be
+
+- A general-purpose agent governance framework (use Microsoft AGAT, LangGraph
+  governance, or similar).
+- An identity or access control layer (use Orchid Security, IAM, or similar).
+- A monitoring or observability platform (use LangSmith, Temporal, or
+  similar).
+
+Caro is a focused, single-responsibility primitive: **validate shell commands
+before they execute, regardless of who or what generated them.** That focus
+is its strength in a guardian stack — it does one thing, deterministically,
+and it does not depend on the LLM to self-police.
+
+## See also
+
+- [SAFETY_PHILOSOPHY.md](SAFETY_PHILOSOPHY.md) — the engineering doctrine
+  behind Caro's safety architecture
+- [SECURITY.md](../SECURITY.md) — vulnerability disclosure policy
+- [README.md](../README.md) — full feature list and installation instructions


### PR DESCRIPTION
Clean rebase of PR #1093 onto current main.

Adds:
- README.md: 'How Caro fits in the guardian agent architecture' section
- docs/GUARDIAN_AGENT.md: 1-page explainer on guardian agents and Caro's role

Cherry-picked to resolve merge conflicts with .beads/issues.jsonl.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repositions Caro as the execution safety layer for guardian agent stacks. Adds a README section and `docs/GUARDIAN_AGENT.md` explaining Caro’s role, risk tiers, and integration paths (CLI today; MCP/OpenAI endpoints in progress), with context on the Gartner Guardian Agents category and CVE-2026-25592/26030.

<sup>Written for commit 1832a2dcfb72cf83677d452a76ab811b5e96c71c. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1114?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

