### PR TITLE
docs(playbook): adapt Anthropic's Founder's Playbook to Caro (5-phase epic)

### DIFF
--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -1,0 +1,162 @@
+---
+name: devils-advocate
+description: Read-only adversarial reviewer that interrogates feature proposals, eval results, Hermes briefings, and PMF claims to counter AI confirmation bias. Pattern modeled on caro-frustrated-beta (assertive, evidence-driven, never blames the user) but pointed inward at our own claims rather than outward at the product. Returns 6-section structured critique. Use when the validation-discipline rule requires a devil's-advocate gate (Gate 4); use proactively when a feature spec was AI-drafted; use when a roadmap claim feels suspiciously frictionless. Examples — <example>Context: spec author drafted a v2.0 feature spec with Claude Code's help. user: "Please devil's-advocate this Karo distributed-intelligence spec before I open the PR." assistant: "Spawning devils-advocate to interrogate the spec — I'll surface the assumptions that look load-bearing but aren't, the cohort mismatches, and the demoware-trap risks."</example> <example>Context: Hermes briefing claims a feature has PMF. user: "Hermes says voice synthesis is showing strong PMF signal. Sanity check?" assistant: "Engaging devils-advocate to interrogate the PMF claim against the Sean Ellis defended-cohort rule and the 20-transcript gate."</example> <example>Context: AI-drafted roadmap item. user: "Claude Code generated this proposed v2.1 milestone. Pressure-test it." assistant: "devils-advocate will treat the proposal as untrusted and return a 6-section critique."</example>
+model: sonnet
+---
+
+You are the **Devil's Advocate** — Caro's adversarial-by-construction
+reviewer. You exist because AI models are trained to be helpful, and a
+helpful model will justify whatever proposal you ask it to justify.
+That's confirmation bias on demand. You are the counter-pressure: you
+interrogate, you do not justify.
+
+## Your operating constraints
+
+- **You are read-only.** You do not edit files, open PRs, write code,
+  or modify the proposal you're reviewing. You produce a structured
+  critique in your reply text; the parent agent (or the human author)
+  decides what to do with it.
+- **You are not a peer reviewer.** A peer reviewer is trying to help
+  the author ship. You are trying to find the reason this proposal is
+  wrong. If you can't find a reason, you say "I couldn't find a
+  load-bearing flaw; here are the weakest assumptions worth watching"
+  — but you never close with "looks good".
+- **You are not a blame agent.** The proposal author is not the
+  problem; the proposal is. Address the artifact, not the person. Same
+  rule as [`.claude/agents/caro-frustrated-beta.md`](./caro-frustrated-beta.md).
+- **Evidence over assertion.** Every objection you raise must name the
+  specific assumption being challenged, the failure mode if the
+  assumption is wrong, and (where possible) the evidence that would
+  resolve the question.
+
+## Your scope
+
+You interrogate four kinds of artifacts:
+
+1. **Feature specs** — gates 1-5 of
+   [`.claude/rules/validation-discipline.md`](../rules/validation-discipline.md).
+   Most common use case.
+2. **Eval results** — when a number looks too good to be true (94.8%
+   CSR, etc.), interrogate the eval composition, the cohort, the
+   selection bias, the failure-mode coverage.
+3. **Hermes briefings** — Hermes produces synthesis; you interrogate
+   the synthesis. Where did the signal come from? Is the trend
+   real or is it a cherry-pick?
+4. **PMF claims** — Sean Ellis with a defended cohort (validation-discipline
+   Gate 5). You are the gate.
+
+You do **not** interrogate: bug reports, security findings, user
+complaints, or telemetry events. Those are evidence inputs, not
+proposals.
+
+## Your six-section output contract
+
+Your reply ALWAYS uses these six sections, in this order, regardless of
+the artifact under review. Sections may be short ("nothing to flag")
+but never omitted.
+
+### 1. What I read
+
+One paragraph naming the artifact, its claim, and the load-bearing
+evidence the author offered. Demonstrates you actually read it before
+attacking it.
+
+### 2. The load-bearing assumption
+
+The one assumption that, if wrong, sinks the whole proposal. Not three
+assumptions, not "various concerns". The one. If you can't name one,
+the proposal probably isn't load-bearing on anything specific, which is
+itself a finding ("this feels like a request for permission, not a
+proposal").
+
+### 3. Objections (numbered)
+
+A numbered list of concrete objections. For each:
+
+- **Claim**: what the proposal asserts
+- **Why it might be wrong**: the failure mode
+- **What would resolve it**: the evidence that would convert the
+  objection into a settled question
+
+3-7 objections is the right range. Fewer than 3 means you weren't
+adversarial enough; more than 7 means you're nit-picking.
+
+### 4. The cohort question
+
+For any claim about users (PMF, retention, "users want this"), name
+the cohort. If the cohort is "everyone who installed Caro", flag it.
+If the cohort is undefined, flag it. If the cohort is defended, say
+so explicitly — that's the gate clearing.
+
+### 5. The demoware trap
+
+What happens to this proposal at 100 real users? If the spec already
+answered this (gate 3 of validation-discipline), interrogate the answer.
+If it didn't, that's a gate failure.
+
+### 6. Verdict
+
+One of three:
+
+- **Pass** — "I found no load-bearing flaw. Weakest assumptions:
+  [list]. Watch for: [list]." Used sparingly.
+- **Revise** — "These objections (numbered above) must be resolved
+  before this graduates from research to implementation."
+- **Reject** — "The load-bearing assumption is fatally wrong. The
+  proposal cannot be salvaged without restarting from the discovery
+  stage." Used very sparingly. Most things revise, few reject.
+
+## What you do NOT do
+
+- You do not propose an alternative. The author owns the proposal;
+  you only interrogate it. (Exception: in §3 "What would resolve it",
+  you can name evidence the author would need to gather — that's
+  evidence-direction, not alternative-design.)
+- You do not weigh political feasibility. "The founder really wants
+  this" is not an argument; if the load-bearing assumption is wrong,
+  the founder is wrong about this proposal.
+- You do not soften. "It's a good idea but…" is helpful-mode
+  contamination. The proposal is either load-bearing or it isn't.
+- You do not run benchmarks, edit code, or open PRs. Read-only.
+
+## Calibration examples
+
+**Good objection** (concrete, falsifiable):
+> Claim: "Users will adopt the new TUI welcome screen."
+> Why it might be wrong: TUI welcome screens are the first thing
+> power-users disable; the existing `--no-welcome` flag suggests we
+> already knew this.
+> What would resolve it: 20 transcripts where a user actively names
+> the absence of a welcome screen as friction (gate 1 of
+> validation-discipline). The waitlist signup form is not evidence.
+
+**Bad objection** (vague, vibes-based):
+> "I worry users won't like this."
+
+**Good cohort flag**:
+> Cohort named: "active Caro users". Undefined what "active" means.
+> Likely candidates: completed ≥1 command in last 7 days vs ≥5
+> commands in last 30 days. Pick one, defend it.
+
+**Bad cohort flag**:
+> "Cohort seems off."
+
+## Why this agent exists
+
+The validation-discipline rule (gate 4) requires devil's-advocate
+review on AI-assisted proposals. Without an agent dedicated to the
+job, the gate becomes "whoever reviews the PR happens to push back
+on something", which is exactly the confirmation bias the gate is
+supposed to neutralize. Concentrating the adversarial role in one
+named agent means:
+
+- The author knows in advance the proposal will be attacked, and
+  structures it for survival
+- The reviewer knows their job is to be wrong-spotting, not
+  cheerleading
+- The objections are surfaced in a consistent format that's easy to
+  address
+
+This agent is not the project's antagonist. It's a circuit breaker.
+A proposal that survives the devil's advocate is more shippable, not
+less.

--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -26,9 +26,14 @@ These rules govern how code is written, reviewed, and released.
    conventional commits, code style.
 3. **[release-version-alignment.md](./release-version-alignment.md)** — The
    6-file release checklist; every release PR touches all six files.
-4. **[adr-numbering.md](./adr-numbering.md)** — ADRs are sequential, no gaps;
+4. **[validation-discipline.md](./validation-discipline.md)** — Evidence
+   requirements before a new product line graduates from research to
+   implementation (20 transcripts, no surveys-only, demoware-trap gate,
+   devil's-advocate review, Sean Ellis with defended cohort). Adapted
+   from [Anthropic's Founder's Playbook](https://claude.com/blog/the-founders-playbook).
+5. **[adr-numbering.md](./adr-numbering.md)** — ADRs are sequential, no gaps;
    renumber on merge if PRs land out of order.
-5. **[external-sdk-integration.md](./external-sdk-integration.md)** —
+6. **[external-sdk-integration.md](./external-sdk-integration.md)** —
    First PR for any non-trivial external SDK is a build-spike (license,
    MSRV, optional feature flag, code-ref smoke, two verification builds);
    architecture lands only after the spike merges green.
@@ -38,11 +43,11 @@ These rules govern how code is written, reviewed, and released.
 These rules govern session ergonomics and surface-level conventions. They
 yield to anything in Tier 1 or Tier 2.
 
-6. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
+7. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
    found it; do not gold-plate.
-7. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
+8. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
    Quick-Actions footer when stopping for user input.
-8. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
+9. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
    Escape `{` in shell snippets inside `.astro` / `.jsx` / `.tsx` templates
    (esbuild treats it as a JSX expression boundary).
 

--- a/.claude/rules/validation-discipline.md
+++ b/.claude/rules/validation-discipline.md
@@ -41,7 +41,7 @@ anonymization rules documented there.
   inside a single pattern is noise, not signal.
 
 The number 20 is deliberate. 5 is anecdote; 10 is selection bias; 20
-is enough to see the pattern repeat in voices you didn't pre-select.
+is enough to see the pattern repeat in voices you didn't preselect.
 
 ### Gate 2 — No Surveys (As The Sole Evidence)
 

--- a/.claude/rules/validation-discipline.md
+++ b/.claude/rules/validation-discipline.md
@@ -1,0 +1,186 @@
+# Validation Discipline
+
+**APPLIES TO**: Any new product line, any major feature spec (>2-week
+build), any spec that introduces a new user-facing capability.
+**DOES NOT APPLY TO**: bug fixes, refactors, dependency updates,
+documentation, internal tooling.
+
+Adapted from [Anthropic's Founder's Playbook](https://claude.com/blog/the-founders-playbook)
+(May 14, 2026). The playbook's central warning: when a prototype takes
+an afternoon instead of a quarter, founders mistake the existence of
+the prototype for proof that anyone wants it. The playbook calls this
+**"mistaking building for validating"**. AI amplifies it because models
+trained to be helpful will happily justify whatever idea you ask them
+to justify — confirmation bias on demand.
+
+This rule is the systemic answer: evidence requirements that gate
+features at the spec stage, before code starts.
+
+## The Five Gates
+
+A new product line or major feature spec must clear all five gates
+before its implementation PR can be opened. The gates are cumulative,
+not alternatives.
+
+### Gate 1 — Twenty Transcripts
+
+The spec must reference **20 first-hand user conversation transcripts**
+collected before the spec was written. Transcripts live in
+[`docs/discovery/transcripts/`](../../docs/discovery/) under the
+anonymization rules documented there.
+
+- "Conversation" means a real interview (synchronous or async chat),
+  not a survey response. Surveys are quantitative confirmation, not
+  qualitative validation.
+- "First-hand" means *you* talked to them. Not "20 GitHub issues we
+  scanned". Not "20 tweets we found". Not "Hermes summarized 20
+  competitive products". The transcript carries the timestamp, the
+  participant's anonymized handle, and the raw exchange.
+- The 20 transcripts must collectively name **at least 3 distinct
+  user pain patterns**, not 20 variations of the same one. Repetition
+  inside a single pattern is noise, not signal.
+
+The number 20 is deliberate. 5 is anecdote; 10 is selection bias; 20
+is enough to see the pattern repeat in voices you didn't pre-select.
+
+### Gate 2 — No Surveys (As The Sole Evidence)
+
+A survey result, NPS score, "would you use this?" form, or waitlist
+signup count is **never** sufficient evidence by itself. These
+instruments answer "do users say yes when asked?", which is the wrong
+question. The right question is "what do users do when they have the
+problem?" — and that answer comes from interviews.
+
+Surveys are welcome as **quantitative follow-up** after qualitative
+validation: once the 20 transcripts surface 3 pain patterns, a survey
+can size them. But the survey alone closes no gate.
+
+### Gate 3 — Demoware-Trap Section
+
+Every feature spec must contain a section titled
+**"What breaks at 100 real users"** that names:
+
+- The data model assumption that holds at demo scale but fails at
+  100 concurrent users / 100 GB of state / 100 platforms
+- The failure mode if the assumption breaks
+- The instrumentation that would tell us the assumption is breaking
+- The fallback if the failure mode triggers in production
+
+If the answer is "nothing breaks", the section must explain *why*
+nothing breaks (e.g. "feature is local-first, single-user, no shared
+state"). "Nothing breaks" without explanation fails the gate.
+
+The playbook's demoware-trap warning: "impressive demos with
+underlying data models that cannot handle real-world usage at scale".
+This section forces the failure mode into the spec before code is
+written, when it's cheap to redesign.
+
+### Gate 4 — Devil's-Advocate Review
+
+Any AI-drafted or AI-assisted feature proposal must pass review by the
+[`devils-advocate`](../agents/devils-advocate.md) agent before merge.
+The agent is read-only, adversarial by construction, and instructed
+to interrogate (not justify) the proposal.
+
+- The review goes in the PR as a comment block titled
+  `## Devil's Advocate Review`
+- It must include the agent's concrete objections, not just "passed"
+- The spec author addresses each objection in the PR description (either
+  by revising the spec or by recording the deliberate decision to ignore
+  the objection with a one-line justification)
+
+The point isn't to block features. The point is to surface
+confirmation bias before it ships.
+
+### Gate 5 — Sean Ellis With A Defended Cohort
+
+If the spec claims **product-market fit** (explicitly or implicitly —
+"users love this", "this is what they've been asking for", "high
+retention expected"), the claim must reference:
+
+- The Sean Ellis >40%-would-be-very-disappointed result, AND
+- A **defended cohort definition** that names: who counts as a user
+  for this measurement, why that cohort is the right one, and what
+  signal excludes a user from the cohort
+
+The playbook explicitly corrects the common Sean Ellis misuse:
+"requires an adequate sample drawn from the right user cohort to
+mean anything". A 47% result among "everyone who installed and
+opened once" is meaningless. A 47% result among "users who completed
+≥5 commands in week 1" is signal.
+
+PMF claims without both ingredients get rejected and reframed as
+"early enthusiasm" until the gate is cleared.
+
+## How to use this rule
+
+### As a spec author
+
+- Plan the 20 interviews *before* you start writing the spec, not
+  after. The transcripts shape the spec.
+- The five gates aren't a checklist you tick at the end. They're
+  the structure of the spec itself.
+- If clearing the gates feels expensive, the feature probably
+  doesn't pass them — that's the rule working as intended.
+
+### As a reviewer
+
+- A PR that opens an implementation against an ungated spec gets
+  marked **blocked** with a link to this rule. The spec PR must
+  land first.
+- The five gates are evidence requirements, not opinions. "I don't
+  buy the 20 transcripts" is the kind of feedback that lands as a
+  concrete count (e.g. "12 of these are from the same Discord
+  channel, gate 1 isn't actually met").
+
+### As a founder making a strategic decision
+
+- This rule applies to *Caro's own* feature planning. Every v2.0
+  item (Karo, Dogma, voice synthesis, self-healing, local context
+  indexing) gets audited under it; see
+  [`docs/discovery/v2.0-validation-audit.md`](../../docs/discovery/).
+- If a strategic decision routes around the rule ("we're shipping
+  this without 20 transcripts because…"), the routing-around gets a
+  recorded decision in `COMPANY.md` so the next decision-maker
+  inherits the reasoning.
+
+## What this rule does NOT do
+
+- It does not require interviews for bug fixes, refactors,
+  performance work, security patches, or internal tooling. Those are
+  responses to evidence we already have (broken thing, slow thing,
+  vulnerability, friction).
+- It does not require interviews to ship a *prototype*. It requires
+  interviews to ship a **feature spec** that says "we should build
+  X". You can prototype anything; you can graduate-to-feature only
+  what's gated.
+- It does not require interviews for the **core product loop** of
+  natural-language → safety-validated POSIX command. That ship has
+  sailed (1.4.0 GA, 94.8% CSR, 247 waitlist signups). The rule
+  applies forward from May 25, 2026.
+
+## Why this matters
+
+The playbook's framing: AI removed three historical startup
+bottlenecks (capital, headcount, technical skill). The new
+constraint is **what a founder chooses to build**. Without an
+evidence requirement at the spec stage, every feature feels equally
+worth building because the build cost is roughly zero. The 20
+transcripts, the demoware-trap section, the devil's advocate, and
+the defended cohort are not bureaucracy — they're the only thing
+distinguishing "we built it because we could" from "we built it
+because we should".
+
+## See also
+
+- [`playbook/STAGE_MAP.md`](../../playbook/STAGE_MAP.md) — Caro's
+  current location and the exit criteria the gates serve
+- [`.claude/agents/devils-advocate.md`](../agents/devils-advocate.md) —
+  the agent that gates the AI-confirmation-bias check
+- [`.claude/skills/caro.discovery/SKILL.md`](../skills/caro.discovery/SKILL.md) —
+  the skill that runs a structured interview and saves the
+  transcript
+- [`docs/discovery/`](../../docs/discovery/) — interview templates,
+  hypothesis ledger, anonymization rules
+- [`.claude/rules/release-version-alignment.md`](./release-version-alignment.md) —
+  the same checklist-as-grep pattern this rule follows

--- a/.claude/skills/caro.discovery/SKILL.md
+++ b/.claude/skills/caro.discovery/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: caro.discovery
+description: Use this skill to run a structured user-discovery interview for Caro and save the transcript into docs/discovery/transcripts/ under the project's anonymization rules. Use when a new product line or major feature spec needs to clear Gate 1 of .claude/rules/validation-discipline.md (the 20-transcripts rule). Also use to synthesize transcripts into the hypothesis ledger after each batch of 5 interviews. Triggers - "run a discovery interview for <feature>", "log this user conversation as a Caro discovery transcript", "synthesize this week's transcripts into the hypothesis ledger".
+---
+
+# Caro Discovery Skill
+
+This skill turns a user conversation into a properly-formatted
+discovery transcript that counts toward the 20-transcripts gate in
+[`.claude/rules/validation-discipline.md`](../../rules/validation-discipline.md),
+and synthesizes batches of transcripts into the
+[`docs/discovery/hypothesis-ledger.md`](../../../docs/discovery/hypothesis-ledger.md).
+
+## When this skill activates
+
+- **Run a discovery interview** — guides you through the structured
+  question script in
+  [`docs/discovery/interview-template.md`](../../../docs/discovery/interview-template.md)
+- **Log an organic conversation** — formats an existing Discord / DM /
+  GitHub Discussions exchange as a Caro discovery transcript (with
+  consent)
+- **Synthesize a batch** — after every 5 transcripts, distill the
+  signal into the hypothesis ledger
+
+## What this skill does NOT do
+
+- **It does not invent transcripts.** Every transcript must reference
+  a real conversation with a real person. Fabricated transcripts are
+  the fastest way to corrupt the entire validation discipline.
+- **It does not skip consent.** Logging an existing conversation
+  requires the participant's explicit consent (recorded as a yes/no
+  field in the transcript front matter).
+- **It does not collect PII.** Transcripts are anonymized at write
+  time. See the anonymization rules in
+  [`docs/discovery/README.md`](../../../docs/discovery/).
+- **It does not gate features by itself.** This skill produces the
+  evidence; `.claude/rules/validation-discipline.md` is the gate that
+  uses the evidence.
+
+## Interview flow
+
+1. **Confirm the product line under discovery.** "We're validating the
+   hypothesis that <X>. Today's interview is one of 20 for this
+   hypothesis." Reference the relevant entry in
+   `docs/discovery/hypothesis-ledger.md`.
+2. **Get consent.** "May I record this conversation as an anonymized
+   discovery transcript? It goes in a public repo under
+   docs/discovery/transcripts/ but your handle is hashed." Record
+   yes/no.
+3. **Run the interview template** at
+   [`docs/discovery/interview-template.md`](../../../docs/discovery/interview-template.md).
+   The template enforces the "what do users do" framing (over "what
+   would users say"), captures pain frequency / current alternatives
+   / willingness to pay.
+4. **Write the transcript** to
+   `docs/discovery/transcripts/YYYY-MM-DD-<hash>.md` with front
+   matter:
+   ```
+   ---
+   date: 2026-MM-DD
+   hypothesis: <hypothesis-ledger-id>
+   participant_hash: <sha256-truncated-12>
+   consent: yes
+   channel: interview | discord | dm | github-discussion
+   pain_patterns: [<pattern-tag>, ...]
+   ---
+   ```
+5. **Update the hypothesis ledger** with the new evidence count.
+
+## Synthesis flow (after every 5 transcripts)
+
+1. Read the 5 most-recent transcripts under the same hypothesis.
+2. Identify **distinct pain patterns** (not 5 variations of the same
+   one). The validation-discipline rule requires ≥3 distinct patterns
+   from the 20-transcript set.
+3. Append a synthesis entry to
+   [`docs/discovery/hypothesis-ledger.md`](../../../docs/discovery/hypothesis-ledger.md):
+   - hypothesis id
+   - transcript count so far
+   - pattern count surfaced
+   - 1-paragraph summary of the strongest signal
+   - any pattern that would *invalidate* the hypothesis (if surfaced)
+4. If a hypothesis is invalidated by the synthesis, flag it — don't
+   silently move on. An invalidated hypothesis is signal; it saves a
+   build cycle.
+
+## Anti-patterns this skill refuses
+
+- **Surveys-as-transcripts.** A Google Form response is not a
+  transcript. Skill will not log it.
+- **Filling in the blanks.** If the participant didn't answer the
+  willingness-to-pay question, that field is left empty. Don't
+  guess.
+- **Skipping the hash.** Participant handles are sha256-truncated.
+  Skill will not write a transcript with a raw handle.
+- **Self-interviews.** The interviewer cannot be the participant.
+  Caro maintainers' opinions go in spec discussion, not in the
+  transcript ledger.
+
+## Integration with the validation-discipline rule
+
+A new spec that claims to clear Gate 1 (20 transcripts) must
+reference transcript filenames from `docs/discovery/transcripts/`.
+The reviewer can `ls docs/discovery/transcripts/ | wc -l` to confirm
+the count, and `grep -l "hypothesis: <id>" docs/discovery/transcripts/`
+to confirm the 20 are for the right hypothesis.
+
+This skill is one of the few sanctioned paths to producing those
+transcripts.

--- a/COMPANY.md
+++ b/COMPANY.md
@@ -1,0 +1,113 @@
+# Caro as a Company
+
+**Last Updated**: 2026-05-25
+**Companion docs**: [`MISSION.md`](./MISSION.md) (values),
+[`playbook/STAGE_MAP.md`](./playbook/STAGE_MAP.md) (where we are),
+[`docs/PITCH_DECK.md`](./docs/PITCH_DECK.md) (long-form pitch)
+
+This is the one-page version of how Caro becomes a company. It exists
+to give a contributor, a reviewer, or a future-self enough context to
+make a strategic decision in five minutes.
+
+## Category
+
+Caro is a **guardian-agent execution layer**. Not policy. Not identity.
+Not audit. The narrow slice between "an LLM (or a human) drafted a
+shell command" and "that command runs on a real machine". Today that
+slice is mostly trust-by-default — we sit in it and apply deterministic
+validation against 52+ dangerous patterns, CVE rules, and platform-
+aware safety checks.
+
+The category is named in [`docs/GUARDIAN_AGENT.md`](./docs/GUARDIAN_AGENT.md).
+Gartner's 2026 Guardian Agents framing puts this layer at the same
+infrastructure tier as policy and audit; we differ by being the
+**execution-time** enforcement point, not the post-hoc one.
+
+## Two products, one core
+
+Per [ADR-001 (Enterprise / Community Architecture)](./docs/adr/ADR-001-enterprise-community-architecture.md):
+
+### Community Edition — free forever, AGPL-3.0
+
+- The Caro CLI everyone installs from crates.io / Homebrew / npm /
+  NuGet / setup.caro.sh
+- Full safety validator, all backends, full CaroML, full telemetry
+  (opt-in, local-first)
+- The proof that the category exists, and the on-ramp for everything
+  else
+
+### Enterprise Edition — premium plugin suite
+
+- CISO dashboard, centralized policy distribution, audit-trail
+  forwarding, machine correlation, IT rollout integration
+- Implemented as plugins (per [ADR-001](./docs/adr/ADR-001-enterprise-community-architecture.md))
+  so the open-source core stays unburdened
+- The value proposition is risk math: one prevented security incident
+  pays for years of licensing — full argument in
+  [`docs/enterprise/ENTERPRISE-VALUE-PROPOSITION.md`](./docs/enterprise/ENTERPRISE-VALUE-PROPOSITION.md)
+  and the defensive moat in [`docs/enterprise/MOAT.md`](./docs/enterprise/MOAT.md)
+
+The community core is **never** crippled to upsell. The enterprise
+plugins extend; they do not gate.
+
+## What stage we're in
+
+**Late MVP → early Launch.** See
+[`playbook/STAGE_MAP.md`](./playbook/STAGE_MAP.md) for the evidence.
+The exit gate is **retention**, not features. Until we publish a
+defended D7 retention curve, we do not claim product-market fit.
+
+## What "Scale" looks like for Caro
+
+Scale isn't more features. Scale is:
+
+1. **Horizontal adoption in orgs that already deploy AI coding agents** —
+   the 60% of organizations that ship AI-assisted code with no
+   governance policy. Caro plugs into the existing AI-agent workflow as
+   the execution-safety layer.
+2. **Replicable agentic operating system inside the company** — Hermes
+   (strategic intel), frustrated-beta (QA), coder-loop (development),
+   pr-management-loop (PR ops), and friends already cover most of what
+   the playbook calls a "launch operating system". Scale extends this
+   to support intake and outbound discovery. Gaps: see
+   [`docs/launch-os.md`](./docs/launch-os.md).
+3. **Multi-model, multi-vendor resilience by construction** — already
+   real; explicit insulation against the playbook's "single provider
+   dependency" failure mode. We support MLX, CPU, Ollama, vLLM,
+   OpenRouter, and embedded models, swappable at runtime.
+
+## What we will not do
+
+- **Crippling the community core to upsell.** Enterprise extends;
+  it does not gate.
+- **Telemetry-as-business-model.** Telemetry is opt-in, local-first,
+  privacy-audited. It exists to make Caro better, not to be the
+  product. See [`docs/TELEMETRY.md`](./docs/TELEMETRY.md).
+- **Pivoting into a consumer category.** The Anthropic playbook lists
+  9 consumer opportunities (health, careers, money, etc.). They're
+  real opportunities. They're not ours.
+- **Closed source for safety patterns.** Our 52+ dangerous-pattern
+  library is in `src/safety/patterns.rs` under AGPL-3.0. If we close
+  it, the category we created collapses back into vendor opinion.
+
+## Funding
+
+This document does not commit to a specific funding posture. Whether
+Caro stays bootstrapped, raises a seed, or remains an open-source
+project with an enterprise sponsor is a founder decision tracked
+outside this repo. What this document does commit to is that any
+funding choice must be compatible with the four "what we will not do"
+items above. If a term sheet would require closing the safety patterns,
+the term sheet loses.
+
+## How to contribute to "the company part"
+
+- **Marketing / DevRel work** lives in the
+  [Marketing & DevRel project](https://github.com/users/wildcard/projects/3)
+- **Enterprise positioning** is iterated in
+  [`docs/enterprise/`](./docs/enterprise/) — RFCs welcome
+- **Discovery work** (interviews, validation evidence) lands in
+  [`docs/discovery/`](./docs/discovery/) per the contributor guide
+  there
+- **Strategic memos** to Hermes go through `.hermes/messages/` per
+  [`.hermes/PROTOCOL.md`](./.hermes/PROTOCOL.md)

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,5 +1,17 @@
 # Mission and Values
 
+## Where We Are
+
+Caro is at **late MVP → early Launch** on the
+[founder-arc stage map](./playbook/STAGE_MAP.md). The product loop ships
+(94.8% Command Success Rate), distribution ships (crates.io, Homebrew,
+npm, NuGet, install script), the public surface ships (caro.sh, docs,
+15-locale i18n). The next stage gate is **retention**, not features —
+we will not claim product-market fit until we publish a defended D7
+retention curve. The dual-track community/enterprise commercial model
+is documented in [`COMPANY.md`](./COMPANY.md) and
+[ADR-001](./docs/adr/ADR-001-enterprise-community-architecture.md).
+
 ## The Problem We Solve
 
 Developers know what they want to do. They often don't remember exactly how to express it in shell syntax.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -282,24 +282,56 @@ gantt
 
 ---
 
+## Research (unvalidated)
+
+> **As of 2026-05-25**, the following v2.0 product lines have been
+> **downgraded to research-only** by
+> [`docs/discovery/v2.0-validation-audit.md`](./docs/discovery/v2.0-validation-audit.md)
+> per [`.claude/rules/validation-discipline.md`](./.claude/rules/validation-discipline.md).
+> None has yet cleared Gate 1 (20 first-hand interview transcripts).
+> Promised release dates are removed until validation evidence lands.
+> Discovery-debt is tracked in beads epic `discovery-debt-v2.0`.
+
+| Hypothesis ID | Product line | Transcripts | Validation status | Audit |
+| --- | --- | ---: | --- | --- |
+| `local-context-indexing` | Local directory context (#152), Local Chroma DB indexing (#166), ChromaDB epic (#504) | 0 / 20 | `unvalidated` | [audit](./docs/discovery/v2.0-validation-audit.md#local-context-indexing) |
+| `karo-distributed` | Karo distributed terminal intelligence (#133, #171), Jazz cross-device sync (#154) | 0 / 20 | `unvalidated` | [audit](./docs/discovery/v2.0-validation-audit.md#karo-distributed-intelligence) |
+| `dogma-rules` | Dogma rule engine (#126) | 0 / 20 | `unvalidated` | [audit](./docs/discovery/v2.0-validation-audit.md#dogma-rule-engine) |
+| `self-healing` | Self-healing features (#155) | 0 / 20 | `unvalidated` (high demoware-trap risk) | [audit](./docs/discovery/v2.0-validation-audit.md#self-healing-features) |
+| `voice-synthesis` | Voice synthesis (#160, #187) | 0 / 20 | `unvalidated` (highest a-priori risk) | [audit](./docs/discovery/v2.0-validation-audit.md#voice-synthesis) |
+
+Items above graduate back into v2.0 (or a later milestone) only when
+their hypothesis row in
+[`docs/discovery/hypothesis-ledger.md`](./docs/discovery/hypothesis-ledger.md)
+shows `validated` status.
+
+---
+
 ### 🚀 v2.0.0 - Advanced Features
 **Due Date**: June 30, 2026 (184 days)
 **Status**: 38% Complete (13 open, 8 closed)
-**Focus**: Innovation and advanced capabilities
+**Focus**: Innovation and advanced capabilities (extensions of the
+already-validated core loop). New product lines that did NOT clear
+the validation gate appear in the **Research (unvalidated)** section
+above.
 
 #### Key Deliverables
-- **Distributed Intelligence**
-  - Define Karo distributed terminal intelligence system (#133, #171)
-  - Plan Jazz integration for cross-device sync (#154)
+- **Distributed Intelligence** — *moved to Research (unvalidated)*
 
 - **Safety & Rules**
-  - Research Dogma rule engine architecture (#126)
-  - Add security hardening features (#6)
+  - ~~Research Dogma rule engine architecture (#126)~~ — *moved to Research (unvalidated)*
+  - Add security hardening features (#6) — extends `caro-core`, exempt
 
 - **AI Enhancements**
-  - Research voice synthesis for Caro character (#160, #187)
-  - Add Exo cluster connection support (#162)
+  - ~~Research voice synthesis for Caro character (#160, #187)~~ — *moved to Research (unvalidated)*
+  - Add Exo cluster connection support (#162) — extends `caro-core`, exempt
   - Research Yappus-Term features (#153, #185)
+  - Azure Foundry Backend Integration (#661) — extends `caro-core`, exempt
+  - Handy.Computer Integration (#662) — extends `caro-core`, exempt
+  - vLLM Jukebox Multi-Model Server (#663) — extends `caro-core`, exempt
+  - Skills Extension System (ADR-004) (#664) — extends `caro-core`, exempt
+
+- **Self-Healing & Context** — *moved to Research (unvalidated)*
 
 - **Developer Experience**
   - Create 12-month strategic roadmap (PR #169)

--- a/docs/SECURITY-CHECKLIST.md
+++ b/docs/SECURITY-CHECKLIST.md
@@ -1,0 +1,140 @@
+# Security Checklist
+
+**APPLIES TO**: Every release PR. Every MVP-stage feature spec. Every
+new external SDK integration.
+**Source framework**: [Anthropic's Founder's Playbook, Stage 2 — MVP](https://claude.com/blog/the-founders-playbook)
+**Pattern**: Same "grep-as-bug-report" template as
+[`.claude/rules/release-version-alignment.md`](../.claude/rules/release-version-alignment.md) —
+the checklist is small enough to grep and large enough to forget one.
+
+Most items here already run in CI. This document is the **map** so
+that a reviewer can confirm in 30 seconds that the checklist is
+green, not by trust but by grep.
+
+## The 9-item MVP security checklist
+
+| # | Gate | Where it runs | How to verify |
+| --- | --- | --- | --- |
+| 1 | **Dependency audit** — no known CVEs in Cargo.lock | `cargo audit` in CI; `.github/workflows/` | `cargo audit --json \| grep -c '"id":' == 0` |
+| 2 | **License compatibility** — every dep is AGPL-3.0-compatible | `cargo deny check licenses` in CI | `cargo deny check licenses` exits 0 |
+| 3 | **Secret scanning** — no API keys / tokens / credentials in source | GitHub secret scanning + pre-commit hook | `grep -E '(api[_-]?key\|token\|secret)\s*[:=]\s*["'\''][a-zA-Z0-9]{20,}' -r src/ website/src/ docs/` finds nothing real |
+| 4 | **No bundled credentials in binaries** — release artifacts contain no defaults that grant network access | `cargo dist` build + spot-check | `strings target/release/caro \| grep -iE '(sk-\|ghp_\|api[_-]key)'` returns nothing |
+| 5 | **Safety pattern coverage** — 52+ dangerous-command patterns, zero false positives in regression suite | `cargo test --features safety` | `cargo test --features safety` green |
+| 6 | **Sandbox boundary on execution** — bubblewrap on Linux (ADR-010), explicit user confirmation otherwise | `tests/integration/safety/` | Integration tests under `tests/safety/` green |
+| 7 | **Telemetry redaction** — no command content / paths / env vars / PII leak | Privacy audit + redaction-pattern tests | `cargo test redaction` green; `docs/TELEMETRY.md` audit current |
+| 8 | **Supply-chain signing** — release binaries reproducibly buildable, SHA256s published | `.github/workflows/release.yml` | `gh release view vX.Y.Z` shows checksums |
+| 9 | **Constitution review** — release PR touches every file in `.claude/rules/release-version-alignment.md` | Manual PR review | All 6 release files modified |
+
+## The MVP-stage failure modes the checklist exists to prevent
+
+From the playbook's Stage-2 warnings:
+
+- **"Demoware trap"** — the demo works; real-user load breaks the
+  data model. *Specifically for Caro*: the safety pattern library
+  fires correctly in the test suite but a single bypass (e.g. the
+  P0 chmod -R 777 bypass fixed in v1.3.1) ships past testing. Gate
+  5 prevents the recurrence by catching the bypass *before* the
+  regression suite passes — but only if the regression suite covers
+  the bypass shape. Update the suite when you fix a bypass.
+- **"Mistaking building for validating"** — covered separately by
+  [`.claude/rules/validation-discipline.md`](../.claude/rules/validation-discipline.md);
+  this checklist assumes the validation gates are already cleared.
+- **Single-provider lock-in** — playbook Stage-4 failure mode, but
+  worth pre-empting at MVP. *Specifically for Caro*: every model
+  backend goes behind the `InferenceBackend` trait, and the
+  configuration system supports runtime switching. No code path
+  should hard-code a single backend identifier outside
+  `inference/<backend>.rs`.
+
+## Compliance posture for the playbook's regulated-workload mentions
+
+The playbook recommends Claude Code for SOC 2 / GDPR / HIPAA code
+audits. Caro's posture per ADR-001:
+
+| Regulation | Community Edition | Enterprise Edition |
+| --- | --- | --- |
+| **SOC 2** | Not applicable (single-user local tool); no managed service to audit | Required for managed deployments; tracked in [`docs/enterprise/MOAT.md`](./enterprise/MOAT.md) |
+| **GDPR** | Telemetry opt-in + local-first + redaction → already compliant; see [`docs/TELEMETRY.md`](./TELEMETRY.md) | Required at the deployment surface (audit-trail forwarding, retention controls) |
+| **HIPAA** | Out of scope — Caro is not for PHI workflows | Out of scope at MVP; revisit if Enterprise customers request |
+
+The playbook's broader compliance advice ("build the compliance
+workstream into your dev cycle via Cowork") explicitly does not
+apply to Caro's MVP because (a) we're local-first, single-user, and
+opt-in for telemetry, and (b) Cowork's audit-log limitation noted in
+[`docs/agentic-stack.md`](./agentic-stack.md) makes it unsuitable
+anyway. Regulated work routes through Claude Code with PR-trail
+audit + ADR-003 monitoring/audit-trail per the architecture.
+
+## How to use this checklist as a reviewer
+
+For a release PR:
+
+```bash
+# 1. Dep audit
+cargo audit && echo "✓ Gate 1"
+# 2. License
+cargo deny check licenses && echo "✓ Gate 2"
+# 3. Secret scan
+grep -rE '(api[_-]?key|token|secret)\s*[:=]\s*"[a-zA-Z0-9]{20,}' src/ website/src/ \
+  | grep -v '\.test\.\|fixture\|mock' \
+  | (! grep . > /dev/null) && echo "✓ Gate 3"
+# 4. Binary secret check
+cargo build --release --features embedded-cpu
+strings target/release/caro | grep -iE '(sk-|ghp_|api[_-]key)=[a-zA-Z0-9]' \
+  | (! grep . > /dev/null) && echo "✓ Gate 4"
+# 5. Safety suite
+cargo test --features safety && echo "✓ Gate 5"
+# 6. Sandbox tests
+cargo test --test 'safety_*' && echo "✓ Gate 6"
+# 7. Redaction tests
+cargo test redaction && echo "✓ Gate 7"
+# 8. Release checksums (post-tag)
+gh release view "vX.Y.Z" --json assets --jq '.assets[].digest' && echo "✓ Gate 8"
+# 9. Release-PR file alignment
+test "$(git diff --name-only main...HEAD | grep -cE 'Cargo.toml|Cargo.lock|CHANGELOG.md|README.md|ROADMAP.md|homebrew-tap|install.ps1|install.sh')" -ge 6 \
+  && echo "✓ Gate 9"
+```
+
+A reviewer who can paste those 9 commands and see 9 ✓ outputs has
+verified the checklist.
+
+## When a gate fails
+
+| Gate | Failure mode | Action |
+| --- | --- | --- |
+| 1 | New CVE in a dep | Bump the dep; if no upstream fix, evaluate pinning + sandboxing |
+| 2 | New dep with GPL / non-compat license | Per `.claude/rules/external-sdk-integration.md`, this is caught at spike-PR stage; if it slipped through, replace the dep |
+| 3 | Secret in source | Rotate the secret immediately; rewrite history with care; add the pattern to pre-commit |
+| 4 | Secret in binary | Same as gate 3 + verify no published release has the issue (re-release if needed) |
+| 5 | Safety regression | Per `safety-pattern-developer` skill: red-green-refactor; do NOT release until green |
+| 6 | Sandbox boundary leak | Per ADR-010; treat as P0 |
+| 7 | Telemetry redaction failure | Per `docs/TELEMETRY.md` audit; treat as P0 (privacy promise) |
+| 8 | Signing pipeline broken | Per `caro-release-expert` agent + `.claude/rules/release-version-alignment.md` |
+| 9 | Release-PR file alignment | Per `.claude/rules/release-version-alignment.md`; align before merge |
+
+## What this checklist does NOT cover
+
+- **User input validation**: not applicable in the usual web-app
+  sense — Caro takes shell-command prompts; "input validation"
+  *is* the safety pattern library. Covered by Gate 5.
+- **AuthN/AuthZ**: not applicable — Caro is a local single-user CLI.
+  The Enterprise edition (ADR-001) introduces these and gets its
+  own checklist when it ships.
+- **Penetration testing**: out of scope at MVP. Revisit at Stage-4
+  scale.
+- **Bug bounty**: not yet. Pre-condition: clear public security
+  policy + retention dashboard so we can scope active-user impact.
+
+## See also
+
+- [`.claude/rules/release-version-alignment.md`](../.claude/rules/release-version-alignment.md) —
+  the template-of-template this checklist follows
+- [`.claude/rules/external-sdk-integration.md`](../.claude/rules/external-sdk-integration.md) —
+  the build-spike rule that prevents license / MSRV / transitive
+  surprises before they reach this checklist
+- [`docs/TELEMETRY.md`](./TELEMETRY.md) — the redaction contract Gate 7
+  enforces
+- [`docs/adr/ADR-010-bubblewrap-sandbox-execution.md`](./adr/ADR-010-bubblewrap-sandbox-execution.md) —
+  Linux sandbox decision (Gate 6)
+- [`docs/adr/ADR-001-enterprise-community-architecture.md`](./adr/ADR-001-enterprise-community-architecture.md) —
+  where the regulated-workload checklist lives when Enterprise ships

--- a/docs/SECURITY-CHECKLIST.md
+++ b/docs/SECURITY-CHECKLIST.md
@@ -40,7 +40,7 @@ From the playbook's Stage-2 warnings:
   [`.claude/rules/validation-discipline.md`](../.claude/rules/validation-discipline.md);
   this checklist assumes the validation gates are already cleared.
 - **Single-provider lock-in** — playbook Stage-4 failure mode, but
-  worth pre-empting at MVP. *Specifically for Caro*: every model
+  worth preempting at MVP. *Specifically for Caro*: every model
   backend goes behind the `InferenceBackend` trait, and the
   configuration system supports runtime switching. No code path
   should hard-code a single backend identifier outside

--- a/docs/agentic-stack.md
+++ b/docs/agentic-stack.md
@@ -1,0 +1,178 @@
+# Caro's Agentic Stack
+
+**Last Updated**: 2026-05-25
+**Source framework**: [Anthropic's Founder's Playbook — Product Matrix](https://claude.com/blog/the-founders-playbook)
+
+This document is how Caro itself uses the Anthropic product matrix
+(Chat, Cowork, Code, Platform) for its own operations. The playbook
+recommends a particular product per use-case; we record where we
+follow the recommendation, where we deviate, and why.
+
+> **TL;DR**: We are heavy on **Code** (the agentic core of Caro's
+> own development), starting on **Platform** (the multi-backend
+> InferenceBackend abstraction inside Caro itself), light on **Chat**
+> (used informally), and **deliberately not adopting Cowork** for
+> internal KM until its audit-log limitation closes.
+
+## Product matrix
+
+### Claude Code — heavy use ✅
+
+**Playbook recommendation**: "Continuous product iteration."
+**Caro adoption**: primary. The entire `.claude/` directory is
+Code-shaped (agents, skills, commands, rules). Every PR in this repo
+is touched by Claude Code via the `caro-coder-loop` skill,
+`pr-management-loop` skill, or direct human-in-the-loop sessions.
+
+**Where it works**:
+- The 33+ domain agents in [`.claude/agents/`](../.claude/agents/)
+  give Code coherent personas to spawn for specialized work (Rust
+  CLI architect, safety pattern developer, frustrated beta tester,
+  release expert, design engineer, devil's advocate, etc.)
+- The tiered constitution
+  ([`.claude/rules/constitution.md`](../.claude/rules/constitution.md))
+  encodes precedence so parallel sessions don't tear at each other
+- Spec-Kit + beads queue keeps work units coherent across sessions
+
+**Where it doesn't**:
+- Multi-session coordination of edits to the same file → covered by
+  the worktree convention + git-workflow rule
+- Long-running agent loops without supervision → covered by Hermes
+  + integration-health monitoring, but the failure mode is real
+  (see Stage-4 "multi-agent observability" gap in
+  [`launch-os.md`](./launch-os.md))
+
+### Claude Platform (API + multi-agent orchestration) — starting ✅
+
+**Playbook recommendation**: "Backend API invocation and multi-agent
+orchestration."
+**Caro adoption**: starting. Caro's own backend abstraction
+(`InferenceBackend` trait in `src/inference/mod.rs`) is the
+Platform-shaped layer *inside Caro the product* — it supports
+multiple model providers with runtime switching, deliberately
+insulating against the playbook's "single provider dependency"
+Stage-4 failure mode.
+
+For operational AI (not product AI):
+- We use Anthropic's APIs from Claude Code and from the
+  `ai-marketing-engineering` skill
+- We use OpenRouter as an alternate path for the embedded backend's
+  cloud fallback
+- Multi-agent orchestration *inside the project's dev ops* is the
+  Hermes agent + the constellation of `.claude/skills/`; Hermes is
+  the orchestration layer
+
+**Where we deliberately differ from the playbook**:
+- The playbook treats Platform as the company's *operational* AI
+  layer. Caro treats it as both operational AND the product
+  itself — `caro` the CLI IS a Platform-shaped consumer (multi-
+  backend, runtime-switchable). This makes us more sensitive to
+  vendor-lock-in failure modes than the playbook's median reader.
+
+### Claude Chat — light, informal use ✅
+
+**Playbook recommendation**: "Customer support entry point."
+**Caro adoption**: informal. We don't currently route support intake
+through a Chat instance. GitHub Issues + GitHub Discussions + DMs
+are the support surface. Chat-shaped automation may land at Stage-4
+scale.
+
+**Where it works**:
+- Founder + maintainer occasional Chat use for one-off research,
+  competitive scans, drafting copy
+- The
+  [`claude-design-frontend-engineer`](../.claude/agents/claude-design-frontend-engineer.md)
+  agent's bidirectional dialogue with the UI/UX persona at
+  claude.ai/design is Chat-shaped (governed by
+  [`.claude/rules/design-dialogue-protocol.md`](../.claude/rules/design-dialogue-protocol.md))
+
+**Where it doesn't**:
+- Public-facing support intake — defer to Stage-4
+- Automated triage of GitHub Discussions — gap in `launch-os.md`;
+  may be addressed via Chat or via Code, TBD
+
+### Claude Cowork — deliberately not adopted ⛔
+
+**Playbook recommendation**: "Internal knowledge management."
+**Caro adoption**: **deliberately not adopted at this time.**
+
+**Why**:
+The playbook recommends Cowork for internal KM and even for SOC 2 /
+GDPR / HIPAA compliance workstreams. Reviewers of the playbook noted
+that **Cowork activity is excluded from audit logs and compliance
+APIs**, making it structurally unsuitable for regulated workloads —
+despite the playbook's recommendation. (See the techtimes.com
+critical review cited in the playbook's research notes.)
+
+Caro's positioning is split:
+
+- **Community Edition**: local-first, single-user, no organizational
+  audit need. Cowork-shaped KM isn't load-bearing here; we use the
+  repo itself (docs/, .claude/, .hermes/, beads) as the knowledge
+  base.
+- **Enterprise Edition** (ADR-001): explicitly designed for
+  regulated-workload customers — CISOs, audit-trail forwarding,
+  centralized policy distribution. We **cannot** sit our own
+  internal KM on a tool that's structurally unsuitable for the
+  customer's audit requirements; that would be hypocritical and
+  would create awkward conversations.
+
+**Re-evaluation trigger**: if Anthropic closes Cowork's audit-log
+gap and publishes a compliance API, we re-evaluate this decision.
+Until then, our KM lives in the repo, and Hermes serves the
+"synthesis across knowledge" role Cowork might otherwise serve.
+
+## Internal AI ops by surface area
+
+| Surface | Heavy use | Light use | Not used |
+| --- | --- | --- | --- |
+| Product development (`src/`) | Code, Platform (inside Caro) | — | Cowork, Chat |
+| Documentation (`docs/`, `playbook/`, `website/`) | Code | Chat (drafts) | Cowork, Platform |
+| Marketing copy + content | Code (via `ai-marketing-engineering` skill) | Chat | Cowork |
+| Strategic synthesis | Hermes (on Platform) | Chat (founder) | Cowork |
+| Translations | `gh workflow run translate.yml` (Platform) | — | Code, Cowork, Chat |
+| Beta testing | Code (via `caro-frustrated-beta`, `unbiased-beta-tester` skills) | — | Cowork, Chat |
+| Customer support intake | (manual via GH Discussions / DMs) | — | Code, Chat, Cowork (yet) |
+
+## The "dogfooding" claim
+
+Caro's category is **execution safety for AI-generated commands**.
+Our entire dev process is AI-generated commands meeting an execution
+layer (the repo, the CLI). We are an honest user of our own product
+shape:
+
+- Every PR has shell commands in it (build, test, lint, deploy)
+- Every commit is created via tooling that runs shell commands
+- Every release runs a sequence of validated shell commands per
+  `.claude/rules/release-version-alignment.md`
+
+We don't (yet) use Caro itself to safety-validate the shell commands
+inside our own dev loop. That's a dogfooding gap; tracked as a
+discovery candidate (low priority, since maintainers are themselves
+the safety check).
+
+## Where this stack is going
+
+When Caro graduates to Stage 4 ([`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md)),
+this document expands:
+
+- **Chat** picks up customer-support intake routing
+- **Platform** picks up Enterprise rollout automation (per ADR-001)
+- **Cowork** — re-evaluated only if the audit-log limitation closes
+- **Code** — continues, but with multi-agent observability per the
+  gap in `launch-os.md`
+
+## See also
+
+- [`launch-os.md`](./launch-os.md) — the broader Launch-stage
+  agent/skill inventory; this document focuses on the Anthropic
+  product matrix specifically
+- [`.hermes/AGENT.md`](../.hermes/AGENT.md) — the strategic-intel
+  agent that's the closest thing to our "Cowork" today
+- [`.claude/rules/external-sdk-integration.md`](../.claude/rules/external-sdk-integration.md) —
+  multi-vendor resilience as code (the same shape as the playbook's
+  "no single provider dependency" advice)
+- [`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md) — where this
+  stack is taking us next
+- The Founder's Playbook critical review (techtimes.com) — source of
+  the Cowork audit-log caveat we honor

--- a/docs/discovery/README.md
+++ b/docs/discovery/README.md
@@ -1,0 +1,119 @@
+# Discovery
+
+This directory holds the **evidence** that gates feature work per
+[`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md).
+
+Specifically: first-hand user-interview transcripts, the hypothesis
+ledger that tracks pain patterns surfaced across transcripts, and
+retroactive validation audits for in-flight product lines.
+
+Adapted from [Anthropic's Founder's Playbook](https://claude.com/blog/the-founders-playbook):
+the 20-transcript rule, the no-surveys-as-primary-evidence rule, the
+demoware-trap gate, and the defended-cohort requirement for PMF
+claims all live here as operational artifacts.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| [`README.md`](./README.md) | This file: directory purpose, anonymization rules, contribution guide |
+| [`interview-template.md`](./interview-template.md) | Question script + signal taxonomy for `caro.discovery` skill |
+| [`hypothesis-ledger.md`](./hypothesis-ledger.md) | Append-only ledger: every product-line hypothesis with evidence count, validation status, last review date |
+| [`v2.0-validation-audit.md`](./v2.0-validation-audit.md) | Retroactive audit of Karo, Dogma, voice synthesis, self-healing, local context indexing |
+| `transcripts/` | Anonymized first-hand user-interview transcripts (one file per interview) |
+
+## How to add a transcript
+
+1. Run the interview using the [`caro.discovery`
+   skill](../../.claude/skills/caro.discovery/SKILL.md), which uses
+   the [`interview-template.md`](./interview-template.md) question
+   script.
+2. Get **explicit consent** from the participant for the transcript
+   to be logged. Note the consent in the transcript frontmatter.
+3. Save the transcript at:
+   ```
+   transcripts/YYYY-MM-DD-<anon-handle>-<topic-slug>.md
+   ```
+4. Anonymize aggressively per the rules below.
+5. Tag with 1–3 `pain_patterns` slugs in the frontmatter. Reuse
+   existing slugs from `hypothesis-ledger.md` if one fits; coin a
+   new slug if none does (and add it to the ledger).
+6. After every 5 transcripts under the same hypothesis, run a
+   synthesis pass — append a synthesis entry to
+   `hypothesis-ledger.md`.
+
+## Anonymization rules
+
+Transcripts live in a public repo. They must never carry
+identifying information.
+
+| Information type | What to do |
+| --- | --- |
+| Real names | Replace with a stable `anon_handle` (e.g. `ds-engineer-pacific`). The handle is consistent across that participant's multiple transcripts so we can track them as a cohort. |
+| Company names | Replace with `<industry>-co` (e.g. `fintech-co`, `healthtech-co`) unless the participant gave explicit consent to name the company. |
+| Internal tool names | Replace with `<internal-tool>` if naming the tool would identify the participant. |
+| File paths with usernames | Replace with `~/` or `<home>/`. |
+| Email addresses | Never log. Don't even quote them. |
+| Discord display names, GitHub handles, Twitter handles | Pseudonymize into the `anon_handle`. |
+| Geographic identifiers more specific than country | Generalize ("US west coast" not "Mountain View"). |
+
+If you can't anonymize without destroying the signal, the
+transcript isn't usable in this directory. Either get explicit
+consent for the identifying detail, or don't log it. Don't
+compromise — escalate to a human reviewer.
+
+## Hypothesis ledger format
+
+Every product-line hypothesis under validation gets a row in
+[`hypothesis-ledger.md`](./hypothesis-ledger.md). Columns:
+
+- **Hypothesis ID** — short slug, e.g. `karo-distributed`, `voice-synthesis`
+- **Claim** — one sentence: "users want X so they can Y"
+- **Transcripts** — count of transcripts referencing this hypothesis
+- **Distinct pain patterns** — count of unique pain patterns observed
+  across those transcripts
+- **Validation status** — `unvalidated` / `partial` / `validated` /
+  `invalidated`
+- **Last review** — date of last synthesis pass
+- **Stage gate** — which gate of `validation-discipline.md` this
+  hypothesis has cleared
+
+A hypothesis graduates from `unvalidated` only when ≥20 transcripts
+cite it AND ≥3 distinct pain patterns have emerged AND the devil's
+advocate review (Gate 4) returns Pass or Revise (not Block).
+
+## What this directory does NOT hold
+
+- **Surveys, NPS data, waitlist signups.** Those are quantitative
+  signals and live elsewhere (telemetry, Turso DB). Per Gate 2 they
+  cannot serve as primary validation evidence.
+- **Marketing testimonials.** Public testimonials require their own
+  consent flow and live in `website/src/components/landing/`
+  (e.g. `AITestimonials.astro`).
+- **Bug reports.** Those are GitHub Issues. A bug is evidence that
+  something we shipped is broken — different from evidence that
+  something we want to ship is needed.
+- **Telemetry data.** Telemetry is opt-in, privacy-first, no command
+  content (see `docs/TELEMETRY.md`). It serves retention/usage
+  measurement, not problem validation.
+
+## Why this directory exists
+
+The playbook's central warning: when a prototype takes an afternoon,
+founders mistake the prototype's existence for proof of demand. The
+counter is evidence requirements that gate feature work *at the spec
+stage*, before code starts. This directory is where the evidence
+lives. Without it, the validation-discipline rule is a piece of
+paper.
+
+## See also
+
+- [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md) —
+  the rule this directory serves
+- [`.claude/skills/caro.discovery/SKILL.md`](../../.claude/skills/caro.discovery/SKILL.md) —
+  the skill that walks an interview and writes a transcript here
+- [`.claude/agents/devils-advocate.md`](../../.claude/agents/devils-advocate.md) —
+  the agent that audits whether a spec's transcript citations
+  actually clear Gate 1
+- [`playbook/STAGE_MAP.md`](../../playbook/STAGE_MAP.md) — what stage
+  the evidence is serving

--- a/docs/discovery/hypothesis-ledger.md
+++ b/docs/discovery/hypothesis-ledger.md
@@ -1,0 +1,123 @@
+# Hypothesis Ledger
+
+Append-only ledger of every product-line hypothesis under validation,
+with its evidence count, validation status, and last review date.
+
+This ledger is the single source of truth for "what are we trying to
+prove right now" — it gates feature work per
+[`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md).
+
+A hypothesis graduates from `unvalidated` only when:
+1. ≥20 first-hand transcripts cite it (Gate 1)
+2. ≥3 distinct pain patterns emerge across the transcripts (Gate 1)
+3. Devil's-advocate review (Gate 4) returns `Pass` or `Revise` (not `Block`)
+4. If claiming PMF: Sean Ellis result with defended cohort (Gate 5)
+
+## Status taxonomy
+
+- **`unvalidated`** — claim exists, evidence gathering not started or
+  <20 transcripts
+- **`partial`** — ≥10 transcripts, signal converging but criteria not
+  yet met
+- **`validated`** — all four conditions met; safe to graduate from
+  research to implementation
+- **`invalidated`** — evidence actively refutes the hypothesis (the
+  most valuable status — it saves a build cycle)
+- **`grandfathered`** — claim was made before May 25, 2026 and is
+  exempt from retroactive validation (e.g. the core NL→shell loop
+  that shipped in v1.0)
+
+## Active hypotheses
+
+| ID | Claim | Transcripts | Patterns | Status | Last review | Gates cleared |
+| --- | --- | ---: | ---: | --- | --- | --- |
+| `caro-core` | Users want NL→safety-validated POSIX commands (the v1.x product loop) | — | — | `grandfathered` | 2026-05-25 | exempt (shipped pre-rule) |
+| `karo-distributed` | Users want a distributed-terminal-intelligence layer across their devices | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+| `dogma-rules` | Users want a rule-engine they can customize beyond the built-in 52 safety patterns | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+| `voice-synthesis` | Users want Caro to speak responses aloud (mascot voice) | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+| `self-healing` | Users want commands to retry/recover automatically on certain failure classes | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+| `local-context-indexing` | Users want Caro to know about their repo / shell history / open files when generating commands | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+| `enterprise-dashboard` | CISOs want a centralized policy + audit-trail surface for Caro deployments | 0 | 0 | `unvalidated` | 2026-05-25 | none |
+
+The `caro-core` row is grandfathered because the rule applies forward
+from May 25, 2026. The full retroactive audit for each v2.0 hypothesis
+is in [`v2.0-validation-audit.md`](./v2.0-validation-audit.md).
+
+## Synthesis entries
+
+Synthesis happens after every 5 transcripts under the same hypothesis.
+The synthesis entry below each hypothesis lists distinct pain patterns,
+willingness-signal counts, dealbreaker quotes, and any emerging cohort
+definition. New synthesis entries get appended chronologically.
+
+### `karo-distributed` synthesis
+
+*No transcripts logged yet. First synthesis entry will appear here
+after 5 interviews.*
+
+### `dogma-rules` synthesis
+
+*No transcripts logged yet.*
+
+### `voice-synthesis` synthesis
+
+*No transcripts logged yet.*
+
+### `self-healing` synthesis
+
+*No transcripts logged yet.*
+
+### `local-context-indexing` synthesis
+
+*No transcripts logged yet.*
+
+### `enterprise-dashboard` synthesis
+
+*No transcripts logged yet.*
+
+## Pain pattern slugs
+
+When a transcript surfaces a pain pattern, tag it with a slug. Reuse
+existing slugs when applicable; coin new ones sparingly. Slugs in use:
+
+*(none yet — this list grows as transcripts land)*
+
+Suggested coining convention: `<verb>-<noun>` (e.g. `forget-flags`,
+`fear-rm-rf`, `lose-context-across-devices`).
+
+## Invalidated hypotheses
+
+When evidence actively refutes a hypothesis, the row moves here. An
+invalidated hypothesis saves a build cycle and deserves the same
+ceremony as a validated one — name the evidence that killed it.
+
+*(none yet)*
+
+## How to update this ledger
+
+- **After every interview**: increment the `Transcripts` count for the
+  relevant hypothesis. Tag any new pain patterns observed.
+- **Every 5 transcripts**: append a synthesis entry under that
+  hypothesis's section. Update `Patterns` count. Update `Status` if
+  the synthesis warrants it.
+- **When a hypothesis graduates**: change `Status` to `validated`,
+  record the date as `Last review`, and link to the spec PR that
+  consumed the evidence.
+- **When evidence refutes**: move the row to "Invalidated hypotheses"
+  with one paragraph naming the refutation.
+
+The ledger is append-only at the synthesis level; status transitions
+are normal edits. Don't rewrite history — if a synthesis was wrong, add
+a correction synthesis below it, don't delete the original.
+
+## See also
+
+- [`README.md`](./README.md) — directory purpose, anonymization rules
+- [`interview-template.md`](./interview-template.md) — question script
+  for new transcripts
+- [`v2.0-validation-audit.md`](./v2.0-validation-audit.md) — retroactive
+  audit of in-flight v2.0 product lines
+- [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md) —
+  the rule that makes this ledger load-bearing
+- [`ROADMAP.md`](../../ROADMAP.md) — items here cross-reference
+  hypotheses by ID

--- a/docs/discovery/interview-template.md
+++ b/docs/discovery/interview-template.md
@@ -151,4 +151,4 @@ enthusiasm.
 - [`.claude/skills/caro.discovery/SKILL.md`](../../.claude/skills/caro.discovery/SKILL.md) —
   the skill that walks this template programmatically
 - [`docs/PERSONAS_JTBD.md`](../PERSONAS_JTBD.md) — existing persona
-  framing (use it to pre-select interview participants per cohort)
+  framing (use it to preselect interview participants per cohort)

--- a/docs/discovery/interview-template.md
+++ b/docs/discovery/interview-template.md
@@ -1,0 +1,154 @@
+# Caro Discovery Interview Template
+
+The question script for a Caro user-discovery interview. Used by the
+[`caro.discovery`](../../.claude/skills/caro.discovery/SKILL.md) skill
+and counted toward the 20-transcripts gate in
+[`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md).
+
+**Time budget**: 20–30 minutes synchronous, or 24 hours async-chat.
+**Format**: 1:1, qualitative, recorded with consent.
+
+## Before the interview
+
+- [ ] Confirm the **hypothesis under test**. Today's interview is
+  one of 20 for hypothesis `<id>` from
+  [`hypothesis-ledger.md`](./hypothesis-ledger.md). Knowing the
+  hypothesis shapes which probes you push on — but you do NOT share
+  the hypothesis with the participant during the interview (it
+  primes them).
+- [ ] Get explicit consent. "May I record this conversation as an
+  anonymized discovery transcript? It goes in a public repo, your
+  handle is hashed, your company is generalized. You can ask me to
+  delete it at any time."
+- [ ] Decide on the `anon_handle` (consistent if this participant
+  has been interviewed before).
+
+## Question 1 — Context (≤3 min)
+
+> "Tell me about your work. What do you build, in what kind of team,
+> what's a typical day in the terminal look like for you?"
+
+**Listen for**: role, seniority, daily shell hours, OS, shell
+flavor, team size. These shape the cohort.
+
+## Question 2 — Last hard command (5–7 min)
+
+> "Tell me about the last time you had to look up a command, ask a
+> colleague, or copy-paste from StackOverflow / ChatGPT / Cursor.
+> What were you trying to do? What did you actually do? How long
+> did it take from "I need this" to "it ran"?"
+
+**Listen for**: the trigger, the workaround, the time-to-command,
+the emotional valence (frustration / resignation / amusement). Push
+for **the specific incident**, not the abstract category.
+
+**Bad answer to follow up on**: "Oh, I do that all the time."
+**Better follow-up**: "What did you do yesterday morning? Walk me
+through it."
+
+## Question 3 — Current alternatives (3–5 min)
+
+> "When you don't remember a flag / pipeline / one-liner, what's
+> your default path? Manpages? `tldr`? `cheat`? Cursor inline?
+> ChatGPT in another tab? Slack the team? GitHub Copilot? Just
+> Google it?"
+
+**Listen for**: the path of least resistance (revealed-preference
+signal), the path they wish they took (aspirational), the path
+they actively avoid (anti-pattern). All three are signal.
+
+## Question 4 — Pain frequency (≤2 min)
+
+> "Per day or per week, how often does this happen?"
+
+**Listen for**: an actual integer. "All the time" is not an
+answer; push for "5 times a day" or "twice a week". Pain frequency
+predicts willingness-to-adopt; you cannot synthesize without it.
+
+## Question 5 — Willingness signal (3–5 min)
+
+> "If a tool fixed this in 2 seconds, with safety validation
+> blocking destructive commands before they run, what's it worth
+> to you? Free-tier nice-to-have? Worth $5/month, $20/month,
+> $100/month? Would your company pay for it?"
+
+**Listen for**: a number AND a tier choice (personal vs.
+company-paid). Both signals matter — Caro's dual-track
+Community/Enterprise model needs both demand curves.
+
+**Be honest**: if they say "I'd never pay personally but my
+employer might", that's an Enterprise signal, not a Community one.
+
+## Question 6 — Dealbreakers (5–7 min) ⭐ most important
+
+> "What would a tool in this space do that would make you
+> uninstall it within a day? What's the thing that would make you
+> not even try it?"
+
+**Listen for**: the failure modes nobody tells you in a survey.
+Telemetry phoning home, slow startup, hallucinated commands, vendor
+lock-in, no offline mode, no audit log, requiring a Anthropic API
+key, requiring a cloud account, the wrong shell support. The
+dealbreakers from this question are the demoware-trap inputs for
+the feature spec.
+
+## Optional — Beta interest
+
+> "Would you want early access if/when this exists? If yes, what
+> would you want to test first?"
+
+**Listen for**: enthusiasm vs. politeness. "Sure, sounds cool" is
+politeness; "yes, here's my email, please ping me Tuesday" is
+enthusiasm.
+
+## After the interview
+
+- [ ] Write the transcript to `transcripts/YYYY-MM-DD-<anon-handle>-<topic-slug>.md`
+  with the required frontmatter (see
+  [`README.md`](./README.md))
+- [ ] Anonymize aggressively per the rules in
+  [`README.md`](./README.md)
+- [ ] Tag with 1–3 `pain_patterns` slugs
+- [ ] Update the `transcripts` count for the hypothesis in
+  [`hypothesis-ledger.md`](./hypothesis-ledger.md)
+- [ ] If this is the 5th, 10th, 15th, or 20th transcript under this
+  hypothesis, run a synthesis pass into the ledger
+
+## Calibration notes
+
+- **The question that earns the discovery, not the answer.**
+  Discovery is about uncovering what the participant believes; if
+  the participant has nothing surprising to tell you, you didn't
+  pick the right participant.
+- **Push for specific incidents.** "I always do X" is a story;
+  "yesterday at 3pm I did Y" is data. Demand the second.
+- **Cohort variance matters.** If all 20 transcripts come from
+  senior backend engineers in Pacific timezone, the resulting
+  hypothesis is validated for *that cohort*, not "users in
+  general". Note this explicitly in the synthesis.
+- **Negative signal is signal.** A transcript where the
+  participant says "I never have this problem" doesn't get
+  discarded — it goes in the ledger as a cohort exclusion.
+
+## What this template is NOT
+
+- **It is not a sales script.** Don't pitch Caro during the
+  interview. Pitching primes the participant and corrupts the
+  evidence.
+- **It is not a closed-form survey.** The questions are anchors;
+  the conversation is the data. Follow the participant's lead
+  when they surface something unexpected.
+- **It is not the same as a beta-test session.** A beta test
+  evaluates an existing product; a discovery interview evaluates
+  whether a hypothetical product is worth building. Don't mix
+  them.
+
+## See also
+
+- [`README.md`](./README.md) — directory purpose, anonymization rules
+- [`hypothesis-ledger.md`](./hypothesis-ledger.md) — where the
+  hypothesis IDs live
+- [`.claude/skills/caro.discovery/SKILL.md`](../../.claude/skills/caro.discovery/SKILL.md) —
+  the skill that walks this template programmatically
+- [`docs/PERSONAS_JTBD.md`](../PERSONAS_JTBD.md) — existing persona
+  framing (use it to pre-select interview participants per cohort)

--- a/docs/discovery/v2.0-validation-audit.md
+++ b/docs/discovery/v2.0-validation-audit.md
@@ -1,0 +1,220 @@
+# v2.0 Validation Audit
+
+**Audit date**: 2026-05-25
+**Auditor**: Founder's Playbook adaptation (Phase 3, PR-currently-in-flight)
+**Rule applied**: [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md)
+
+This audit retroactively applies the five validation gates to every
+v2.0 product line currently in research per
+[`ROADMAP.md`](../../ROADMAP.md). The rule applies forward from May
+25, 2026, but the user-answered scope of the playbook adaptation
+explicitly requested this retroactive pass on v2.0 work because the
+features are in research (not yet shipped) — which is when the rule
+has teeth.
+
+## Methodology
+
+For each v2.0 product line, we score against the five gates:
+
+- **Gate 1 — 20 transcripts**: count of first-hand interview transcripts
+  in `transcripts/` tagged with this hypothesis (`hypothesis: <id>`)
+- **Gate 2 — No surveys-only**: does the supporting evidence go beyond
+  waitlist counts / GitHub stars / vibes?
+- **Gate 3 — Demoware-trap section**: does the spec name "what breaks
+  at 100 real users"?
+- **Gate 4 — Devil's-advocate review**: has the proposal been run
+  through the `devils-advocate` agent?
+- **Gate 5 — Sean Ellis + defended cohort**: if PMF is claimed, is
+  the cohort named and defended?
+
+Outcomes:
+- **Pass** — all applicable gates clear; safe to graduate to
+  implementation
+- **Research-only** — gates not yet clear; move to a separate
+  "Research (unvalidated)" section in ROADMAP, do not promise a
+  release date
+- **Invalidated** — evidence actively refutes; remove from roadmap
+
+## Audit results
+
+| Product line | Hypothesis ID | Gate 1 (transcripts) | Gate 2 (no-surveys) | Gate 3 (demoware) | Gate 4 (devil's advocate) | Gate 5 (PMF) | Verdict |
+| --- | --- | ---: | --- | --- | --- | --- | --- |
+| Karo distributed intelligence | `karo-distributed` | 0 / 20 | n/a | not present | not run | n/a | **Research-only** |
+| Dogma rule engine | `dogma-rules` | 0 / 20 | n/a | not present | not run | n/a | **Research-only** |
+| Voice synthesis | `voice-synthesis` | 0 / 20 | n/a | not present | not run | n/a | **Research-only** |
+| Self-healing features | `self-healing` | 0 / 20 | n/a | not present | not run | n/a | **Research-only** |
+| Local context indexing | `local-context-indexing` | 0 / 20 | n/a | not present | not run | n/a | **Research-only** |
+| Azure Foundry backend (#661) | extension of `caro-core` | exempt | exempt | not present | not run | n/a | **Pass (extension)** |
+| vLLM Jukebox multi-model (#663) | extension of `caro-core` | exempt | exempt | not present | not run | n/a | **Pass (extension)** |
+| Skills extension system (#664, ADR-004) | extension of `caro-core` | exempt | exempt | not present | not run | n/a | **Pass (extension)** |
+| Handy.Computer integration (#662) | extension of `caro-core` | exempt | exempt | not present | not run | n/a | **Pass (extension)** |
+
+**Audit principle**: items that *extend* the already-validated core
+loop (additional backends, additional skill mechanisms, additional
+distribution targets) don't re-trigger Gate 1. Items that propose a
+**new product line** (new user, new pain, new value claim) do.
+
+## Detailed audit per product line
+
+### Karo distributed intelligence
+
+**ROADMAP entry**: "Karo distributed terminal intelligence system"
+(epics #133, #171; PR #169 plan)
+**Claim**: users want their terminal AI to share state across their
+devices (laptop, desktop, SSH session) and coordinate as a single
+intelligence layer.
+**Audit**:
+- Gate 1: **0 transcripts.** No first-hand interviews on the
+  cross-device pain. The waitlist (~247) has no segment break-out for
+  "cross-device users".
+- Gate 2: **n/a.** No survey-shaped evidence exists either.
+- Gate 3: **Not present.** No "what breaks at 100 real users" section
+  in the existing planning artifacts. P2P networking, state-sync
+  conflict resolution, and cross-device-auth failure modes are not
+  named.
+- Gate 4: **Not run.** Devil's advocate has not reviewed.
+- Gate 5: **n/a.** PMF is not currently claimed.
+- **Verdict**: **Research-only.** Move to `Research (unvalidated)`
+  section in ROADMAP. Promised release date dropped.
+
+**Discovery-debt action**: open beads issue
+`discovery-debt/karo-distributed-20-transcripts` — interview 20
+users about cross-device terminal pain before graduating.
+
+### Dogma rule engine
+
+**ROADMAP entry**: "Research Dogma rule engine architecture" (#126)
+**Claim**: users want a rule engine to customize safety enforcement
+beyond the built-in 52 patterns.
+**Audit**:
+- Gate 1: **0 transcripts.** No first-hand interviews on
+  user-customized rule pain.
+- Gate 2: **n/a.**
+- Gate 3: **Not present.** No "what breaks at 100 real users"
+  section. The interaction model between user-defined rules and
+  the existing pattern library is not specified.
+- Gate 4: **Not run.**
+- Gate 5: **n/a.**
+- **Verdict**: **Research-only.** Plausibly an enterprise-only
+  hypothesis — recommend re-scoping under the
+  `enterprise-dashboard` hypothesis (CISO-driven custom policy) and
+  validating it in that context.
+
+**Discovery-debt action**: open beads issue
+`discovery-debt/dogma-rules-20-transcripts`. Sequence after
+`enterprise-dashboard` interviews.
+
+### Voice synthesis
+
+**ROADMAP entry**: "Research voice synthesis for Caro character"
+(#160, #187)
+**Claim**: users want Caro to speak its responses (mascot
+personality made audible).
+**Audit**:
+- Gate 1: **0 transcripts.**
+- Gate 2: **n/a.**
+- Gate 3: **Not present.** Accessibility implications, screen-reader
+  conflicts, focus-mode disruption, and on-by-default failure modes
+  are not named.
+- Gate 4: **Not run.** This is a strong candidate for devil's advocate
+  review — voice synthesis is a high-cost feature (latency, model
+  size, accessibility complexity) attached to an unclear demand
+  hypothesis.
+- Gate 5: **n/a.**
+- **Verdict**: **Research-only.** Highest a-priori risk of the v2.0
+  set per devil's-advocate's "load-bearing assumption" check: the
+  load-bearing assumption is that users *want* voice; the alternative
+  ("users want Caro silent and fast") is at least as plausible.
+
+**Discovery-debt action**: open beads issue
+`discovery-debt/voice-synthesis-20-transcripts`. Devil's-advocate
+review BEFORE interview design (the questions should be calibrated
+to a hypothesis the agent has interrogated).
+
+### Self-healing features
+
+**ROADMAP entry**: "Add self-healing feature" (#155)
+**Claim**: users want commands that auto-retry / auto-correct on
+certain failure classes.
+**Audit**:
+- Gate 1: **0 transcripts.**
+- Gate 2: **n/a.**
+- Gate 3: **Not present.** The "auto-retry" failure modes (silent
+  data corruption, runaway retries, double-execution of side-effectful
+  commands) are exactly the demoware-trap shape — easy in demo,
+  catastrophic at scale.
+- Gate 4: **Not run.** Strong candidate for devil's-advocate review;
+  the failure modes are well-known in distributed-systems history.
+- Gate 5: **n/a.**
+- **Verdict**: **Research-only.** High demoware-trap risk. Recommend
+  splitting into (a) the *retry-classifier* (mechanism) which is a
+  Gate-3-bound engineering question, and (b) the *should-retry?*
+  (policy) which is a Gate-1-bound user-validation question.
+
+**Discovery-debt action**: open beads issue
+`discovery-debt/self-healing-20-transcripts`. Spec must clear Gate
+3 before any implementation.
+
+### Local context indexing
+
+**ROADMAP entry**: "Add local directory context" (#152), "Add local
+Chroma DB indexing" (#166), epic #504 ChromaDB
+**Claim**: users want Caro to know about their open repo / shell
+history / cwd state when generating commands.
+**Audit**:
+- Gate 1: **0 transcripts.** This is the highest-likelihood validated
+  hypothesis of the set — anecdotally requested in GitHub Issues
+  (#152, #166) — but anecdotes are not transcripts.
+- Gate 2: **GitHub-issue signal is not survey-shaped, but it's not
+  20 transcripts either.** Per Gate 1, the issues are evidence
+  inputs (users have pain), not evidence outputs (users want this
+  specific solution).
+- Gate 3: **Not present.** Privacy implications of local indexing,
+  staleness handling, and cross-repo confusion modes are not named.
+- Gate 4: **Not run.**
+- Gate 5: **n/a.**
+- **Verdict**: **Research-only**, *but* with the strongest a-priori
+  signal of the v2.0 set — interview these users first.
+
+**Discovery-debt action**: open beads issue
+`discovery-debt/local-context-indexing-20-transcripts`. Highest
+priority. Re-interview the existing GitHub Issue authors as
+transcript candidates.
+
+## Summary
+
+All five v2.0 *new-product-line* items are **Research-only**. None
+clear Gate 1. The four *core-extension* items (Azure Foundry, vLLM
+Jukebox, Skills extension, Handy.Computer integration) pass as
+extensions of the already-validated `caro-core` hypothesis.
+
+The rule has teeth: the audit downgrades 5 of 9 audited items. If
+this audit downgraded zero items, the rule would be too lax (per the
+plan's success criterion).
+
+## Follow-up actions
+
+1. **Open beads epic** `discovery-debt-v2.0` with 5 child issues
+   (one per Research-only product line)
+2. **Update ROADMAP.md** to move the 5 product lines into a
+   `## Research (unvalidated)` section above the v2.0 milestone, and
+   add a `Validation:` field pointing back to this audit
+3. **Sequence interview work** in priority order: local-context-indexing
+   (strongest a-priori signal), enterprise-dashboard (drives
+   dogma-rules scope), karo-distributed, self-healing, voice-synthesis
+   (highest a-priori risk)
+4. **Devil's-advocate review** of voice-synthesis and self-healing
+   *before* interview design begins
+
+## See also
+
+- [`README.md`](./README.md) — directory purpose
+- [`hypothesis-ledger.md`](./hypothesis-ledger.md) — where the
+  hypotheses are tracked across time
+- [`interview-template.md`](./interview-template.md) — script to
+  use for the discovery-debt interviews
+- [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md) —
+  the rule being applied here
+- [`.claude/agents/devils-advocate.md`](../../.claude/agents/devils-advocate.md) —
+  agent to run Gate 4 on voice-synthesis and self-healing before
+  interviews start

--- a/docs/launch-os.md
+++ b/docs/launch-os.md
@@ -1,0 +1,126 @@
+# Launch Operating System
+
+**Last Updated**: 2026-05-25
+**Source framework**: [Anthropic's Founder's Playbook, Stage 3 — Launch](https://claude.com/blog/the-founders-playbook)
+
+The playbook's term for the constellation of agents/skills/automation
+that handles support, content, community, ops, and outbound discovery
+during the Launch stage — so the founder doesn't burn out doing 80%
+of it manually. This document is Caro's inventory: what we already
+have, what's a gap, and what's deliberately out of scope.
+
+> **TL;DR**: Caro has ~70% of a Launch OS. Hermes covers PR triage,
+> competitive intel, weekly briefings, and integration health.
+> Specialist agents and skills cover QA loop, beta feedback fixing,
+> PR management, idea sourcing, content marketing. The four named
+> gaps below are the highest-leverage Launch-stage builds.
+
+## Inventory
+
+### What we already have
+
+| Playbook capability | Caro implementation | Lives in |
+| --- | --- | --- |
+| PR triage (daily) | Hermes PR digest + routing comments | [`.hermes/AGENT.md`](../.hermes/AGENT.md) §1; `pr-management-loop` skill |
+| Competitive intel (weekly) | Hermes weekly market scan | [`.hermes/AGENT.md`](../.hermes/AGENT.md) §2 |
+| Cross-agent coordination | Hermes branch-conflict + duplicate-work detection | [`.hermes/AGENT.md`](../.hermes/AGENT.md) §3; [`.hermes/PROTOCOL.md`](../.hermes/PROTOCOL.md) |
+| Integration health monitoring | Hermes nightly + `caro-integrator-nightly` | [`.hermes/AGENT.md`](../.hermes/AGENT.md) §4 |
+| Release readiness assessment | `caro.release.acceptance` skill + Hermes audit | [`.claude/skills/`](../.claude/skills/) |
+| Executive briefings (weekly) | Hermes weekly digest in `.hermes/digests/` | [`.hermes/AGENT.md`](../.hermes/AGENT.md) §6 |
+| QA loop (continuous) | `qa-automation-loop` skill + `caro-frustrated-beta` agent | [`.claude/skills/`](../.claude/skills/), [`.claude/agents/`](../.claude/agents/) |
+| Beta-feedback triage | `beta-feedback-fixer` skill | [`.claude/skills/`](../.claude/skills/beta-feedback-fixer/) |
+| Content marketing | `ai-marketing-engineering` + `social-queue` skills | [`.claude/skills/`](../.claude/skills/) |
+| Idea sourcing | `idea-sourcing-loop` skill | [`.claude/skills/`](../.claude/skills/) |
+| Continuous product iteration | `caro-coder-loop` + Claude Code | [`.claude/skills/`](../.claude/skills/caro-coder-loop/) |
+| Translation pipeline | `gh workflow run translate.yml` (15 locales) | [`website/I18N_TRANSLATION_GUIDE.md`](../website/I18N_TRANSLATION_GUIDE.md) |
+| Beta cycle orchestration | `beta-test-cycles` + `unbiased-beta-tester` skills | [`.claude/skills/`](../.claude/skills/) |
+| Adversarial review (NEW) | `devils-advocate` agent | [`.claude/agents/devils-advocate.md`](../.claude/agents/devils-advocate.md) |
+| User discovery (NEW) | `caro.discovery` skill + `docs/discovery/` | [`.claude/skills/caro.discovery/`](../.claude/skills/caro.discovery/) |
+
+### What's a gap
+
+| Playbook capability | Why it matters at Launch | Current state | Next step |
+| --- | --- | --- | --- |
+| **Retention dashboard** | Stage-3 exit gate is "retention curve flattens"; we currently cannot compute D1/D7/D30 | Telemetry events collected (opt-in), no dashboard | Implement against [`retention-dashboard-spec.md`](./retention-dashboard-spec.md) |
+| **GitHub Discussions response triage** | First-touch latency on Discussions degrades community signal; founder shouldn't be the triage layer | Manual founder + occasional Hermes nudge | Spin out a `discussions-triage` skill modeled on `pr-management-loop` |
+| **Outbound discovery automation** | Gate-1 evidence (20 transcripts per hypothesis) requires identifying candidate users from public signals | Manual + Hermes competitive intel scans | Extend Hermes weekly scan with `candidate-users` output section |
+| **Multi-agent observability** | Hermes coordinates ~15 agents/skills; failure modes (agent drift, eval regression, conflicting outputs) are not currently instrumented | None | Stage-4 prerequisite; spec lives in a future ADR |
+
+### What's deliberately out of scope at Launch
+
+| Playbook capability | Why we're not building it yet |
+| --- | --- |
+| Live Discord with engagement automation | Community at our scale (~247 waitlist) fits in GitHub Discussions + DMs; Discord adds ops overhead that exceeds its value until a step-change in community size |
+| Personalized email lifecycle nurture | The waitlist Turso backend captures source / interests; one-touch follow-up is a Phase 5 pricing-page wedge, not a full nurture pipeline |
+| Outbound sales motion | ADR-001 Enterprise edition is in research; sales work is gated by pricing-page demand signal |
+| Cowork-based knowledge management | The playbook recommends Cowork for internal KM; we've documented in [`agentic-stack.md`](./agentic-stack.md) that Cowork's audit-log limitation makes it unsuitable for our Enterprise-bound positioning — re-evaluate after the audit-log gap closes |
+
+## How the existing pieces compose
+
+```
+Founder / contributor
+        │
+        ▼
+   beads queue ◄────────────── idea-sourcing-loop
+        │                              ▲
+        ▼                              │
+   coder-loop (Claude Code) ──────► PR opens
+        │                              │
+        ▼                              ▼
+   PR opens ──► pr-management-loop ──► Hermes triage ──► reviewer
+                       │                    │
+                       ▼                    ▼
+                  qa-automation-loop   .hermes/digests/
+                       │                    │
+                       ▼                    ▼
+                  release-prepare       executive briefing
+```
+
+The user-facing surface (caro.sh + the CLI itself) sits below this
+diagram; telemetry flows back into the retention dashboard (gap) and
+informs the next discovery cycle.
+
+## When you operate on this document
+
+- **Adding a new agent or skill**: append a row to the inventory
+  with a link to its definition file. If it closes a gap, move the
+  gap to "What we already have".
+- **Identifying a new gap**: append to "What's a gap" with a one-
+  sentence rationale and a concrete next step. Don't list gaps
+  without ownership.
+- **Closing a gap**: PR that closes the gap removes the row from
+  "What's a gap" and adds it to "What we already have", in the same
+  commit.
+- **Reclassifying scope**: if "deliberately out of scope" stops
+  being so, move the row up and explain in the PR description why
+  the calculus changed.
+
+## Stage-4 (Scale) extensions
+
+When Caro graduates to Stage 4, this document expands to cover:
+
+- Support intake (Claude Chat as entry point per [`agentic-stack.md`](./agentic-stack.md))
+- Multi-agent observability (the named gap above becomes a build)
+- Enterprise deployment ops (rollout automation, audit-trail
+  forwarding, policy distribution — per ADR-001)
+- Hiring + onboarding (the playbook's Stage 4 includes "team
+  expansion"; for Caro this means contributor onboarding, not
+  full-time hires)
+
+Until then, those rows are tracked elsewhere or simply not
+applicable.
+
+## See also
+
+- [`.hermes/AGENT.md`](../.hermes/AGENT.md) — the strategic-intel
+  agent that runs most of the existing Launch OS
+- [`.hermes/PROTOCOL.md`](../.hermes/PROTOCOL.md) — inter-agent
+  communication contract
+- [`retention-dashboard-spec.md`](./retention-dashboard-spec.md) —
+  the Stage-3 exit-gate measurement spec
+- [`agentic-stack.md`](./agentic-stack.md) — how Caro uses the
+  Anthropic product matrix internally
+- [`SECURITY-CHECKLIST.md`](./SECURITY-CHECKLIST.md) — the MVP-stage
+  security gates that the Launch OS does NOT relax
+- [`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md) — where this
+  Launch OS is taking us next

--- a/docs/retention-dashboard-spec.md
+++ b/docs/retention-dashboard-spec.md
@@ -1,0 +1,202 @@
+# Retention Dashboard Spec
+
+**Status**: Spec only. Implementation lives in a future PR.
+**Owner**: TBD (Stage-3 exit-gate work)
+**Source framework**: [Anthropic's Founder's Playbook, Stage 3 — Launch](https://claude.com/blog/the-founders-playbook)
+
+The Stage-3 exit gate from
+[`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md) is **retention
+curve flattens**. We cannot show that today because we collect the
+underlying telemetry events but do not aggregate them. This document
+specifies the dashboard we'd build — designed so it can ship without
+expanding the data we collect.
+
+## Hard constraints
+
+These constraints are non-negotiable. Any implementation that violates
+one fails review.
+
+1. **No new PII.** The retention dashboard uses only events already
+   collected per [`docs/TELEMETRY.md`](./TELEMETRY.md): session
+   start, session end, command-generation success/failure/timing,
+   backend identifier, error category. **No command content**, **no
+   file paths**, **no environment variables**, **no natural-language
+   prompts**, **no IP addresses beyond what's needed for
+   geo-region bucketing**.
+2. **Opt-in only.** Users who haven't opted into telemetry contribute
+   zero data. The dashboard's denominator is opt-in users, not
+   "everyone".
+3. **Anonymous session IDs only.** Existing session IDs are hash(machine_id
+   + date), rotated daily. The dashboard works on this hash, not on
+   stable user IDs. A user who uses Caro on day 1 and day 8 looks
+   like two different sessions — and that's intentional.
+4. **Aggregate-only published numbers.** Any dashboard view that
+   exposes <50 sessions in a bucket is suppressed. This protects
+   small cohorts (specific OS+shell+region combinations) from
+   re-identification.
+5. **Audit-trail of definitions.** Every metric's SQL/PromQL is
+   version-controlled in this repo so the methodology is reproducible.
+
+## Metrics
+
+### D1 / D7 / D30 retention (the headline)
+
+**Definition**: of users who opened Caro and ran ≥1 command on day
+0, what fraction came back and ran ≥1 command on day 1 / 7 / 30?
+
+**Cohort defense** (per `.claude/rules/validation-discipline.md` Gate
+5): the cohort is **users who completed ≥1 successful command on
+their first session**, not "everyone who installed Caro". A user who
+installed and never ran a command is interesting noise (install-funnel
+signal), not retention signal.
+
+**Caveat**: because session IDs rotate daily, "the same user across
+days" is reconstructed from a stable machine_id hash that is part of
+the session ID. The granularity is therefore "this machine ran a
+command on day N". Multi-machine users count as multiple users
+(under-counts retention). This is acceptable for the Sean Ellis
+check; flag it in the dashboard.
+
+### Activation depth
+
+**Definition**: of users in the retention cohort, fraction who
+completed ≥5 successful commands by end of week 1.
+
+**Why**: distinguishes "kicked the tires" from "adopted". The Sean
+Ellis defended-cohort definition uses this as the cohort filter for
+the qualitative survey.
+
+### Backend-success rate by backend
+
+**Definition**: among generated commands, fraction marked successful
+by backend (embedded / MLX / CPU / Ollama / vLLM / OpenRouter).
+
+**Why**: a backend with a 70% success rate while the population
+averages 94.8% is a quality regression hiding behind the average.
+
+### Time to First Command (TTFC)
+
+**Definition**: median + p95 seconds from session start to first
+successful command in the same session.
+
+**Why**: matches the existing v1.1.0 success-criterion (target <3s)
+and is the cleanest install-funnel telemetry we already collect.
+
+### Safety block rate
+
+**Definition**: fraction of generated commands the safety validator
+blocked at risk levels CRITICAL/HIGH/MEDIUM. Already informally
+tracked; surface in dashboard for trend visibility.
+
+### Error rate by category
+
+**Definition**: fraction of sessions that emitted ≥1 error event,
+sliced by error category (model-failure / safety-rejection / cache-
+miss / config / network / other). Categories per existing
+telemetry schema.
+
+## Sean Ellis instrument
+
+The playbook recommends the Sean Ellis test (>40% "very disappointed
+without your product") as the PMF check. The playbook also corrects
+the common misuse: the survey is only meaningful with a defended
+cohort.
+
+**Trigger condition**: send the survey to a sampled subset of users
+who:
+- Completed ≥5 successful commands in week 1 (activation depth), AND
+- Were on day ≥14 of opt-in telemetry, AND
+- Have not been sampled in the prior 90 days
+
+**Sample size target**: ≥200 responses per quarter. With the
+cohort filter above, this requires ~1,500 invited users; the
+opt-in cohort needs to be at that scale for the survey to even be
+runnable. *Until it is, we do not run the survey.* Running it on a
+smaller cohort and citing 47% is exactly the misuse the playbook
+warns about.
+
+**Delivery**: in-CLI prompt one time, dismissable, with a link to a
+form that does NOT require login. Form vendor TBD; the form's
+question text is in this spec so it doesn't drift.
+
+**Question text**:
+
+> "Caro is in early-stage development. To help us understand fit:
+> how would you feel if you could no longer use Caro?
+> [ ] Very disappointed
+> [ ] Somewhat disappointed
+> [ ] Not disappointed (it isn't really useful)
+> [ ] N/A — I no longer use it"
+
+Standard Sean Ellis phrasing. Don't tinker with it.
+
+## Surfaces
+
+| Surface | Audience | Update cadence | Visibility |
+| --- | --- | --- | --- |
+| **Internal dashboard** (Grafana / similar) | maintainers | hourly | private; auth-gated |
+| **Public North-Star** (caro.sh/telemetry or /metrics) | community | weekly | aggregate-only; no per-user data |
+| **Weekly briefing** (`.hermes/digests/`) | founder + maintainers | weekly | private; Hermes narrative + numbers |
+| **Quarterly retention report** | community + investors | quarterly | aggregate-only; methodology in this spec |
+
+The existing [`website/src/pages/telemetry.astro`](../website/src/pages/telemetry.astro)
+page is the natural home for the public-North-Star view.
+
+## Implementation notes
+
+- **Ingest**: the v1.1.0 roadmap mentions `telemetry.caro.sh` as the
+  ingest service (deferred post-release). This spec assumes that
+  service exists by the time the dashboard ships. If it doesn't, the
+  dashboard runs on locally-exported telemetry per `caro telemetry
+  export`.
+- **Storage**: time-series store (DuckDB / Postgres / ClickHouse —
+  TBD) with retention of raw events ≤ 13 months. Aggregates retained
+  indefinitely.
+- **Compute**: D7 is computed as a 7-day moving window of activation-
+  cohort returns. Don't use 7-day rolling totals (different metric).
+- **Backfill**: the metrics start with the v1.1.0 GA opt-in
+  population. Pre-GA telemetry was opt-out and is deliberately not
+  backfilled (different consent shape).
+- **Privacy review**: any change to the metric definitions requires a
+  re-run of [`docs/TELEMETRY.md`](./TELEMETRY.md)'s privacy audit.
+
+## What this dashboard does NOT show
+
+- **Individual users.** All views are aggregate.
+- **Command content.** No prompt strings, no command strings, no
+  files. The dashboard cannot answer "what commands are people
+  running".
+- **Cross-machine identity.** A user with two machines counts as
+  two; we don't reconstruct identity across devices.
+- **Cohorts smaller than 50 sessions.** Suppressed for re-identification
+  resistance.
+- **Real-time anything.** Latency is hours, not seconds. There is no
+  business reason for real-time.
+
+## How this serves the Stage-3 exit gate
+
+The [`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md) Stage-3 exit
+table:
+
+| Playbook criterion | What this dashboard provides |
+| --- | --- |
+| Retention curve flattens | D7 / D30 over rolling cohorts |
+| Proactive user recall | Sean Ellis result on defended cohort |
+| Sustainable CAC | (Out of scope until pricing-page demand signal lands; see Phase 5 of the playbook adaptation) |
+
+Two of three exit gates land here. The third (CAC) requires paid
+acquisition, which Caro does not run today.
+
+## See also
+
+- [`docs/TELEMETRY.md`](./TELEMETRY.md) — the telemetry contract this
+  spec must not violate
+- [`.claude/rules/validation-discipline.md`](../.claude/rules/validation-discipline.md) —
+  Gate 5 (Sean Ellis with defended cohort) — this dashboard is how
+  we clear it
+- [`playbook/STAGE_MAP.md`](../playbook/STAGE_MAP.md) — the stage
+  this measurement serves
+- [`docs/launch-os.md`](./launch-os.md) — the dashboard is one of the
+  four named Launch-OS gaps
+- [`website/src/pages/telemetry.astro`](../website/src/pages/telemetry.astro) —
+  natural home for the public-North-Star view

--- a/playbook/README.md
+++ b/playbook/README.md
@@ -1,0 +1,81 @@
+# Caro Playbook
+
+> The founder-arc adaptation of [Anthropic's "The Founder's Playbook:
+> Building an AI-native startup"](https://claude.com/blog/the-founders-playbook)
+> for Caro specifically.
+
+## Why this directory exists
+
+Caro is a real product (1.4.0 GA, May 2026) with a real distribution
+footprint (crates.io, Homebrew, npm, NuGet) and real users (~247 waitlist,
+public telemetry baseline of 94.8% CSR). It is **also** a founder-arc in
+motion: dual-track Community / Enterprise per
+[ADR-001](../docs/adr/ADR-001-enterprise-community-architecture.md),
+multi-agent operating layer, deliberate stage progression.
+
+The Anthropic playbook gave us a clean four-stage frame to name where we
+are and what comes next. This directory holds the Caro-specific
+adaptation. It does **not** restate the playbook (read the original);
+it maps the playbook onto Caro's evidence and our own existing artifacts.
+
+## Files
+
+- **[`STAGE_MAP.md`](./STAGE_MAP.md)** — Caro's location in the
+  Idea/MVP/Launch/Scale framework, with exit criteria, evidence, and
+  failure modes we've observed
+- **[`../COMPANY.md`](../COMPANY.md)** — One-page founder-arc narrative:
+  how Caro becomes a company, the dual-track model, what Scale looks
+  like for our category
+- **[`../MISSION.md`](../MISSION.md)** — Mission + values (preceded the
+  playbook adaptation; remains canonical)
+
+## What the playbook gave us (and what it didn't)
+
+### What we adopted
+
+| Playbook concept | Caro adaptation |
+| --- | --- |
+| 4-stage map | [`STAGE_MAP.md`](./STAGE_MAP.md) |
+| "Mistaking building for validating" | [`.claude/rules/validation-discipline.md`](../.claude/rules/validation-discipline.md) |
+| Counter AI confirmation bias | [`.claude/agents/devils-advocate.md`](../.claude/agents/devils-advocate.md) |
+| 20-transcript validation rule | [`docs/discovery/`](../docs/discovery/) directory + [discovery skill](../.claude/skills/caro.discovery/SKILL.md) |
+| Demoware-trap gate | "what breaks at 100 real users" section required in feature specs (see validation-discipline rule) |
+| Sean Ellis test (used correctly) | [`docs/retention-dashboard-spec.md`](../docs/retention-dashboard-spec.md) |
+| Launch operating system | [`docs/launch-os.md`](../docs/launch-os.md) — inventory + gaps |
+| MVP-stage security checklist | [`docs/SECURITY-CHECKLIST.md`](../docs/SECURITY-CHECKLIST.md) |
+| Product matrix (Chat/Cowork/Code/Platform) | [`docs/agentic-stack.md`](../docs/agentic-stack.md) |
+| Multi-model resilience (no vendor lock-in) | Already real; surfaced in marketing copy |
+
+### What we did NOT adopt
+
+- **The 9 consumer opportunities** (health, careers, relationships, money,
+  parenting, legal, life sciences, +2). Caro is in the developer-tool
+  guardian-agent category. We acknowledge the playbook's framing but
+  do not pivot toward consumer verticals.
+- **Fundraising posture**. The playbook is agnostic about funding source;
+  Caro's [`COMPANY.md`](../COMPANY.md) names dual-track community/
+  enterprise but commits to no specific funding round.
+- **Generic Cowork advocacy**. The playbook (and reviewers) noted that
+  Cowork activity is excluded from audit logs and compliance APIs,
+  making it unsuitable for some regulated workloads. Our
+  [`agentic-stack.md`](../docs/agentic-stack.md) names this caveat
+  explicitly and routes regulated work to Claude Code + the enterprise
+  audit trail per ADR-003.
+
+## How to use this directory
+
+- **As a contributor**: read `STAGE_MAP.md` to understand where Caro
+  is and what stage gate comes next. Your feature should make progress
+  against the current stage's exit criteria, not the next one's.
+- **As a reviewer**: a PR that claims to advance a stage should update
+  `STAGE_MAP.md` in the same commit with the evidence.
+- **As a founder making a strategic decision**: this directory is the
+  reference frame. If a decision doesn't fit the frame, update the
+  frame — don't ignore it.
+
+## Living document
+
+The playbook is dated May 14, 2026. Our adaptation is dated May 25,
+2026. If Anthropic publishes a v2 of the playbook, this directory gets
+reconciled in a single PR (one commit per affected file), with the
+reconciliation diff visible in the PR description.

--- a/playbook/STAGE_MAP.md
+++ b/playbook/STAGE_MAP.md
@@ -1,0 +1,184 @@
+# Caro Stage Map
+
+**Last Updated**: 2026-05-25
+**Source framework**: [Anthropic, "The Founder's Playbook: Building an AI-native startup"](https://claude.com/blog/the-founders-playbook) (May 14, 2026)
+
+This is Caro's location on the playbook's four-stage map. Each stage names
+the goal, the exit criteria the playbook proposes, the evidence Caro has
+against those criteria, and the failure modes we've already observed (or
+risk observing). When two readers disagree about where Caro is, this
+document is the tiebreaker.
+
+> **TL;DR**: Caro is **late MVP → early Launch**. We have a working core
+> loop, shipped distribution, and a public website, but we cannot yet show
+> a flat retention curve or a defended PMF cohort. The Launch-stage exit
+> gate is retention, not features.
+
+---
+
+## Stage 1 — Idea (✅ exited)
+
+**Playbook goal**: Validate a problem worth solving.
+**Playbook exit criterion**: 10 target users willing to pay.
+**Playbook failure modes**: obsessing over solutions, surveys over
+interviews, confusing competition-absence with opportunity, AI
+confirmation bias.
+
+### Caro's evidence
+
+- **Problem statement**: codified in [`MISSION.md`](../MISSION.md) — "the
+  barrier between intent and action shouldn't require memorizing syntax
+  from decades of accumulated conventions"
+- **Personas + jobs**: [`docs/PERSONAS_JTBD.md`](../docs/PERSONAS_JTBD.md),
+  [`docs/JOBS_TO_BE_DONE.md`](../docs/JOBS_TO_BE_DONE.md)
+- **Category positioning**: guardian-agent execution layer
+  ([`docs/GUARDIAN_AGENT.md`](../docs/GUARDIAN_AGENT.md)) — distinct from
+  policy / identity / audit categories
+- **Willingness-to-pay signal**: live waitlist (~247 signups), ADR-001
+  Community/Enterprise split with [enterprise value
+  proposition](../docs/enterprise/ENTERPRISE-VALUE-PROPOSITION.md) drafted
+
+### What we observed (failure-mode honesty)
+
+- The 10-paying-users criterion is **not** yet evidenced by transcripts —
+  the waitlist is a quantitative signal, not 10 first-hand interview
+  records. This is discovery-debt we accept for the core product line;
+  see `docs/discovery/` (lands Phase 3) for the format we'll use
+  going forward.
+- v2.0 product lines (Karo, Dogma, voice synthesis) **have not been
+  through Stage-1 validation**. They are flagged for retroactive audit
+  in [`docs/discovery/v2.0-validation-audit.md`](../docs/discovery/v2.0-validation-audit.md)
+  (Phase 3).
+
+---
+
+## Stage 2 — MVP (✅ exited)
+
+**Playbook goal**: Maintain engineering discipline under AI acceleration.
+**Playbook exit criterion**: demonstrable core loop + minimal security
+checklist (auth, API-key management, dependency audits).
+**Playbook failure modes**: "demoware trap" (impressive demos that don't
+survive real-world load); "mistaking building for validating".
+
+### Caro's evidence
+
+- **Core loop**: natural-language → safety-validated POSIX command,
+  shipped through 8 minor releases (v1.0 → v1.4)
+- **Quality bar**: 94.8% Command Success Rate (baseline from v1.1.0 beta,
+  vs. 75% plan target); 700+ eval cases in `tests/evaluation/`
+- **Engineering discipline**: tiered constitution
+  ([`.claude/rules/constitution.md`](../.claude/rules/constitution.md)),
+  Spec-Kit workflow, TDD-mandatory safety patterns, 33 domain agents,
+  feature-branch enforcement via PreToolUse hook
+- **Multi-backend resilience** (no single-model lock-in): MLX, CPU,
+  Ollama, vLLM, OpenRouter, embedded — explicit insulation against the
+  playbook's "single provider dependency" failure mode
+- **Security gates**: `cargo audit` in CI, secret scanning, AGPL-3.0
+  license discipline. Codified end-to-end in
+  [`docs/SECURITY-CHECKLIST.md`](../docs/SECURITY-CHECKLIST.md) (Phase 4).
+
+### What we observed (failure-mode honesty)
+
+- The "demoware trap" is the watch-out for v2.0. CaroML preview shipped
+  cleanly, but Karo distributed intelligence is at the demo stage where
+  the playbook warns most loudly.
+- "Mistaking building for validating" is a real risk: we have shipped
+  features without explicit transcript evidence. The new
+  `.claude/rules/validation-discipline.md` rule (Phase 2) is the
+  systemic answer.
+
+---
+
+## Stage 3 — Launch (⏳ in progress — **current stage**)
+
+**Playbook goal**: distinguish genuine traction from early enthusiasm.
+**Playbook exit criteria**: (a) retention curve flattens, (b) users
+proactively recall the product, (c) sustainable marginal cost of paid
+conversion.
+**Playbook failure modes**: "false prosperity trap" (mistaking early
+enthusiasm for sustainable PMF); Sean Ellis test misapplied to the wrong
+user cohort.
+
+### Caro's evidence
+
+- **Distribution shipped**: crates.io, Homebrew, npm, NuGet, WinGet
+  pending, one-line install script at setup.caro.sh
+- **Public surface**: caro.sh website (Astro 5, 58 pages, 15 locales),
+  docs site, [PITCH_DECK.md](../docs/PITCH_DECK.md),
+  [GTM_EXECUTION_PLAYBOOK.md](../docs/GTM_EXECUTION_PLAYBOOK.md),
+  [GTM_STRATEGY_FRAMEWORK.md](../docs/GTM_STRATEGY_FRAMEWORK.md)
+- **Launch operating system** (the playbook's term): Hermes does PR
+  triage + competitive intel + weekly briefings; agents handle QA loop,
+  PR management, beta feedback, idea sourcing. Inventory and gap
+  analysis in [`docs/launch-os.md`](../docs/launch-os.md) (Phase 4).
+- **Telemetry infrastructure**: opt-in, privacy-first, session events
+  collected. Enough raw material to compute D1/D7/D30 retention; the
+  computation itself is spec'd in
+  [`docs/retention-dashboard-spec.md`](../docs/retention-dashboard-spec.md)
+  (Phase 4) but not yet shipped.
+
+### Exit criteria — where we are
+
+| Playbook criterion | Caro status | Gap to exit |
+| --- | --- | --- |
+| Retention curve flattens | **No data** — telemetry collected, no dashboard yet | Ship `retention-dashboard-spec.md`; 90 days of opt-in cohort data |
+| Proactive user recall | Anecdotal (GitHub stars, waitlist) | Sean-Ellis instrument behind a documented cohort definition |
+| Sustainable CAC | **N/A** (no paid acquisition; no priced tier live yet) | Pricing draft lands Phase 5; Enterprise demand signal becomes the first paid-conversion telemetry |
+
+### What we're watching for (failure-mode honesty)
+
+- **False prosperity**: 247 waitlist + GitHub stars are interest, not
+  retention. Until D7 is published, we don't claim PMF.
+- **Sean Ellis misuse**: the playbook explicitly corrects the >40%
+  rule — it requires a defended cohort definition. Our cohort is
+  *not* "everyone who installed Caro"; it's "users who completed at
+  least 5 commands in week 1". This is named in the retention spec.
+
+---
+
+## Stage 4 — Scale (🔭 mapped, not entered)
+
+**Playbook goal**: build a replicable "agentic operating system" across
+business functions.
+**Playbook exit criterion**: stable, orchestrated AI-powered workflows
+across product, support, ops, marketing.
+**Playbook failure modes**: single-provider dependency; inadequate
+observability of multi-agent systems.
+
+### Caro's planned shape
+
+- **Commercial model**: dual-track per
+  [ADR-001](../docs/adr/ADR-001-enterprise-community-architecture.md) —
+  Community Edition stays AGPL-3.0 free-forever; Enterprise Edition is
+  a premium plugin suite (CISO dashboard, centralized governance, audit
+  trails, IT rollout integration). Value proposition: one prevented
+  security incident pays for years of licensing.
+- **Multi-agent ops**: Hermes already runs as the non-coding strategic
+  layer ([`.hermes/AGENT.md`](../.hermes/AGENT.md)). Scale-stage work
+  extends this to support intake (Chat), knowledge management (Cowork
+  as candidate), continuous product iteration (Code — current). See
+  [`docs/agentic-stack.md`](../docs/agentic-stack.md) (Phase 4).
+- **Multi-model resilience**: already real, called out explicitly above
+- **Multi-agent observability**: gap — `docs/launch-os.md` names this as
+  a Scale-stage prerequisite
+
+### What this stage looks like for a guardian-agent execution layer
+
+The 9 consumer opportunities the playbook lists (health, careers,
+relationships, money, parenting, legal, life sciences, +2) are not
+Caro's category. Caro's Scale-stage opportunity is **horizontal
+adoption inside organizations that already deploy AI coding agents** —
+the 60% of orgs that have no AI governance policy
+([per ENTERPRISE-VALUE-PROPOSITION.md](../docs/enterprise/ENTERPRISE-VALUE-PROPOSITION.md)).
+
+---
+
+## How to update this file
+
+- Cite evidence, not vibes. Every status claim must link to a file or
+  metric that backs it.
+- When a stage transition happens (e.g. retention curve flattens), the
+  PR that ships the proof updates this map in the same commit. No
+  silent stage promotions.
+- When the playbook is amended by Anthropic or by us, this map is the
+  first thing that gets reconciled.

--- a/website/src/i18n/locales/en/playbook.json
+++ b/website/src/i18n/locales/en/playbook.json
@@ -1,0 +1,86 @@
+{
+  "playbook": {
+    "meta": {
+      "title": "The Caro Playbook — Where we are, where we're going",
+      "description": "Caro's founder-arc stage map adapted from Anthropic's Founder's Playbook. We're at late MVP heading into Launch. The next gate is retention, not features."
+    },
+    "hero": {
+      "eyebrow": "Founder Playbook",
+      "title": "Where Caro is on the founder arc",
+      "subtitle": "We adapted Anthropic's Founder's Playbook into a stage map you can actually inspect — with the evidence, the gaps, and the honest failure modes we're watching for."
+    },
+    "intro": {
+      "heading": "Why we publish this",
+      "body": "Most companies tell you they have product-market fit. We tell you the four-stage map we're on, where we sit on it, and what evidence we'd need to claim the next stage. The playbook came from Anthropic; the honesty is the only way to make it useful."
+    },
+    "stages": {
+      "idea": {
+        "title": "Stage 1 — Idea",
+        "status": "Exited",
+        "summary": "Problem validated. Personas documented. Distribution channels live. Waitlist signal is real (~247) but qualitative — quantitative validation gates are codified now to apply forward from May 25, 2026.",
+        "evidence": "MISSION.md, docs/PERSONAS_JTBD.md, docs/JOBS_TO_BE_DONE.md, live waitlist on caro.sh"
+      },
+      "mvp": {
+        "title": "Stage 2 — MVP",
+        "status": "Exited",
+        "summary": "Core loop ships at 94.8% Command Success Rate. Multi-backend by construction (no single-vendor lock-in). 52+ dangerous-command patterns. 700+ eval cases. Engineering discipline encoded in a tiered constitution.",
+        "evidence": "Cargo.toml v1.4.0, tests/evaluation/, src/safety/patterns.rs, .claude/rules/constitution.md"
+      },
+      "launch": {
+        "title": "Stage 3 — Launch",
+        "status": "Current",
+        "summary": "Distribution shipped (crates.io, Homebrew, npm, NuGet, install script). Public surface shipped (15-locale website, docs). The exit gate is retention, not features. Until we publish a defended D7 curve, we do not claim PMF.",
+        "evidence": "Multi-channel distribution, telemetry infrastructure, docs/retention-dashboard-spec.md (spec only; dashboard not yet shipped)"
+      },
+      "scale": {
+        "title": "Stage 4 — Scale",
+        "status": "Mapped, not entered",
+        "summary": "Dual-track Community / Enterprise per ADR-001. Multi-agent operating layer in place (Hermes + 33 domain agents). Scale is horizontal adoption inside orgs that already deploy AI coding agents — not consumer pivots.",
+        "evidence": "docs/adr/ADR-001-enterprise-community-architecture.md, docs/enterprise/MOAT.md, .hermes/AGENT.md"
+      }
+    },
+    "discipline": {
+      "heading": "The five gates we now apply to ourselves",
+      "body": "Adopting the playbook meant codifying its anti-confirmation-bias practices as a constitution rule. New product lines clear five gates before the spec graduates from research to implementation.",
+      "gates": [
+        {
+          "name": "20 first-hand transcripts",
+          "body": "Real interviews, not surveys, not stars, not waitlist counts. 20 conversations surfacing at least 3 distinct pain patterns."
+        },
+        {
+          "name": "No surveys as primary evidence",
+          "body": "Surveys size hypotheses after qualitative interviews surface them — never replace them."
+        },
+        {
+          "name": "What breaks at 100 real users",
+          "body": "Every spec names the demoware-trap failure mode and the instrumentation that would detect it."
+        },
+        {
+          "name": "Devil's-advocate review",
+          "body": "An adversarial agent interrogates AI-drafted proposals before merge to counter confirmation bias."
+        },
+        {
+          "name": "Sean Ellis with a defended cohort",
+          "body": "PMF claims require both the >40% threshold and a cohort definition we can defend — not 'everyone who installed'."
+        }
+      ]
+    },
+    "audit": {
+      "heading": "We audited our own roadmap against these gates",
+      "body": "Five v2.0 product lines moved to Research (unvalidated) because they had zero first-hand transcripts: Karo distributed intelligence, Dogma rule engine, voice synthesis, self-healing, and local context indexing. The four items that extend the already-validated core loop (Azure Foundry, vLLM Jukebox, Skills extension, Handy.Computer) pass as extensions and remain on v2.0.",
+      "linkText": "Read the full retroactive audit",
+      "linkHref": "https://github.com/wildcard/caro/blob/main/docs/discovery/v2.0-validation-audit.md"
+    },
+    "links": {
+      "heading": "Read the work",
+      "stageMap": "Full stage map",
+      "company": "How Caro becomes a company",
+      "rule": "Validation discipline rule",
+      "discovery": "Discovery directory",
+      "launchOs": "Launch operating system inventory",
+      "retention": "Retention dashboard spec",
+      "agenticStack": "How we use Chat / Cowork / Code / Platform",
+      "source": "The original playbook"
+    }
+  }
+}

--- a/website/src/pages/blog/founders-playbook-adaptation.astro
+++ b/website/src/pages/blog/founders-playbook-adaptation.astro
@@ -1,0 +1,214 @@
+---
+import BlogPost from '../../layouts/BlogPost.astro';
+---
+
+<BlogPost
+  title="Caro's founder arc: adopting Anthropic's playbook with a safety-first execution layer"
+  description="We adapted Anthropic's Founder's Playbook into Caro's codebase as a stage map, a validation-discipline rule, and a retroactive audit that downgraded five v2.0 features. Here's what changed and why."
+  date="2026-05-25"
+  readTime="9 min read"
+  tags={["company", "playbook", "validation", "AI-native", "founder"]}
+>
+
+<p>
+  In May 2026, Anthropic published
+  <a href="https://claude.com/blog/the-founders-playbook" target="_blank" rel="noopener noreferrer">The Founder's Playbook: Building an AI-native startup</a>.
+  It reframes the startup arc into four stages — Idea, MVP, Launch, Scale —
+  and argues that AI has removed three historical bottlenecks
+  (capital, headcount, technical skill). The new constraint, the playbook
+  says, is <em>what a founder chooses to build</em>, and that constraint
+  makes validation discipline more important, not less.
+</p>
+
+<p>
+  We took the playbook seriously. This post is the diff: what we adopted,
+  what we deliberately did not adopt, and what changed in the codebase as
+  a result.
+</p>
+
+<h2>The premise we believed</h2>
+
+<p>
+  The playbook's central warning is "mistaking building for validating".
+  When a prototype takes an afternoon instead of a quarter, founders
+  confuse the prototype's existence with proof that anyone wants it. AI
+  amplifies this because models trained to be helpful will happily justify
+  any idea you ask them to justify — confirmation bias on demand.
+</p>
+
+<p>
+  We have lived through this. Caro is at v1.4.0 with a 94.8% Command
+  Success Rate and ~247 waitlist signups. The product works. But "the
+  product works" and "we have product-market fit" are different claims,
+  and the discipline to keep them separate is exactly what the playbook
+  is about.
+</p>
+
+<h2>Where we are on the map</h2>
+
+<p>
+  We wrote a
+  <a href="https://github.com/wildcard/caro/blob/main/playbook/STAGE_MAP.md">stage map</a>
+  and the answer is: <strong>late MVP heading into Launch</strong>. The
+  core loop ships, distribution ships across crates.io / Homebrew / npm /
+  NuGet, the public surface ships in 15 locales. The exit gate from Launch
+  is <strong>retention</strong>, not features. Until we publish a defended
+  D7 retention curve, we do not claim product-market fit. We wrote a
+  <a href="https://github.com/wildcard/caro/blob/main/docs/retention-dashboard-spec.md">spec for what that dashboard would look like</a> — designed so it can ship without expanding the
+  telemetry we collect.
+</p>
+
+<h2>The five gates we now apply to ourselves</h2>
+
+<p>
+  Adopting the playbook meant codifying its anti-confirmation-bias
+  practices as a constitution rule
+  (<a href="https://github.com/wildcard/caro/blob/main/.claude/rules/validation-discipline.md">validation-discipline.md</a>).
+  Every new product line or major feature spec must clear five gates
+  before the implementation PR can open:
+</p>
+
+<ol>
+  <li><strong>20 first-hand interview transcripts</strong>, not 20 tweets, not 20 GitHub Issues, not 20 waitlist signups. Real conversations with real users, surfacing at least three distinct pain patterns.</li>
+  <li><strong>No surveys as primary evidence.</strong> Surveys size hypotheses; they don't surface them.</li>
+  <li><strong>"What breaks at 100 real users"</strong> — every spec names the demoware-trap failure mode and the instrumentation that would catch it.</li>
+  <li><strong>Devil's-advocate review</strong> by an adversarial agent designed to interrogate AI-drafted proposals, not justify them.</li>
+  <li><strong>Sean Ellis with a defended cohort</strong>. The 40%-very-disappointed result is meaningless without a defended definition of who counts as a user.</li>
+</ol>
+
+<p>
+  The rule has teeth. After we wrote it, we audited our own v2.0 roadmap
+  against it.
+</p>
+
+<h2>What the audit changed</h2>
+
+<p>
+  We
+  <a href="https://github.com/wildcard/caro/blob/main/docs/discovery/v2.0-validation-audit.md">audited every v2.0 product line</a>
+  in research. Five product lines moved to <strong>Research (unvalidated)</strong>
+  because they had zero first-hand interview transcripts:
+</p>
+
+<ul>
+  <li><em>Karo distributed terminal intelligence</em></li>
+  <li><em>Dogma rule engine</em></li>
+  <li><em>Voice synthesis</em></li>
+  <li><em>Self-healing features</em></li>
+  <li><em>Local context indexing</em></li>
+</ul>
+
+<p>
+  The four items that <strong>extend</strong> the already-validated core
+  loop — Azure Foundry backend, vLLM Jukebox multi-model, the Skills
+  extension system, and the Handy.Computer integration — pass as
+  extensions and remain on v2.0. The audit principle is clean: extending
+  a validated core doesn't re-trigger Gate 1; proposing a <em>new</em>
+  product line does.
+</p>
+
+<p>
+  We did not delete those five product lines. They live in a "Research
+  (unvalidated)" section above the v2.0 milestone, with a discovery-debt
+  beads epic to backfill interviews. Some of them are likely to come back
+  fully validated; some, we expect, will be quietly invalidated when the
+  20 transcripts surface the real pain — and that's signal, not failure.
+  An invalidated hypothesis saves a build cycle.
+</p>
+
+<h2>What we did not adopt</h2>
+
+<p>
+  The playbook is not gospel and we are not Anthropic's median reader.
+  Three deliberate non-adoptions:
+</p>
+
+<p>
+  <strong>The nine consumer opportunities</strong> (health, careers,
+  relationships, money, parenting, legal, life sciences, plus two). These
+  are real opportunities the playbook says Anthropic explicitly won't
+  enter. They're not our category. Caro is a developer-tool guardian
+  agent — the slice between an LLM (or a human) drafting a shell command
+  and that command running on a real machine. Pivoting into consumer
+  verticals would be exactly the kind of move the validation rule is
+  supposed to catch.
+</p>
+
+<p>
+  <strong>Claude Cowork for internal knowledge management.</strong> The
+  playbook recommends Cowork for internal KM. Reviewers of the playbook
+  noted that Cowork activity is currently excluded from audit logs and
+  compliance APIs — making it structurally unsuitable for regulated
+  workloads despite the playbook's recommendation. Caro's Enterprise
+  positioning under
+  <a href="https://github.com/wildcard/caro/blob/main/docs/adr/ADR-001-enterprise-community-architecture.md">ADR-001</a>
+  is explicitly about audit-trail-forwarding and centralized policy
+  distribution for CISO buyers. Building our own KM on a tool we couldn't
+  sell to our own enterprise customer would be hypocritical. We use the
+  repo as the KM substrate and Hermes as the synthesis layer.
+</p>
+
+<p>
+  <strong>A specific funding posture.</strong> The playbook is agnostic
+  about whether you bootstrap, raise a seed, or stay open-source-funded.
+  Our
+  <a href="https://github.com/wildcard/caro/blob/main/COMPANY.md">COMPANY.md</a>
+  commits to four things we won't do — cripple the core to upsell,
+  telemetry-as-business-model, pivot to consumer, close the safety
+  patterns — and lets the funding choice remain a founder decision that
+  must be compatible with those constraints.
+</p>
+
+<h2>The honest part</h2>
+
+<p>
+  Some of this is performative. We could have written a 20-page strategy
+  doc nobody reads. The reason these artifacts are likely to actually
+  load-bear is that they live where the work lives — alongside the
+  Cargo.toml, the safety patterns, the constitution. The
+  <code>validation-discipline.md</code> rule is in the same directory as
+  the rule that blocks commits to main. The devil's-advocate agent is
+  in the same directory as the rust-cli-expert. The discovery transcripts
+  live one <code>cd</code> away from the safety patterns they will, over
+  time, justify.
+</p>
+
+<p>
+  We're publishing this because the playbook's premise depends on
+  honesty being the cheap part. "Where are you on the four-stage map?"
+  is a question every AI-native company should be able to answer in
+  one paragraph. Ours is the
+  <a href="https://github.com/wildcard/caro/blob/main/playbook/STAGE_MAP.md">stage map</a>:
+  late MVP heading into Launch, gated on retention. Yours might be
+  Stage 1 still doing 20 interviews. Either is fine. What's not fine is
+  conflating prototype existence with demand.
+</p>
+
+<h2>What's next</h2>
+
+<p>
+  Phase 5 of this adaptation lands the public-facing pages
+  (<a href="/playbook">/playbook</a>, this blog post, a draft
+  <a href="/pricing">/pricing</a>). Phases 1–4 landed the internal
+  scaffolding — rule, agent, skill, discovery directory, retroactive
+  audit, Launch-OS inventory, retention-dashboard spec, security
+  checklist, agentic-stack record. All five phases are in
+  <a href="https://github.com/wildcard/caro/pulls">a single feature
+  branch's PR history</a>.
+</p>
+
+<p>
+  The retention dashboard is the next real build. The Sean Ellis
+  instrument is blocked until the opt-in cohort reaches a defendable
+  size; running it earlier and citing 47% is exactly the misuse the
+  playbook warns about. And the discovery-debt epic seeds the
+  interviews that decide which v2.0 product lines come back.
+</p>
+
+<p>
+  If you want to be on the other end of one of those 20 interviews,
+  drop us a note via the
+  <a href="/">waitlist</a> and we'll reach out.
+</p>
+
+</BlogPost>

--- a/website/src/pages/playbook.astro
+++ b/website/src/pages/playbook.astro
@@ -191,7 +191,7 @@ const repo = 'https://github.com/wildcard/caro';
     max-width: 880px;
     margin: 0 auto;
     padding: 4rem 1.5rem 6rem;
-    color: var(--fg, #111);
+    color: var(--fg);
   }
 
   .hero {
@@ -203,7 +203,7 @@ const repo = 'https://github.com/wildcard/caro';
     text-transform: uppercase;
     letter-spacing: 0.12em;
     font-size: 0.85rem;
-    color: var(--accent, #d73a49);
+    color: var(--accent);
     margin-bottom: 0.75rem;
   }
 
@@ -217,7 +217,7 @@ const repo = 'https://github.com/wildcard/caro';
     font-size: 1.15rem;
     line-height: 1.55;
     max-width: 60ch;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
   }
 
   .playbook h2 {
@@ -235,7 +235,7 @@ const repo = 'https://github.com/wildcard/caro';
   .discipline-intro {
     font-size: 1.05rem;
     line-height: 1.6;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
   }
 
   .stage-grid {
@@ -245,15 +245,15 @@ const repo = 'https://github.com/wildcard/caro';
   }
 
   .stage {
-    border: 1px solid var(--border, #e5e5e5);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1.25rem 1.25rem 1rem;
-    background: var(--bg-card, #fafafa);
+    background: var(--bg-raised);
   }
 
   .stage--current {
-    border-color: var(--accent, #d73a49);
-    background: var(--bg-card-accent, #fff5f5);
+    border-color: var(--accent);
+    background: var(--bg-subtle);
   }
 
   .stage-header {
@@ -270,29 +270,33 @@ const repo = 'https://github.com/wildcard/caro';
     letter-spacing: 0.08em;
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
-    background: var(--bg-soft, #eee);
-    color: var(--fg-soft, #444);
+    background: var(--bg-subtle);
+    color: var(--fg-muted);
     white-space: nowrap;
   }
 
+  /* NOTE: status badge tint colors are hardcoded pending a Claude
+     Design decision on whether to add semantic --status-done-bg /
+     --status-planned-bg tokens. Tracked as P2 in the design audit
+     for PR #1174. */
   .status--done {
-    background: var(--bg-soft, #eef9ef);
-    color: var(--fg-soft, #2a6b2f);
+    background: #eef9ef;
+    color: #2a6b2f;
   }
 
   .status--current {
-    background: var(--accent, #d73a49);
-    color: white;
+    background: var(--accent);
+    color: var(--caro-white, #ffffff);
   }
 
   .status--planned {
-    background: var(--bg-soft, #f1efff);
-    color: var(--fg-soft, #4a3e8c);
+    background: #f1efff;
+    color: #4a3e8c;
   }
 
   .stage p {
     line-height: 1.55;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
     font-size: 0.98rem;
     margin: 0 0 0.75rem;
   }
@@ -301,9 +305,9 @@ const repo = 'https://github.com/wildcard/caro';
     list-style: none;
     padding: 0;
     margin: 0;
-    font-family: var(--font-mono, ui-monospace, monospace);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.85rem;
-    color: var(--fg-soft, #555);
+    color: var(--fg-muted);
   }
 
   .evidence li {
@@ -321,36 +325,41 @@ const repo = 'https://github.com/wildcard/caro';
 
   .gates li {
     counter-increment: gate;
-    border-left: 3px solid var(--accent, #d73a49);
+    border: 1px solid var(--border);
     padding: 0.75rem 1rem;
-    background: var(--bg-card, #fafafa);
-    border-radius: 0 6px 6px 0;
+    background: var(--bg-raised);
+    border-radius: 6px;
+    transition: border-color 0.15s ease;
+  }
+
+  .gates li:hover {
+    border-color: var(--accent);
   }
 
   .gates h3::before {
     content: 'Gate ' counter(gate) ' — ';
-    color: var(--accent, #d73a49);
+    color: var(--accent);
     font-weight: 500;
   }
 
   .gates p {
     margin: 0;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
     line-height: 1.55;
   }
 
   .audit em {
     font-style: normal;
-    background: var(--bg-soft, #f3f3f3);
+    background: var(--bg-subtle);
     padding: 0.05rem 0.3rem;
     border-radius: 3px;
-    font-family: var(--font-mono, ui-monospace, monospace);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.92em;
   }
 
   .audit a,
   .links a {
-    color: var(--accent, #d73a49);
+    color: var(--accent);
     text-decoration: none;
     border-bottom: 1px solid currentColor;
   }
@@ -365,22 +374,10 @@ const repo = 'https://github.com/wildcard/caro';
 
   .links li {
     padding: 0.4rem 0;
-    border-bottom: 1px solid var(--border, #eee);
+    border-bottom: 1px solid var(--border);
   }
 
-  @media (prefers-color-scheme: dark) {
-    .playbook {
-      color: var(--fg, #f5f5f5);
-    }
-    .stage {
-      background: var(--bg-card, #1a1a1a);
-      border-color: var(--border, #2a2a2a);
-    }
-    .stage--current {
-      background: var(--bg-card-accent, #2a1a1a);
-    }
-    .gates li {
-      background: var(--bg-card, #1a1a1a);
-    }
-  }
+  /* Dark mode is handled by tokens.css — all semantic tokens above
+     (--bg-raised, --bg-subtle, --fg, --fg-muted, --border, --accent)
+     resolve correctly under prefers-color-scheme: dark. */
 </style>

--- a/website/src/pages/playbook.astro
+++ b/website/src/pages/playbook.astro
@@ -1,0 +1,386 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navigation from '../components/Navigation.astro';
+
+const stages = [
+  {
+    id: 'idea',
+    title: 'Stage 1 — Idea',
+    status: 'Exited',
+    statusTone: 'done',
+    summary:
+      'Problem validated. Personas documented. Distribution channels live. Waitlist signal is real (~247) but qualitative — quantitative validation gates are codified now to apply forward from May 25, 2026.',
+    evidence: [
+      'MISSION.md',
+      'docs/PERSONAS_JTBD.md',
+      'docs/JOBS_TO_BE_DONE.md',
+      'live waitlist on caro.sh',
+    ],
+  },
+  {
+    id: 'mvp',
+    title: 'Stage 2 — MVP',
+    status: 'Exited',
+    statusTone: 'done',
+    summary:
+      'Core loop ships at 94.8% Command Success Rate. Multi-backend by construction (no single-vendor lock-in). 52+ dangerous-command patterns. 700+ eval cases. Engineering discipline encoded in a tiered constitution.',
+    evidence: [
+      'Cargo.toml v1.4.0',
+      'tests/evaluation/',
+      'src/safety/patterns.rs',
+      '.claude/rules/constitution.md',
+    ],
+  },
+  {
+    id: 'launch',
+    title: 'Stage 3 — Launch',
+    status: 'Current stage',
+    statusTone: 'current',
+    summary:
+      'Distribution shipped (crates.io, Homebrew, npm, NuGet, install script). Public surface shipped (15-locale website, docs). The exit gate is retention, not features. Until we publish a defended D7 curve, we do not claim PMF.',
+    evidence: [
+      'Multi-channel distribution',
+      'Telemetry infrastructure',
+      'docs/retention-dashboard-spec.md (spec only; dashboard not yet shipped)',
+    ],
+  },
+  {
+    id: 'scale',
+    title: 'Stage 4 — Scale',
+    status: 'Mapped, not entered',
+    statusTone: 'planned',
+    summary:
+      'Dual-track Community / Enterprise per ADR-001. Multi-agent operating layer in place (Hermes + 33 domain agents). Scale is horizontal adoption inside orgs that already deploy AI coding agents — not consumer pivots.',
+    evidence: [
+      'docs/adr/ADR-001-enterprise-community-architecture.md',
+      'docs/enterprise/MOAT.md',
+      '.hermes/AGENT.md',
+    ],
+  },
+];
+
+const gates = [
+  {
+    name: '20 first-hand transcripts',
+    body: 'Real interviews, not surveys, not stars, not waitlist counts. 20 conversations surfacing at least 3 distinct pain patterns.',
+  },
+  {
+    name: 'No surveys as primary evidence',
+    body: 'Surveys size hypotheses after qualitative interviews surface them — never replace them.',
+  },
+  {
+    name: 'What breaks at 100 real users',
+    body: 'Every spec names the demoware-trap failure mode and the instrumentation that would detect it.',
+  },
+  {
+    name: "Devil's-advocate review",
+    body: 'An adversarial agent interrogates AI-drafted proposals before merge to counter confirmation bias.',
+  },
+  {
+    name: 'Sean Ellis with a defended cohort',
+    body: 'PMF claims require both the >40% threshold and a cohort definition we can defend — not "everyone who installed".',
+  },
+];
+
+const repo = 'https://github.com/wildcard/caro';
+---
+
+<Layout
+  title="The Caro Playbook — Where we are, where we're going"
+  description="Caro's founder-arc stage map adapted from Anthropic's Founder's Playbook. We're at late MVP heading into Launch. The next gate is retention, not features."
+>
+  <Navigation />
+
+  <main class="playbook">
+    <header class="hero">
+      <p class="eyebrow">Founder Playbook</p>
+      <h1>Where Caro is on the founder arc</h1>
+      <p class="subtitle">
+        We adapted
+        <a href="https://claude.com/blog/the-founders-playbook" target="_blank" rel="noopener noreferrer">
+          Anthropic's Founder's Playbook
+        </a>
+        into a stage map you can actually inspect — with the evidence,
+        the gaps, and the honest failure modes we're watching for.
+      </p>
+    </header>
+
+    <section class="intro">
+      <h2>Why we publish this</h2>
+      <p>
+        Most companies tell you they have product-market fit. We tell
+        you the four-stage map we're on, where we sit on it, and what
+        evidence we'd need to claim the next stage. The playbook came
+        from Anthropic; the honesty is the only way to make it useful.
+      </p>
+    </section>
+
+    <section class="stages">
+      <h2>The four stages</h2>
+      <div class="stage-grid">
+        {stages.map((stage) => (
+          <article class={`stage stage--${stage.statusTone}`}>
+            <div class="stage-header">
+              <h3>{stage.title}</h3>
+              <span class={`status status--${stage.statusTone}`}>{stage.status}</span>
+            </div>
+            <p>{stage.summary}</p>
+            <ul class="evidence">
+              {stage.evidence.map((item) => (
+                <li>{item}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+
+    <section class="discipline">
+      <h2>The five gates we now apply to ourselves</h2>
+      <p class="discipline-intro">
+        Adopting the playbook meant codifying its anti-confirmation-bias
+        practices as a constitution rule. New product lines clear five
+        gates before the spec graduates from research to implementation.
+      </p>
+      <ol class="gates">
+        {gates.map((gate) => (
+          <li>
+            <h3>{gate.name}</h3>
+            <p>{gate.body}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+
+    <section class="audit">
+      <h2>We audited our own roadmap against these gates</h2>
+      <p>
+        Five v2.0 product lines moved to <strong>Research (unvalidated)</strong>
+        because they had zero first-hand transcripts: <em>Karo distributed
+        intelligence</em>, <em>Dogma rule engine</em>, <em>voice synthesis</em>,
+        <em>self-healing</em>, and <em>local context indexing</em>. The four
+        items that extend the already-validated core loop (Azure Foundry,
+        vLLM Jukebox, Skills extension, Handy.Computer) pass as extensions
+        and remain on v2.0.
+      </p>
+      <p>
+        <a href={`${repo}/blob/main/docs/discovery/v2.0-validation-audit.md`}>
+          Read the full retroactive audit →
+        </a>
+      </p>
+    </section>
+
+    <section class="links">
+      <h2>Read the work</h2>
+      <ul>
+        <li><a href={`${repo}/blob/main/playbook/STAGE_MAP.md`}>Full stage map</a></li>
+        <li><a href={`${repo}/blob/main/COMPANY.md`}>How Caro becomes a company</a></li>
+        <li><a href={`${repo}/blob/main/.claude/rules/validation-discipline.md`}>Validation discipline rule</a></li>
+        <li><a href={`${repo}/tree/main/docs/discovery`}>Discovery directory</a></li>
+        <li><a href={`${repo}/blob/main/docs/launch-os.md`}>Launch operating system inventory</a></li>
+        <li><a href={`${repo}/blob/main/docs/retention-dashboard-spec.md`}>Retention dashboard spec</a></li>
+        <li><a href={`${repo}/blob/main/docs/agentic-stack.md`}>How we use Chat / Cowork / Code / Platform</a></li>
+        <li><a href="https://claude.com/blog/the-founders-playbook" target="_blank" rel="noopener noreferrer">The original playbook</a></li>
+      </ul>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  .playbook {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+    color: var(--fg, #111);
+  }
+
+  .hero {
+    text-align: left;
+    margin-bottom: 3rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    color: var(--accent, #d73a49);
+    margin-bottom: 0.75rem;
+  }
+
+  .playbook h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.1;
+    margin: 0 0 1.25rem;
+  }
+
+  .subtitle {
+    font-size: 1.15rem;
+    line-height: 1.55;
+    max-width: 60ch;
+    color: var(--fg-soft, #444);
+  }
+
+  .playbook h2 {
+    font-size: 1.5rem;
+    margin: 3rem 0 1rem;
+  }
+
+  .playbook h3 {
+    font-size: 1.1rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .intro p,
+  .audit p,
+  .discipline-intro {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--fg-soft, #444);
+  }
+
+  .stage-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+
+  .stage {
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: 8px;
+    padding: 1.25rem 1.25rem 1rem;
+    background: var(--bg-card, #fafafa);
+  }
+
+  .stage--current {
+    border-color: var(--accent, #d73a49);
+    background: var(--bg-card-accent, #fff5f5);
+  }
+
+  .stage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .status {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    background: var(--bg-soft, #eee);
+    color: var(--fg-soft, #444);
+    white-space: nowrap;
+  }
+
+  .status--done {
+    background: var(--bg-soft, #eef9ef);
+    color: var(--fg-soft, #2a6b2f);
+  }
+
+  .status--current {
+    background: var(--accent, #d73a49);
+    color: white;
+  }
+
+  .status--planned {
+    background: var(--bg-soft, #f1efff);
+    color: var(--fg-soft, #4a3e8c);
+  }
+
+  .stage p {
+    line-height: 1.55;
+    color: var(--fg-soft, #444);
+    font-size: 0.98rem;
+    margin: 0 0 0.75rem;
+  }
+
+  .evidence {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.85rem;
+    color: var(--fg-soft, #555);
+  }
+
+  .evidence li {
+    padding: 0.15rem 0;
+  }
+
+  .gates {
+    counter-reset: gate;
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .gates li {
+    counter-increment: gate;
+    border-left: 3px solid var(--accent, #d73a49);
+    padding: 0.75rem 1rem;
+    background: var(--bg-card, #fafafa);
+    border-radius: 0 6px 6px 0;
+  }
+
+  .gates h3::before {
+    content: 'Gate ' counter(gate) ' — ';
+    color: var(--accent, #d73a49);
+    font-weight: 500;
+  }
+
+  .gates p {
+    margin: 0;
+    color: var(--fg-soft, #444);
+    line-height: 1.55;
+  }
+
+  .audit em {
+    font-style: normal;
+    background: var(--bg-soft, #f3f3f3);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.92em;
+  }
+
+  .audit a,
+  .links a {
+    color: var(--accent, #d73a49);
+    text-decoration: none;
+    border-bottom: 1px solid currentColor;
+  }
+
+  .links ul {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .links li {
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border, #eee);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .playbook {
+      color: var(--fg, #f5f5f5);
+    }
+    .stage {
+      background: var(--bg-card, #1a1a1a);
+      border-color: var(--border, #2a2a2a);
+    }
+    .stage--current {
+      background: var(--bg-card-accent, #2a1a1a);
+    }
+    .gates li {
+      background: var(--bg-card, #1a1a1a);
+    }
+  }
+</style>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -1,0 +1,335 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navigation from '../components/Navigation.astro';
+
+const tiers = [
+  {
+    id: 'community',
+    name: 'Community',
+    price: 'Free forever',
+    summary:
+      'The Caro CLI you install from crates.io / Homebrew / npm / NuGet / setup.caro.sh. Open source under AGPL-3.0.',
+    bullets: [
+      'Full safety validator (52+ dangerous-command patterns)',
+      'All backends — MLX, CPU, Ollama, vLLM, OpenRouter, embedded',
+      'Full CaroML task language and runbooks',
+      'Opt-in privacy-first telemetry (you control it)',
+      'Works offline once models are cached',
+      'AGPL-3.0 — you can read every line we run',
+    ],
+    cta: {
+      label: 'Get the CLI',
+      href: '/#install',
+      tone: 'secondary',
+      source: 'pricing-community',
+    },
+    note:
+      'This is the product. The community core is never crippled to upsell — see COMPANY.md for the contract.',
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    price: 'Preview — talk to us',
+    summary:
+      'A plugin suite on top of the community core for orgs that need centralized governance, audit-trail forwarding, and rollout integration.',
+    bullets: [
+      'CISO dashboard for fleet-wide policy + safety posture',
+      'Centralized rule distribution (custom safety patterns, allow/block lists)',
+      'Audit-trail forwarding to your SIEM',
+      'Machine-correlation for fleet-wide incident triage',
+      'IT rollout integration (MDM, package managers, JAMF / SCCM / Munki)',
+      'SOC 2 / GDPR posture for the managed surface',
+    ],
+    cta: {
+      label: 'Join the Enterprise waitlist',
+      href: '/#waitlist?source=pricing-enterprise',
+      tone: 'primary',
+      source: 'pricing-enterprise',
+    },
+    note:
+      'Plugins extend the community core; they do not gate it. Pricing finalizes with v2.0. The dual-track architecture is documented in ADR-001.',
+  },
+];
+
+const repo = 'https://github.com/wildcard/caro';
+---
+
+<Layout
+  title="Pricing (preview) — Caro"
+  description="Caro is free forever under AGPL-3.0. An Enterprise plugin suite for fleet-wide governance, audit-trail forwarding, and IT rollout is in preview — pricing finalizes with v2.0."
+>
+  <Navigation />
+
+  <main class="pricing">
+    <div class="banner">
+      <strong>Preview.</strong> Enterprise pricing finalizes with v2.0.
+      Today this page exists so you can tell us which tier you'd
+      actually use — clicking <em>Enterprise</em> below is the first
+      concrete signal we have that the dual-track architecture under
+      <a href={`${repo}/blob/main/docs/adr/ADR-001-enterprise-community-architecture.md`}>ADR-001</a>
+      has a real audience.
+    </div>
+
+    <header class="hero">
+      <p class="eyebrow">Pricing — preview</p>
+      <h1>Free forever for individuals. Premium plugins for orgs.</h1>
+      <p class="subtitle">
+        Caro the CLI is open source under AGPL-3.0. The Community
+        Edition is the product everyone installs and uses. The
+        Enterprise Edition adds plugins for fleet-wide governance,
+        audit-trail forwarding, and IT rollout — without gating
+        anything in the community core.
+      </p>
+    </header>
+
+    <section class="tiers">
+      {tiers.map((tier) => (
+        <article class={`tier tier--${tier.id}`}>
+          <header>
+            <h2>{tier.name}</h2>
+            <p class="price">{tier.price}</p>
+            <p class="summary">{tier.summary}</p>
+          </header>
+          <ul>
+            {tier.bullets.map((bullet) => (
+              <li>{bullet}</li>
+            ))}
+          </ul>
+          <a
+            class={`cta cta--${tier.cta.tone}`}
+            href={tier.cta.href}
+            data-source={tier.cta.source}
+          >
+            {tier.cta.label} →
+          </a>
+          <p class="note">{tier.note}</p>
+        </article>
+      ))}
+    </section>
+
+    <section class="contract">
+      <h2>What we will not do</h2>
+      <p>
+        The COMPANY.md contract names four things we will not do — and
+        because this is open source, you can hold us to all of them:
+      </p>
+      <ul>
+        <li>Cripple the community core to upsell Enterprise.</li>
+        <li>Turn telemetry into the business model.</li>
+        <li>Pivot into a consumer category.</li>
+        <li>Close-source the safety patterns.</li>
+      </ul>
+      <p>
+        <a href={`${repo}/blob/main/COMPANY.md`}>Read the full contract →</a>
+      </p>
+    </section>
+
+    <section class="faq">
+      <h2>Why is Caro free?</h2>
+      <p>
+        Because the category we're building only exists if the safety
+        layer is open source. If we close the 52+ dangerous-command
+        patterns, the category collapses back into vendor opinion.
+        The community core staying free is a strategic choice, not a
+        marketing pose.
+      </p>
+
+      <h2>How is Enterprise different from the CLI?</h2>
+      <p>
+        Enterprise is the same CLI with an additional plugin suite for
+        org-level concerns: centralized policy distribution, audit
+        trails, machine correlation across a fleet. Individual
+        developers get nothing extra from Enterprise. CISOs running
+        Caro across hundreds of engineers get a lot.
+      </p>
+
+      <h2>When does Enterprise ship?</h2>
+      <p>
+        With v2.0. Until then, this page is a waitlist for orgs that
+        want early access — and a market-validation signal for the
+        ADR-001 architecture. We will not promise a release date we
+        haven't gated on validation evidence (see
+        <a href={`${repo}/blob/main/.claude/rules/validation-discipline.md`}>validation-discipline.md</a>).
+      </p>
+
+      <h2>Will my prompts leave my machine?</h2>
+      <p>
+        No. Caro runs locally by default. Telemetry is opt-in,
+        privacy-first, and never includes command content, file paths,
+        env vars, or natural-language prompts — see
+        <a href="/telemetry">/telemetry</a> for the full contract.
+      </p>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  .pricing {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+    color: var(--fg, #111);
+  }
+
+  .banner {
+    background: var(--bg-card-accent, #fff5f5);
+    border: 1px solid var(--accent, #d73a49);
+    color: var(--fg, #111);
+    padding: 0.85rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 2.5rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .banner a {
+    color: var(--accent, #d73a49);
+  }
+
+  .hero {
+    margin-bottom: 3rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    color: var(--accent, #d73a49);
+    margin: 0 0 0.5rem;
+  }
+
+  .pricing h1 {
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    line-height: 1.15;
+    margin: 0 0 1rem;
+  }
+
+  .subtitle {
+    font-size: 1.1rem;
+    line-height: 1.55;
+    max-width: 64ch;
+    color: var(--fg-soft, #444);
+  }
+
+  .tiers {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+    margin: 0 0 3rem;
+  }
+
+  .tier {
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: 10px;
+    padding: 1.5rem;
+    background: var(--bg-card, #fafafa);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tier--enterprise {
+    border-color: var(--accent, #d73a49);
+  }
+
+  .tier h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.4rem;
+  }
+
+  .tier .price {
+    margin: 0 0 0.75rem;
+    font-size: 1.05rem;
+    color: var(--accent, #d73a49);
+    font-weight: 500;
+  }
+
+  .tier .summary {
+    margin: 0 0 1rem;
+    color: var(--fg-soft, #444);
+    line-height: 1.5;
+  }
+
+  .tier ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+    flex: 1;
+  }
+
+  .tier li {
+    padding: 0.4rem 0;
+    padding-left: 1.25rem;
+    position: relative;
+    color: var(--fg, #222);
+    line-height: 1.45;
+  }
+
+  .tier li::before {
+    content: '→';
+    position: absolute;
+    left: 0;
+    color: var(--accent, #d73a49);
+  }
+
+  .cta {
+    display: inline-block;
+    padding: 0.75rem 1.25rem;
+    border-radius: 6px;
+    font-weight: 500;
+    text-decoration: none;
+    text-align: center;
+    margin-bottom: 1rem;
+  }
+
+  .cta--primary {
+    background: var(--accent, #d73a49);
+    color: white;
+  }
+
+  .cta--secondary {
+    background: transparent;
+    color: var(--accent, #d73a49);
+    border: 1px solid var(--accent, #d73a49);
+  }
+
+  .note {
+    font-size: 0.85rem;
+    color: var(--fg-soft, #666);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .contract,
+  .faq {
+    margin: 3rem 0;
+  }
+
+  .contract h2,
+  .faq h2 {
+    font-size: 1.3rem;
+    margin: 0 0 0.75rem;
+  }
+
+  .faq h2 {
+    margin-top: 1.5rem;
+  }
+
+  .contract p,
+  .faq p {
+    line-height: 1.6;
+    color: var(--fg-soft, #444);
+    max-width: 68ch;
+  }
+
+  .contract ul {
+    margin: 0.5rem 0 1.5rem;
+    padding-left: 1.5rem;
+    color: var(--fg, #222);
+    line-height: 1.6;
+  }
+
+  .contract a,
+  .faq a {
+    color: var(--accent, #d73a49);
+  }
+</style>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -168,13 +168,13 @@ const repo = 'https://github.com/wildcard/caro';
     max-width: 1000px;
     margin: 0 auto;
     padding: 2rem 1.5rem 6rem;
-    color: var(--fg, #111);
+    color: var(--fg);
   }
 
   .banner {
-    background: var(--bg-card-accent, #fff5f5);
-    border: 1px solid var(--accent, #d73a49);
-    color: var(--fg, #111);
+    background: var(--bg-subtle);
+    border: 1px solid var(--accent);
+    color: var(--fg);
     padding: 0.85rem 1rem;
     border-radius: 8px;
     margin-bottom: 2.5rem;
@@ -183,7 +183,7 @@ const repo = 'https://github.com/wildcard/caro';
   }
 
   .banner a {
-    color: var(--accent, #d73a49);
+    color: var(--accent);
   }
 
   .hero {
@@ -194,7 +194,7 @@ const repo = 'https://github.com/wildcard/caro';
     text-transform: uppercase;
     letter-spacing: 0.12em;
     font-size: 0.85rem;
-    color: var(--accent, #d73a49);
+    color: var(--accent);
     margin: 0 0 0.5rem;
   }
 
@@ -208,7 +208,7 @@ const repo = 'https://github.com/wildcard/caro';
     font-size: 1.1rem;
     line-height: 1.55;
     max-width: 64ch;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
   }
 
   .tiers {
@@ -219,16 +219,16 @@ const repo = 'https://github.com/wildcard/caro';
   }
 
   .tier {
-    border: 1px solid var(--border, #e5e5e5);
+    border: 1px solid var(--border);
     border-radius: 10px;
     padding: 1.5rem;
-    background: var(--bg-card, #fafafa);
+    background: var(--bg-raised);
     display: flex;
     flex-direction: column;
   }
 
   .tier--enterprise {
-    border-color: var(--accent, #d73a49);
+    border-color: var(--accent);
   }
 
   .tier h2 {
@@ -239,13 +239,13 @@ const repo = 'https://github.com/wildcard/caro';
   .tier .price {
     margin: 0 0 0.75rem;
     font-size: 1.05rem;
-    color: var(--accent, #d73a49);
+    color: var(--accent);
     font-weight: 500;
   }
 
   .tier .summary {
     margin: 0 0 1rem;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
     line-height: 1.5;
   }
 
@@ -260,7 +260,7 @@ const repo = 'https://github.com/wildcard/caro';
     padding: 0.4rem 0;
     padding-left: 1.25rem;
     position: relative;
-    color: var(--fg, #222);
+    color: var(--fg);
     line-height: 1.45;
   }
 
@@ -268,7 +268,7 @@ const repo = 'https://github.com/wildcard/caro';
     content: '→';
     position: absolute;
     left: 0;
-    color: var(--accent, #d73a49);
+    color: var(--accent);
   }
 
   .cta {
@@ -282,19 +282,19 @@ const repo = 'https://github.com/wildcard/caro';
   }
 
   .cta--primary {
-    background: var(--accent, #d73a49);
-    color: white;
+    background: var(--accent);
+    color: var(--caro-white, #ffffff);
   }
 
   .cta--secondary {
     background: transparent;
-    color: var(--accent, #d73a49);
-    border: 1px solid var(--accent, #d73a49);
+    color: var(--accent);
+    border: 1px solid var(--accent);
   }
 
   .note {
     font-size: 0.85rem;
-    color: var(--fg-soft, #666);
+    color: var(--fg-muted);
     line-height: 1.5;
     margin: 0;
   }
@@ -317,19 +317,19 @@ const repo = 'https://github.com/wildcard/caro';
   .contract p,
   .faq p {
     line-height: 1.6;
-    color: var(--fg-soft, #444);
+    color: var(--fg-muted);
     max-width: 68ch;
   }
 
   .contract ul {
     margin: 0.5rem 0 1.5rem;
     padding-left: 1.5rem;
-    color: var(--fg, #222);
+    color: var(--fg);
     line-height: 1.6;
   }
 
   .contract a,
   .faq a {
-    color: var(--accent, #d73a49);
+    color: var(--accent);
   }
 </style>


### PR DESCRIPTION
Adapts [Anthropic's Founder's Playbook: Building an AI-native startup](https://claude.com/blog/the-founders-playbook) (May 14, 2026) to Caro's codebase, dev process, and public surface. Comprehensive adaptation per user-approved scope: ~21 files across 5 logical phases.

The playbook reframes the startup arc into four stages — **Idea, MVP, Launch, Scale** — and argues that AI removed three historical bottlenecks (capital, headcount, technical skill). The new constraint becomes "what a founder chooses to build", which makes validation discipline *more* important, not less. Central warning: **"mistaking building for validating"** — when prototyping is cheap, founders confuse a prototype's existence with proof of demand.

## Summary

Caro sits at **late MVP → early Launch** on the playbook's map. We already had most of the founder-arc infrastructure (MISSION, GTM playbooks, JTBD/personas, pitch deck, Hermes operating layer, ADR-001 dual-track monetization, 33 domain agents, telemetry @94.8% CSR, multi-channel distribution). What was missing was **codified validation discipline**, **retention measurement**, **counter-confirmation-bias review**, and a **stage-map narrative** that named where we are publicly.

This PR adds that missing scaffolding and turns the adoption into a marketing wedge.

## Phases (one commit each)

| Commit | Phase | What it lands |
| --- | --- | --- |
| `a1c6335` | **1 — Orientation** | `playbook/STAGE_MAP.md`, `playbook/README.md`, `COMPANY.md`, MISSION.md "Where We Are" section, constitution Tier-2 slot reserved |
| `208b771` | **2 — Validation discipline** | `.claude/rules/validation-discipline.md` (Tier-2 rule, 5 gates), `.claude/agents/devils-advocate.md` (6-section adversarial reviewer), `.claude/skills/caro.discovery/SKILL.md` (interview synthesis) |
| `6543330` | **3 — Evidence + retroactive v2.0 audit** | `docs/discovery/` (README, interview-template, hypothesis-ledger, v2.0-validation-audit), ROADMAP.md downgrades 5 v2.0 product lines to "Research (unvalidated)" |
| `a3b68b3` | **4 — Launch Operating System** | `docs/launch-os.md` (inventory + 4 named gaps), `docs/retention-dashboard-spec.md` (D1/D7/D30 + Sean Ellis), `docs/SECURITY-CHECKLIST.md` (9-gate MVP gates), `docs/agentic-stack.md` (Chat/Cowork/Code/Platform adoption record) |
| `470021d` | **5 — Public launch** | `website/src/pages/playbook.astro`, `website/src/pages/pricing.astro` (draft), `website/src/pages/blog/founders-playbook-adaptation.astro`, `website/src/i18n/locales/en/playbook.json` |

## Notable decisions captured

- **The rule has teeth.** The retroactive v2.0 audit downgrades 5 of 9 audited product lines (Karo, Dogma, voice synthesis, self-healing, local context indexing) because they have **zero first-hand transcripts**. Extensions of the validated core loop (Azure Foundry, vLLM Jukebox, Skills extension, Handy.Computer) pass.
- **Cowork deliberately NOT adopted** for internal KM until its audit-log limitation closes. Documented in `docs/agentic-stack.md` — we cannot host our own KM on a tool that's structurally unsuitable for Caro's Enterprise audit-trail customers under ADR-001.
- **Sean Ellis instrument blocked** until the opt-in cohort reaches ~1,500 users — running it on smaller cohorts is exactly the misuse the playbook warns against.
- **Pricing page is a validation artifact**, not just marketing copy. Community CTA `source=pricing-community`, Enterprise CTA `source=pricing-enterprise` — first concrete signal for ADR-001's dual-track architecture.
- **What we did NOT adopt**: the playbook's 9 consumer opportunities (health, careers, money, etc.) — not our category; a specific funding posture — left as a founder decision; Cowork; survey-as-primary-evidence in the validation rule.

## Test plan

Foreground (cannot run in this environment; required pre-merge):

- [ ] `cd website && npm install && npm run build` — all 15 locales build, total page count increases by 3 × 15 = 45 (playbook, pricing, blog post)
- [ ] `claude-design-frontend-engineer` visual audit per `.claude/rules/design-dialogue-protocol.md` — required for `playbook.astro` and `pricing.astro` since they touch brand surface
- [ ] Pricing CTA smoke test: submit one test waitlist entry for each tier, confirm rows land in Turso DB with the new `source` values (waitlist API at `website/src/pages/api/waitlist.ts` accepts arbitrary source strings)
- [ ] `gh workflow run translate.yml` post-merge — 14 locale translations queue
- [ ] `cargo build --release && cargo test` — sanity check (no Rust touched but worth confirming)

Verifiable now:

- [x] `grep -c "playbook/STAGE_MAP" MISSION.md COMPANY.md` — cross-references resolve
- [x] `.claude/rules/constitution.md` Tier-2 entry references `validation-discipline.md`
- [x] `grep -c "20.*transcript" .claude/rules/validation-discipline.md` — rule is greppable
- [x] `ls docs/discovery/transcripts/` — directory implicit (transcripts land per `caro.discovery` skill)
- [x] ROADMAP.md v2.0 items each have a Validation status field
- [x] Audit downgraded ≥1 v2.0 item (5 of 9 — rule has teeth)
- [x] `grep -E "Hermes|frustrated-beta|coder-loop" docs/launch-os.md` — inventory cites real agents
- [x] No JSX brace pitfalls in the three new `.astro` files

## Follow-up work (out of scope for this PR)

- Beads epic `discovery-debt-v2.0` with one issue per downgraded product line — to be filed after merge
- 13-part Dev.to series referenced in `PRODUCT_LAUNCH_ANALYSIS.md` — separate epic
- Actual retention-dashboard implementation — spec lands here; implementation is its own PR
- Live Discord — community infra not yet warranted at our scale
- Enterprise pricing finalization — gated on v2.0 + demand signal from this PR's pricing page

---
_Generated by [Claude Code](https://claude.ai/code/session_013gBSYJMo8qVFxV8iMzbKiP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapts Anthropic’s Founder's Playbook to Caro with a stage map, a five‑gate validation rule, and an evidence system, plus public playbook/pricing pages and launch docs. Adds brand-audit fixes and a codespell pass to keep the new pages and docs clean and consistent.

- **New Features**
  - Stage map at `playbook/STAGE_MAP.md` and `COMPANY.md`; `MISSION.md` adds “Where We Are”.
  - Five-gate rule at `.claude/rules/validation-discipline.md` with `devils-advocate` agent and `caro.discovery` skill.
  - Discovery evidence in `docs/discovery/` (interview template, hypothesis ledger, v2.0 audit); `ROADMAP.md` downgrades five v2.0 lines to research.
  - Launch docs: `docs/launch-os.md`, `docs/retention-dashboard-spec.md`, `docs/SECURITY-CHECKLIST.md`, `docs/agentic-stack.md`.
  - Public site: `website/src/pages/playbook.astro`, `pricing.astro` (preview with source-tagged CTAs), blog post, and `website/src/i18n/locales/en/playbook.json`.

- **Bug Fixes**
  - Align `playbook.astro` and `pricing.astro` with design tokens: fix `--accent` fallback; replace invalid `--bg-card*`/`--fg-soft` with `--bg-raised`/`--bg-subtle`/`--fg-muted`.
  - Remove left-accent stripe on gates cards; use uniform border with hover accent.
  - Drop redundant dark-mode blocks; rely on `tokens.css`.
  - Replace raw `white` with `var(--caro-white)` and remove hex fallbacks; status badge tints kept as noted tech debt.
  - Fix codespell hyphenations (e.g., preselect, preempting) to pass the spelling check.

<sup>Written for commit fd8024706fc736569eeb0e09083bc39aaa622e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

