### PR TITLE
docs(rules): codify CI-green merge gate after PR #925 bincode tombstone

### DIFF
--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -12,23 +12,29 @@ flat pile of rules has no precedence; a layered constitution does.
 
 ## Tier 1 — Project safety (highest priority)
 
-These rules protect the repository and the parallel-session workflow. They
-override anything below them.
+These rules protect the repository, the supply chain, and the
+parallel-session workflow. They override anything below them.
 
 1. **[git-workflow.md](./git-workflow.md)** — Feature branches are mandatory.
    Never commit to `main`. Enforced by a PreToolUse hook.
+2. **[dependency-upgrade-verification.md](./dependency-upgrade-verification.md)** —
+   No PR merges while CI is red. Applies to every contributor and every
+   agent, including Dependabot. Codified after PR #925 / #1150 broke
+   `main` for 24+ hours via an unverified dependency merge despite an AI
+   reviewer's P0 flag. See also `external-sdk-integration.md` (Tier 2 #6)
+   for the sibling rule on *adding* SDKs.
 
 ## Tier 2 — Engineering discipline
 
 These rules govern how code is written, reviewed, and released.
 
-2. **[dev-process.md](./dev-process.md)** — Branch / PR / CI workflow,
+3. **[dev-process.md](./dev-process.md)** — Branch / PR / CI workflow,
    conventional commits, code style.
-3. **[release-version-alignment.md](./release-version-alignment.md)** — The
+4. **[release-version-alignment.md](./release-version-alignment.md)** — The
    6-file release checklist; every release PR touches all six files.
-4. **[adr-numbering.md](./adr-numbering.md)** — ADRs are sequential, no gaps;
+5. **[adr-numbering.md](./adr-numbering.md)** — ADRs are sequential, no gaps;
    renumber on merge if PRs land out of order.
-5. **[external-sdk-integration.md](./external-sdk-integration.md)** —
+6. **[external-sdk-integration.md](./external-sdk-integration.md)** —
    First PR for any non-trivial external SDK is a build-spike (license,
    MSRV, optional feature flag, code-ref smoke, two verification builds);
    architecture lands only after the spike merges green.
@@ -38,11 +44,11 @@ These rules govern how code is written, reviewed, and released.
 These rules govern session ergonomics and surface-level conventions. They
 yield to anything in Tier 1 or Tier 2.
 
-6. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
+7. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
    found it; do not gold-plate.
-7. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
+8. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
    Quick-Actions footer when stopping for user input.
-8. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
+9. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
    Escape `{` in shell snippets inside `.astro` / `.jsx` / `.tsx` templates
    (esbuild treats it as a JSX expression boundary).
 
@@ -62,6 +68,6 @@ yield to anything in Tier 1 or Tier 2.
 ## Why this exists
 
 Inspired by [swarm-forge](https://github.com/unclebob/swarm-forge)'s
-constitution layering. With 8 rule files and 4–5 parallel Claude sessions,
+constitution layering. With 9 rule files and 4–5 parallel Claude sessions,
 "first one I happen to load" is not a deterministic conflict resolution
 strategy; explicit precedence is.

--- a/.claude/rules/dependency-upgrade-verification.md
+++ b/.claude/rules/dependency-upgrade-verification.md
@@ -1,0 +1,203 @@
+# Dependency Upgrade Verification — CI-Green Merge Rule
+
+> **The rule, in one sentence.**
+> **No PR may be merged while any required CI check is failing — regardless of who is reviewing, who is merging, what the change is, or how trivial it appears.** This applies equally to Dependabot PRs, agent-authored PRs, and human-authored PRs. There is no exception for "trivial" version bumps, "obviously safe" lockfile changes, or "the CI is just flaky" assertions.
+
+This is a **Tier 1 — Project Safety** rule. It sits in `.claude/rules/constitution.md` above every engineering-discipline rule. It overrides them on contention.
+
+---
+
+## Why this rule exists
+
+On 2026-04-27, Dependabot opened [PR #925](https://github.com/wildcard/caro/pull/925): `deps: bump bincode from 1.3.3 to 3.0.0`.
+
+`bincode 3.0.0` is **an intentional tombstone release**. Its entire `src/lib.rs` is one line:
+
+```rust
+compile_error!("https://xkcd.com/2347/");
+```
+
+The bincode maintainers published 3.0.0 as a commentary on software-dependency fragility (referencing [xkcd 2347 "Dependency"](https://xkcd.com/2347/)) — there is no expectation that anyone build against it.
+
+On PR #925, the AI reviewer `cubic-dev-ai` posted, **before the merge**:
+
+> **P0**: Pinning `bincode` to `3.0` breaks the build: `3.0.0` is a tombstone release that intentionally emits a compiler error.
+
+PR #925 was merged anyway by the project owner on 2026-05-17 at 02:11:45 UTC. From that point until [PR #1154](https://github.com/wildcard/caro/pull/1154) landed the unblock, **every `cargo build` on `main`, every CI matrix job, every release pipeline, and every `cargo install caro` failed unconditionally** — for 24+ hours.
+
+This was not a Rust bug, not a Dependabot bug, not a CI bug. It was a **process bug**: an unverified merge of an external dependency upgrade, despite an explicit P0 flag from a reviewer, without anyone running `cargo build` against the bumped lockfile.
+
+The bincode maintainers, by publishing a deliberately-broken version, did us a favor: they exposed exactly this gap. The fix is mechanical (replace bincode with [postcard](https://crates.io/crates/postcard)), but the *real* fix is to close the gap so the same class of failure cannot recur — whether the next instance is another well-meaning xkcd reference, a [Shai-Hulud-class supply-chain worm](https://blog.npmjs.org/) (npm/PyPI/crates.io have all seen real-world examples), or just a normal SemVer-major bump that nobody actually compiled.
+
+---
+
+## What every agent and contributor MUST do before invoking `gh pr merge`
+
+This is the checklist. If you cannot tick every box honestly, **stop**. Do not merge.
+
+### 1. Verify CI is green
+
+```bash
+gh pr checks <PR-number>
+```
+
+- **Required**: Zero `fail` rows among required checks.
+- **Required**: Zero `pending` rows among required checks (wait — do not race).
+- **Required**: At least the build/test/lint suite has actually run on the head SHA. If a required check is absent, that is *not* a pass — investigate why it didn't trigger.
+
+```bash
+gh pr view <PR-number> --json mergeStateStatus
+```
+
+- **Required**: `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`.
+- **Forbidden**: `BLOCKED`, `BEHIND`, `DIRTY`, `UNSTABLE`, `UNKNOWN`. If you see one of these, you have *not* satisfied the rule, regardless of how the `gh pr checks` output reads.
+
+### 2. Read every AI-reviewer comment
+
+The reviewers run by this project (`cubic-dev-ai`, `claude-review`, `coderabbitai`, `copilot`, etc.) post structured findings. Any comment that mentions:
+
+- `P0`, `critical`, `blocker`, `breaking`
+- `compile_error`, `panic`, `unsoundness`
+- `tombstone`, `yanked`, `unmaintained`, `RUSTSEC-*`
+
+…is a **hard merge blocker** until explicitly resolved. "Resolved" means one of:
+- The change has been made on the branch and re-verified.
+- The reviewer is demonstrably wrong (false positive); the rationale is recorded in a reply comment with evidence.
+- The finding is out of scope for the PR; a tracking issue exists, is linked in the PR, and a labeled "ack-out-of-scope" comment from a human maintainer is on the thread.
+
+"It looked OK to me" is not a resolution.
+
+### 3. For ANY dependency PR — verify the actual build
+
+Dependabot, Renovate, and human-authored dep bumps are equally subject to this rule. The presence of `app/dependabot` as the PR author is **not** a green light.
+
+For a **major version bump** (`X.Y.Z` where `X` changes) of any direct dependency:
+
+```bash
+# Either: confirm a CI build job ran on the PR's HEAD SHA
+gh pr checks <PR> | grep -E "Build|build"
+
+# Or: build locally against the bumped lockfile
+git fetch origin pull/<PR>/head:pr-<PR>
+git checkout pr-<PR>
+cargo build --release --features embedded-cpu
+cargo test --no-run
+```
+
+If neither is satisfied, **do not merge**, regardless of what the Dependabot bot wrote, what the diff looks like, or whether a "Dependency Review" workflow reported "No vulnerabilities found". Vulnerability scanners catch known advisories; they do not catch deliberately-broken releases, transitive breakage from MSRV changes, or API renames.
+
+### 4. Check transitive impact on direct dependencies
+
+Even a minor or patch bump can shift the resolved version of a transitive dep that *another* direct dep depends on, breaking the build. Run:
+
+```bash
+cargo tree --duplicates
+```
+
+After the bump, this should show zero new duplicate-version entries among security-critical crates (serde family, tokio, rustls, ring, sha2/sha3, ed25519-dalek, regex, syn, candle-*, safetensors, bincode → postcard, etc.). If a duplicate appears, investigate before merging; if you cannot resolve it, file the issue and do not merge.
+
+### 5. Cross-feature build matrix
+
+For PRs touching `Cargo.toml`, `Cargo.lock`, `build.rs`, or any code under a feature flag, verify all relevant feature gates compile:
+
+```bash
+cargo check --no-default-features
+cargo check --no-default-features --features cve-rules
+cargo check --no-default-features --features embedded-cpu
+cargo check --no-default-features --features knowledge
+cargo check          # default features
+```
+
+A green `cargo check` on default features is **not** sufficient if the change touches any optional/gated code.
+
+---
+
+## What this rule prohibits
+
+- **`gh pr merge --admin`** to bypass failing checks. Admin bypass exists for repository administration emergencies (broken CI configuration, locked-out maintainer, etc.), not for "the change looks fine". Every admin-merge is reviewable in the audit log; the project owner has explicitly committed to reviewing them.
+- **"CI is just flaky" merges.** If a check is known-flaky, the flake is itself a `bug` that must have an open tracking issue. The PR description must link that issue, name the specific check, and state why this PR is unaffected. Otherwise: re-run, wait, fix the flake, or do not merge.
+- **"Re-run until it passes" merges** (`gh run rerun ... && gh pr merge`). Re-running checks to flush out non-determinism is **hiding a bug, not fixing one.** A check that passes on the second try is not a passing check — it is a check whose first failure was uninvestigated.
+- **Dependabot auto-merge with a passing-but-incomplete check set.** If the CI matrix runs ten platforms and only three reported in by merge time, that is not "green CI". Wait.
+- **Stale-base merges.** If `mergeStateStatus` is `BEHIND`, the CI ran on a state that doesn't reflect the actual merged result. Rebase, re-run CI, then re-evaluate.
+
+---
+
+## The "main is already broken" exception (narrow, documented)
+
+When `main` is in a state where new PRs cannot reach green CI because of a *pre-existing* breakage, a hotfix PR may merge with failing checks **if and only if all of the following are true**:
+
+1. **The PR title starts with `fix(...)`** and references the issue tracking the broken state.
+2. **The PR body explicitly lists every failing check**, with one paragraph per check explaining why it cannot pass yet AND linking the follow-up issue that will resolve it.
+3. **The failing checks are demonstrably pre-existing**, not introduced by this PR. Evidence: a CI run on the parent commit (i.e. before this PR's changes) shows the same checks failing.
+4. **A second agent or contributor** has independently confirmed the analysis on the PR thread (not just "LGTM" — they must name the failing checks and confirm the pre-existence claim).
+5. **A short post-mortem issue** is opened concurrently, capturing how `main` reached the broken state and the rule revision (if any) needed to prevent recurrence.
+
+The PR #1154 hotfix that unblocked PR #925's breakage is the worked example. It used this exception narrowly: three commits (bincode pin + rusqlite cast + candle alignment) all required to reach green — none of which could be verified in isolation because the *preceding* failure short-circuited everything.
+
+**This exception is not a license to merge red CI in the general case.** It is a tightly-scoped escape valve for the specific situation where the rule itself created a deadlock.
+
+---
+
+## Enforcement
+
+### Phase 1 — Today (this PR)
+
+- Rule added to `.claude/rules/dependency-upgrade-verification.md` (this file).
+- Indexed in `.claude/rules/constitution.md` Tier 1, immediately after `git-workflow.md`.
+- Quoted in `CONTRIBUTING.md` "Pull Request Process" section.
+- Quoted in `SECURITY.md` "Supply Chain Security" section.
+- Quoted in `.github/PULL_REQUEST_TEMPLATE.md` pre-merge checklist.
+- Quoted in `.github/copilot-instructions.md` for the GitHub Copilot review pass.
+
+### Phase 2 — Follow-up issue (not this PR)
+
+- **GitHub branch protection on `main`**: require the full set of required checks (`Build Check (x86_64-unknown-linux-gnu)`, `Unit Tests (ubuntu-latest)`, `Unit Tests (macos-latest)`, `Lint & Format`, `MSRV Check (Rust 1.85)`, etc.) to pass before merge. No admin bypass. Block force-push.
+- **`cargo-deny` policy file**: lock major-version bumps of security-critical crates behind a manual `cargo-deny check bans` allowlist. Dependabot major-bump PRs that would violate the allowlist will fail CI mechanically, not by reviewer attention.
+
+These mechanical enforcement steps land in their own PRs with their own discussion. The rule above is the human-and-agent-facing layer; the GitHub configuration is the belt-and-suspenders.
+
+---
+
+## What to do if you find yourself rationalizing
+
+Watch for these red flags. They mean **stop and re-read the rule**.
+
+| Thought | Reality |
+|---------|---------|
+| "It's just a patch bump." | Patch bumps have shipped yanked-then-republished tombstones (this happens). |
+| "Dependabot says no vulnerabilities." | Dependency Review catches advisories, not deliberate breakage. |
+| "The diff looks safe." | bincode 3.0's diff was a one-line `lib.rs` you'd never read in a Cargo.toml PR. |
+| "We have great test coverage." | Tests can't run if the crate doesn't compile. |
+| "I'll fix it in a follow-up if it breaks." | The cost to revert a broken `main` is ~24 hours of every contributor's time. The cost to wait for CI is 15 minutes. |
+| "CI has been flaky lately." | Then the flake is the bug to fix, not the gate to bypass. |
+| "I'm an admin, I can just merge." | The admin bit is for emergencies, not convenience. |
+| "This is exactly what Dependabot is for." | Dependabot proposes changes. Humans and agents are responsible for verifying them. |
+| "The other reviewer LGTM'd it." | Did the other reviewer verify CI was green? Did they read every cubic-dev-ai comment? |
+
+---
+
+## Precedent and references
+
+- **PR [#925](https://github.com/wildcard/caro/pull/925)** — `deps: bump bincode from 1.3.3 to 3.0.0`. Merged 2026-05-17 despite `cubic-dev-ai` P0 flag. The originating incident.
+- **Issue [#1150](https://github.com/wildcard/caro/issues/1150)** — `cli: cargo build fails — bincode 3.0.0 has deliberate compile_error! (xkcd/2347)`. Filed by `caro-qa-agent` on 2026-05-18; the regression report.
+- **PR [#1154](https://github.com/wildcard/caro/pull/1154)** — `fix(deps,build): unblock main — bincode pin + rusqlite cast + candle align (closes #1150)`. The hotfix that re-greened `main` after invoking the "main is already broken" exception.
+- **Follow-up PR (bincode → postcard migration)** — replaces bincode entirely, closes the `audit.toml` RUSTSEC-2025-0141 suppression.
+- **[xkcd 2347 "Dependency"](https://xkcd.com/2347/)** — the cartoon bincode 3.0.0 references.
+- **[Shai-Hulud npm worm (2024)](https://blog.npmjs.org/)** — example of an actual supply-chain attack class. The rule's threat model includes both deliberate tombstones (this incident) and malicious supply-chain compromise.
+- **[`external-sdk-integration.md`](./external-sdk-integration.md)** — sibling rule for *adding* new external SDKs; complements this rule which governs *upgrading* existing ones.
+
+---
+
+## Quick reference card (paste into your scratch buffer before any merge)
+
+```
+1. gh pr checks <PR>                        →  zero fail, zero pending in required
+2. gh pr view <PR> --json mergeStateStatus  →  CLEAN or HAS_HOOKS only
+3. Read every AI-reviewer comment           →  zero unresolved P0/blocker/compile_error
+4. For dep PRs: build verified on head SHA  →  CI job OR local cargo build --release
+5. cargo tree --duplicates                  →  no new dup among security-critical crates
+6. Feature-gate matrix all checked          →  no-default-features + each feature
+THEN AND ONLY THEN: gh pr merge
+```
+
+Five minutes. Codified once, so the grep is a checklist instead of a bug report.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,21 @@
+<!--
+🚨 PRE-MERGE CHECKLIST — required by .claude/rules/dependency-upgrade-verification.md (Tier 1)
+DO NOT MERGE this PR until every box below is honestly tickable.
+-->
+
+## Pre-merge checklist (Tier 1 — project safety)
+
+- [ ] `gh pr checks` shows zero `fail` and zero `pending` rows among required checks
+- [ ] `gh pr view --json mergeStateStatus` is `CLEAN` or `HAS_HOOKS` (never `BEHIND`/`BLOCKED`/`DIRTY`/`UNSTABLE`)
+- [ ] Every AI-reviewer comment (`cubic-dev-ai`, `claude-review`, `coderabbitai`, `copilot`, etc.) marked `P0`/`blocker`/`compile_error` is resolved on-thread
+- [ ] **For Dependabot / dependency PRs**: the `Build Check` job has actually run on this PR's head SHA, OR `cargo build --release --features embedded-cpu` was verified locally
+- [ ] **For PRs touching `Cargo.toml` / `Cargo.lock` / `build.rs`**: every feature-gate compiles (`--no-default-features`, `--features cve-rules`, `--features embedded-cpu`, default)
+- [ ] `cargo tree --duplicates` reports no new duplicate-version entries among security-critical crates
+
+This is **non-negotiable**. PR #925 (bincode 3.0 tombstone) → 24h broken `main` is the precedent. See [.claude/rules/dependency-upgrade-verification.md](../.claude/rules/dependency-upgrade-verification.md) for the full rule and the narrow "main is already broken" exception.
+
+---
+
 ## Description
 
 <!-- Provide a clear and concise description of what this PR does -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -257,6 +257,10 @@ When reviewing PRs:
 8. Ensure path/URL formats are consistent within files
 9. Flag code duplication that should be extracted to helpers
 
+### 🚨 CI-Green Merge Rule (Tier 1 — non-negotiable)
+
+**Never approve or merge a PR with failing CI.** This applies to every PR — Dependabot, agent-authored, human-authored. If CI is red, flag it explicitly in the review and request the author resolve before re-requesting review. Do not "approve pending CI"; that phrasing has been the source of `main`-breaking merges in this repository (see PR #925 / #1150). Specifically watch for major dependency bumps where `Build Check` did not actually run on the head SHA. Full rule: [.claude/rules/dependency-upgrade-verification.md](../.claude/rules/dependency-upgrade-verification.md).
+
 ## POSIX Compliance
 
 ### Required Practices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -816,6 +816,22 @@ Your PR will use the template from `.github/PULL_REQUEST_TEMPLATE.md`. Include:
 3. **Address feedback** with additional commits
 4. **Approval and merge** once all checks pass
 
+### 🚨 Merging — CI-Green Rule (Tier 1, non-negotiable)
+
+**No PR may be merged while any required CI check is failing — regardless of who is reviewing, who is merging, what the change is, or how trivial it appears.** This applies equally to Dependabot PRs, agent-authored PRs, and human-authored PRs.
+
+Before invoking `gh pr merge` (or clicking the merge button), every contributor and every agent **must**:
+
+1. Run `gh pr checks <PR>` and confirm zero `fail`/`pending` rows among required checks.
+2. Run `gh pr view <PR> --json mergeStateStatus` and confirm `CLEAN` or `HAS_HOOKS`.
+3. Read every AI-reviewer comment (`cubic-dev-ai`, `claude-review`, `coderabbitai`, `copilot`) and resolve every `P0`/`blocker`/`compile_error` callout on-thread.
+4. **For dependency PRs**: confirm a `Build Check` job has run on the PR's head SHA, OR build locally with `cargo build --release --features embedded-cpu`.
+5. **For Cargo.toml / Cargo.lock / build.rs changes**: verify every feature gate compiles (`--no-default-features`, `--features cve-rules`, `--features embedded-cpu`, default).
+
+**This rule exists because of [PR #925](https://github.com/wildcard/caro/pull/925)**: Dependabot bumped `bincode 1.3.3 → 3.0.0`, an intentional `compile_error!` tombstone release. The AI reviewer `cubic-dev-ai` posted a P0 flag before merge. The PR was merged anyway. `cargo build` was broken on `main` for 24+ hours, blocking every contributor, every CI job, and every `cargo install caro`.
+
+There is a narrow "main is already broken" exception for hotfix PRs that cannot reach green CI because of pre-existing breakage. The full rule and the exception conditions are in [`.claude/rules/dependency-upgrade-verification.md`](.claude/rules/dependency-upgrade-verification.md).
+
 ---
 
 ## Areas for Contribution

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -221,6 +221,51 @@ We do **not** consider the following as security vulnerabilities:
 
 ---
 
+## Supply Chain Security
+
+caro is distributed via `cargo install caro`, `brew install caro`, and pre-built binaries from GitHub Releases. A compromise of any direct or transitive dependency, or a deliberate-tombstone release from a maintainer, can break or actively harm every downstream user. The project treats **unverified dependency merges as a first-class supply-chain attack vector** — equivalent to a malicious commit.
+
+### Threat model
+
+The threat model includes, but is not limited to:
+
+- **Deliberate-tombstone releases** — a maintainer publishes a deliberately-broken version as commentary, protest, or burnout (see [PR #925](https://github.com/wildcard/caro/pull/925), `bincode 3.0.0` referencing [xkcd 2347](https://xkcd.com/2347/)).
+- **Account compromise** — an upstream maintainer's crates.io / npm / PyPI account is taken over and a malicious version is published (Shai-Hulud-class worms have demonstrated this on npm).
+- **Typosquatting** — a similarly-named crate is published with malicious code.
+- **Transitive breakage** — a minor or patch bump of a direct dep silently shifts the resolved version of a transitive dep, breaking the build or introducing a vulnerability.
+- **Yank-then-republish** — a yanked version is republished with malicious content under the same version string.
+
+### Mitigation: the CI-green merge rule
+
+The single most important mitigation is also the cheapest: **no PR is merged while CI is red.** A vulnerability scanner that runs *after* a merge cannot stop a tombstone release from breaking the world; a build that runs *before* the merge can.
+
+The full rule is codified in [`.claude/rules/dependency-upgrade-verification.md`](.claude/rules/dependency-upgrade-verification.md) and mirrored into [`CONTRIBUTING.md`](CONTRIBUTING.md#-merging--ci-green-rule-tier-1-non-negotiable) and the project's [PR template](.github/PULL_REQUEST_TEMPLATE.md). Summary:
+
+1. `gh pr checks` — zero `fail`, zero `pending` among required checks.
+2. `gh pr view --json mergeStateStatus` — `CLEAN` or `HAS_HOOKS` only.
+3. Every AI-reviewer P0/blocker/compile_error callout is resolved on-thread before merge.
+4. Dependency PRs: build verified on the head SHA (CI job or local `cargo build --release --features embedded-cpu`).
+5. Cargo.toml / Cargo.lock / build.rs PRs: every feature-gate compiles.
+
+### Additional layers
+
+- **`cargo audit`** — runs in CI and on every release. RUSTSEC advisories surface as build failures.
+- **`audit.toml`** — every advisory suppression is dated, attributed, and has a documented revert criterion. New suppressions require justification in PR review.
+- **`Cargo.lock` is committed** — for binaries, this is the standard; it prevents transitive drift between contributor builds.
+- **Dependabot grouping** — patch/minor bumps are grouped to reduce review fatigue, but **every group still goes through the CI-green gate**.
+- **External-SDK build-spike rule** — first PR for any new non-trivial SDK is a license/MSRV/feature-flag spike, not an integration. See [`.claude/rules/external-sdk-integration.md`](.claude/rules/external-sdk-integration.md).
+- **Branch protection (planned)** — Phase 2 of the rule's enforcement is GitHub branch protection requiring the full required-check set, with no admin bypass. Tracked separately.
+
+### Reporting a suspected supply-chain incident
+
+If you believe a published version of a caro dependency (direct or transitive) is compromised:
+
+1. **Do not** open a public issue — use the private security advisory flow described above.
+2. Include the crate name, version range, and evidence (e.g. a diff between the suspicious release and the previous one, a `cargo audit` advisory ID, or a reproduction).
+3. We will coordinate with the upstream maintainer or `RustSec/advisory-db` as appropriate.
+
+---
+
 ## Security Best Practices for Users
 
 While using caro:


### PR DESCRIPTION
## Summary

Adds **`.claude/rules/dependency-upgrade-verification.md`** as a new **Tier 1** constitution entry: **"No PR merges while CI is red."** Applies equally to Dependabot, agent-authored, and human-authored PRs.

Companion PR to [#1154](https://github.com/wildcard/caro/pull/1154) (the bincode unblock hotfix) and a follow-up bincode → postcard migration PR.

## Why now

On 2026-05-17, [PR #925](https://github.com/wildcard/caro/pull/925) (`deps: bump bincode from 1.3.3 to 3.0.0`) was merged. \`bincode 3.0.0\` is an intentional tombstone — its entire \`src/lib.rs\` is:

\`\`\`rust
compile_error!("https://xkcd.com/2347/");
\`\`\`

The AI reviewer \`cubic-dev-ai\` had posted **before the merge**:

> **P0**: Pinning \`bincode\` to \`3.0\` breaks the build: \`3.0.0\` is a tombstone release that intentionally emits a compiler error.

It was merged anyway. \`main\` was unbuildable for 24+ hours.

This is a **process bug**, not a Rust bug. The fix is to codify the rule that would have prevented it: every agent and contributor verifies CI is green **on the head SHA** before invoking \`gh pr merge\`. No labels, no human gate — just objective, mechanical CI status.

## What's in this PR (docs only, no code)

| File | Change |
|---|---|
| \`.claude/rules/dependency-upgrade-verification.md\` | **New canonical rule.** ~250 lines: the rule itself, why it exists, the 5-step checklist, what it prohibits, the narrow "main is already broken" exception, enforcement phases, the rationalization red-flags table, and a paste-ready quick-reference card. |
| \`.claude/rules/constitution.md\` | Added as Tier 1 #2 (right after \`git-workflow.md\`). Tier 2 + 3 renumbered. |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | Pre-merge checklist injected at the very top of the template. |
| \`CONTRIBUTING.md\` | New "Merging — CI-Green Rule" subsection in the existing "Pull Request Process" section. |
| \`SECURITY.md\` | New "Supply Chain Security" section with threat model (deliberate tombstones, account compromise, typosquatting, transitive breakage, yank-then-republish) and the CI-green gate as the primary mitigation. |
| \`.github/copilot-instructions.md\` | One-paragraph directive in the existing "Pull Request Guidelines" section. |

## Why CI-objective, not human-label-gated

The user's explicit design choice ([direct quote](https://github.com/wildcard/caro/issues/1150#issuecomment-XXX)):

> *"It's not about the human reviewer. Cargo build release should be tested in the CI. If the CI is green and the CI is passing, that's the only case we can actually merge. Any agent must have the minimal ownership to understand and the responsibility to check before any merge that the CI is passing. It's not about human intervention here. There's no need for a human in the loop here. It's very clear, objective status: Is the CI green? Is it passing? Did the build pass?"*

The rule reflects this: agents and humans run the same 5 commands, get the same objective answer.

## Phase 2 (not in this PR, tracked separately)

- **GitHub branch protection on \`main\`**: require the full required-check set; no admin bypass; no force-push.
- **\`cargo-deny\` ban policy**: lock major-version bumps of security-critical crates behind a manual allowlist so Dependabot major-bump PRs fail CI mechanically if the allowlist isn't updated in the same PR.

These are mechanical enforcement; this PR is the human-and-agent-facing layer.

## Test plan

This PR is docs-only — no code, no Cargo.toml, no build changes. The CI checks that matter for *this* PR are:

- [ ] Markdown linting (if enforced)
- [ ] Link check (every internal link in \`dependency-upgrade-verification.md\` points to a file that exists in this PR or in main)
- [ ] Spell check
- [ ] No-code-changes path: cargo build/test/clippy jobs should pass trivially (no source changed)

**Note:** Until [#1154](https://github.com/wildcard/caro/pull/1154) merges, \`main\` itself is broken (bincode 3.0 tombstone). The CI on *this* PR will inherit that breakage on any \`Build Check\` job. Per this PR's own rule's "main is already broken" exception, this PR should not merge until #1154 merges, at which point this PR's CI will re-run cleanly against the green \`main\`. **Order: merge #1154 first, then this PR.**

## Files

- \`.claude/rules/dependency-upgrade-verification.md\` (new, 250 lines)
- \`.claude/rules/constitution.md\` (Tier 1 addition + renumber)
- \`.github/PULL_REQUEST_TEMPLATE.md\` (top-of-file checklist)
- \`.github/copilot-instructions.md\` (one-paragraph directive)
- \`CONTRIBUTING.md\` (Merging subsection)
- \`SECURITY.md\` (Supply Chain Security section)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tier 1 CI-green merge rule: no PR merges while any required check is failing. This prevents repeats of the `bincode 3.0.0` tombstone incident and applies to humans, agents, and `Dependabot`.

- New Features
  - Adds `.claude/rules/dependency-upgrade-verification.md` as the canonical rule and checklist, including a narrow "main is already broken" exception.
  - Elevates the rule to Tier 1 in `.claude/rules/constitution.md` and renumbers lower tiers.
  - Injects a pre-merge checklist into `.github/PULL_REQUEST_TEMPLATE.md`.
  - Documents the rule and supply-chain rationale in `CONTRIBUTING.md` and `SECURITY.md`; adds a reviewer note in `.github/copilot-instructions.md`.
  - Notes Phase 2 enforcement (branch protection on `main`, `cargo-deny` bans) to be done in follow-up PRs.

- Migration
  - Merge the unblock hotfix (#1154) first; this PR should only merge once `main` is green.

<sup>Written for commit b7b0dd708598414bae34ed34fb3a3380d7cec53f. Summary will update on new commits. <a href="https://cubic.dev/pr/wildcard/caro/pull/1157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

