### PR TITLE
style(cli): rustfmt edit_prompt::outcome_equality

### DIFF
--- a/src/cli/edit_prompt.rs
+++ b/src/cli/edit_prompt.rs
@@ -66,10 +66,7 @@ mod tests {
             EditOutcome::Execute("ls".into()),
             EditOutcome::Execute("ls".into())
         );
-        assert_ne!(
-            EditOutcome::Execute("ls".into()),
-            EditOutcome::Cancelled
-        );
+        assert_ne!(EditOutcome::Execute("ls".into()), EditOutcome::Cancelled);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to [#1109](https://github.com/wildcard/caro/pull/1109) — that PR's rustfmt fix was committed but never landed before merge, so main has the un-fmt'd version. Three-line fix:

\`\`\`diff
-        assert_ne!(
-            EditOutcome::Execute(\"ls\".into()),
-            EditOutcome::Cancelled
-        );
+        assert_ne!(EditOutcome::Execute(\"ls\".into()), EditOutcome::Cancelled);
\`\`\`

## Broader fmt drift (out of scope here)

\`cargo fmt\` against current main reveals fmt drift in 8 other files beyond what this PR touches:

- src/agent/pipeline/filters.rs (10 lines)
- src/agent/pipeline/hydrators.rs (6 lines)
- src/agent/pipeline/sources.rs (14 lines)
- src/models/mod.rs (4 lines)
- src/prompts/minimal.rs (3 lines, from [#1111](https://github.com/wildcard/caro/pull/1111))
- src/prompts/mod.rs (2 lines, from [#1111](https://github.com/wildcard/caro/pull/1111))
- tests/custom_patterns_toml.rs (13 lines)
- tests/cve_enforcement.rs (2 lines)

This PR is deliberately scoped to the regression I caused via #1109's incomplete merge. The other 8 files are unrelated drift that pre-dates my work; they should be addressed in a separate fmt-sweep PR so this stays reviewable as a focused style fix.

## Test plan

- [x] \`cargo fmt --check\` against the modified file passes
- [x] \`cargo build --bin caro\` clean
- [x] \`cargo test --lib cli::edit_prompt\` — 4/4 pass

## Plan reference

\`/Users/kobik-private/.claude/plans/any-novel-ideas-we-floofy-rainbow.md\` — Idea #1 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix formatting regression in `src/cli/edit_prompt.rs` by collapsing a short `assert_ne!` call to one line in the `outcome_equality` test. Restores `cargo fmt --check` for this file; follow-up to #1109 where the fmt change didn’t land.

<sup>Written for commit 58c4d0d09eb5574b7640c376143172469ec3e691. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

