### PR TITLE
fix(cli): wire claude + openrouter into CLI_SERVABLE_BACKENDS (#1115 follow-up)

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -28,10 +28,12 @@ use crate::models::{
 /// hard-errored "Unknown backend".
 ///
 /// It lists only backends the CLI can route to today. Enum variants that exist
-/// in [`BackendType`] but are **not yet CLI-wired** (`claude`, `openrouter`,
-/// `mlx`, `static`) are intentionally excluded so no surface advertises a name
-/// that `--backend` rejects. Wiring those (and unifying the remaining help-text
-/// rosters) is the larger follow-up on #1115.
+/// in [`BackendType`] but are **not yet CLI-wired** (`mlx`, `static`) are
+/// intentionally excluded so no surface advertises a name that `--backend`
+/// rejects. `claude` and `openrouter` were added here once `create_backend`
+/// was wired to route to them (the follow-up promised by #1115). Wiring the
+/// remainder (and unifying the remaining help-text rosters) stays tracked by
+/// #1115's follow-on cluster.
 pub const CLI_SERVABLE_BACKENDS: &[(&str, &str)] = &[
     (
         "embedded",
@@ -49,6 +51,14 @@ pub const CLI_SERVABLE_BACKENDS: &[(&str, &str)] = &[
         "AI-Horde volunteer cluster (free, public, no setup)",
     ),
     ("hybrid", "local sanitizer + remote enhancer (PII-safe)"),
+    (
+        "claude",
+        "Anthropic Claude API (requires: ANTHROPIC_API_KEY)",
+    ),
+    (
+        "openrouter",
+        "OpenRouter unified API, 100+ models (requires: OPENROUTER_API_KEY)",
+    ),
 ];
 
 /// Core trait that all command generation backends must implement

--- a/src/backends/remote/mod.rs
+++ b/src/backends/remote/mod.rs
@@ -5,6 +5,7 @@ pub mod claude;
 pub mod exo;
 pub mod mesh;
 pub mod ollama;
+pub mod openrouter;
 pub mod vllm;
 
 pub use ai_horde::AiHordeBackend;
@@ -12,4 +13,5 @@ pub use claude::ClaudeBackend;
 pub use exo::ExoBackend;
 pub use mesh::MeshBackend;
 pub use ollama::OllamaBackend;
+pub use openrouter::{OpenRouterBackend, OpenRouterConfig};
 pub use vllm::VllmBackend;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -430,7 +430,14 @@ impl CliApp {
             if let Some(model) = model_preference {
                 tracing::info!("User requested backend: {}", model);
 
-                match model {
+                // `validate_backend_name` lowercases before checking against
+                // CLI_SERVABLE_BACKENDS, so a mixed-case name like `Claude`
+                // or `CARO_BACKEND=OpenRouter` passes validation. Match on
+                // the same normalized form here so a validated request is
+                // never silently dropped to the `_ => auto-detect` arm.
+                let model_normalized = model.to_lowercase();
+
+                match model_normalized.as_str() {
                     "embedded" => {
                         tracing::info!("Using embedded backend (user preference)");
                         return match std::sync::Arc::try_unwrap(embedded_arc) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -611,8 +611,58 @@ impl CliApp {
                             }
                         }
                     }
+                    #[cfg(feature = "remote-backends")]
+                    "claude" => {
+                        use crate::backends::remote::ClaudeBackend;
+
+                        let claude_backend = ClaudeBackend::from_env()
+                            .map_err(|e| CliError::ConfigurationError {
+                                message: format!("Failed to create Claude backend: {}", e),
+                            })?
+                            .with_embedded_fallback(embedded_arc.clone());
+
+                        if claude_backend.is_available().await {
+                            tracing::info!("Using Claude backend (user preference)");
+                        } else {
+                            tracing::warn!(
+                                "Claude API key looks malformed; will attempt anyway with embedded fallback"
+                            );
+                        }
+                        return Ok(Box::new(claude_backend));
+                    }
+                    #[cfg(feature = "remote-backends")]
+                    "openrouter" => {
+                        use crate::backends::remote::{OpenRouterBackend, OpenRouterConfig};
+
+                        let api_key = std::env::var("OPENROUTER_API_KEY").map_err(|_| {
+                            CliError::ConfigurationError {
+                                message: "OpenRouter backend requires the OPENROUTER_API_KEY \
+                                          environment variable."
+                                    .to_string(),
+                            }
+                        })?;
+                        let config = OpenRouterConfig {
+                            api_key,
+                            ..OpenRouterConfig::default()
+                        };
+                        let openrouter_backend = OpenRouterBackend::new(config)
+                            .map_err(|e| CliError::ConfigurationError {
+                                message: format!("Failed to create OpenRouter backend: {}", e),
+                            })?
+                            .with_embedded_fallback(embedded_arc.clone());
+
+                        if openrouter_backend.is_available().await {
+                            tracing::info!("Using OpenRouter backend (user preference)");
+                        } else {
+                            tracing::warn!(
+                                "OpenRouter API not reachable; will attempt anyway with embedded fallback"
+                            );
+                        }
+                        return Ok(Box::new(openrouter_backend));
+                    }
                     #[cfg(not(feature = "remote-backends"))]
-                    "mesh" | "ollama" | "exo" | "vllm" | "ai-horde" | "hybrid" => {
+                    "mesh" | "ollama" | "exo" | "vllm" | "ai-horde" | "hybrid" | "claude"
+                    | "openrouter" => {
                         return Err(Self::remote_backend_unavailable_error(model));
                     }
                     _ => {
@@ -1189,6 +1239,8 @@ mod tests {
         assert!(CliApp::validate_backend_name("ollama").is_ok());
         assert!(CliApp::validate_backend_name("exo").is_ok());
         assert!(CliApp::validate_backend_name("vllm").is_ok());
+        assert!(CliApp::validate_backend_name("claude").is_ok());
+        assert!(CliApp::validate_backend_name("openrouter").is_ok());
     }
 
     #[test]
@@ -1197,6 +1249,8 @@ mod tests {
         assert!(CliApp::validate_backend_name("Ollama").is_ok());
         assert!(CliApp::validate_backend_name("EXO").is_ok());
         assert!(CliApp::validate_backend_name("VLLM").is_ok());
+        assert!(CliApp::validate_backend_name("Claude").is_ok());
+        assert!(CliApp::validate_backend_name("OpenRouter").is_ok());
     }
 
     #[test]
@@ -1244,7 +1298,8 @@ mod tests {
         // intentionally rejected — advertising them was the #1115 bug. If a
         // future PR wires one of these, add it to CLI_SERVABLE_BACKENDS (which
         // updates every surface at once) rather than special-casing here.
-        for unwired in ["claude", "static", "openrouter", "mlx"] {
+        // `claude` and `openrouter` were wired and moved out of this list.
+        for unwired in ["static", "mlx"] {
             assert!(
                 CliApp::validate_backend_name(unwired).is_err(),
                 "'{}' is not CLI-wired yet and must not be silently accepted",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4032,8 +4032,8 @@ fn print_backend_info() {
     // The roster is driven by `CLI_SERVABLE_BACKENDS` — the SAME slice that
     // `validate_backend_name` accepts — so this table can never advertise a
     // backend that `--backend <name>` would reject (the divergence tracked
-    // by #1115). `static`/`claude`/`openrouter` are intentionally absent
-    // because the CLI does not route to them yet.
+    // by #1115). `static`/`mlx` are intentionally absent because the CLI
+    // does not route to them yet.
     let remote_backends_compiled = cfg!(feature = "remote-backends");
 
     println!("{}", "Available inference backends".bold());
@@ -4063,6 +4063,13 @@ fn print_backend_info() {
                 "exo" if env_or(&["CARO_EXO_URL"]) => "configured",
                 "mesh" if env_or(&["CARO_MESH_URL"]) => "configured",
                 "hybrid" => "needs config",
+                // Claude/OpenRouter have no usable default endpoint — unlike
+                // ollama/vllm/exo/mesh they cannot work without a key, so say
+                // so explicitly instead of implying a free default applies.
+                "claude" if env_or(&["ANTHROPIC_API_KEY"]) => "configured",
+                "claude" => "needs API key",
+                "openrouter" if env_or(&["OPENROUTER_API_KEY"]) => "configured",
+                "openrouter" => "needs API key",
                 _ => "default endpoint",
             }
         };


### PR DESCRIPTION
## What

**Repurposed 2026-07-12** — see note at the bottom. This PR now wires `claude`
and `openrouter` into `create_backend` and into `CLI_SERVABLE_BACKENDS`, the
single source of truth introduced by #1298 (which closed #1115's roster-
divergence bug by *excluding* these two backends rather than wiring them,
citing the #1081 anti-pattern of silently advertising a backend the CLI
can't actually route to). #1298's own doc comment names this as the
promised follow-up.

## Changes

1. Export the previously dead `openrouter` module from
   `src/backends/remote/mod.rs` (added by #1097, never wired up).
2. Add `("claude", …)` and `("openrouter", …)` entries to
   `CLI_SERVABLE_BACKENDS` in `src/backends/mod.rs`, with API-key
   requirement notes; update the doc comment (`mlx`/`static` remain
   excluded — out of scope, unrelated to this fix).
3. Wire `"claude"` and `"openrouter"` construction arms in
   `create_backend` (`src/cli/mod.rs`, feature `remote-backends`), each
   with `.with_embedded_fallback(embedded_arc.clone())` so a transient
   API failure degrades to the embedded backend instead of hard-erroring
   — matching the resilience pattern already used by
   `ollama`/`exo`/`vllm`/`mesh`/`ai-horde` in the same match block.
4. `print_backend_info`: show `needs API key` for `claude`/`openrouter`
   when the corresponding env var isn't set — unlike `ollama`/`vllm`/
   `exo`/`mesh` there's no usable default endpoint for either.
5. Move `claude`/`openrouter` out of the "must be rejected" half of
   `test_validate_backend_name_matches_servable_roster`; add positive
   coverage in `test_validate_backend_name_valid`/`case_insensitive`.

Dropped the `"anthropic"` alias that was in an earlier draft of this PR:
`validate_backend_name` gates on an exact-match lookup against
`CLI_SERVABLE_BACKENDS` *before* `create_backend` ever runs, so an alias
name not present in that roster is unreachable dead code under #1298's
design — `"claude"` alone is sufficient and consistent with the roster.

## Evidence

CI run for this push: https://github.com/wildcard/caro/actions/runs/29184314946
(in progress at time of writing — will confirm green in a follow-up comment).

Verified locally before push:
```
$ cargo check --lib                              # ✓ default features
$ cargo check --lib --features remote-backends   # ✓
$ cargo clippy --lib -- -D warnings                              # ✓ clean
$ cargo clippy --lib --features remote-backends -- -D warnings   # ✓ clean
$ cargo fmt --check                              # ✓ clean
$ cargo test --lib --features remote-backends cli::   # 14/14 pass
```

## Demo

```
$ caro --backend-info
  ...
  claude        needs API key     Anthropic Claude API (requires: ANTHROPIC_API_KEY)
  openrouter    needs API key     OpenRouter unified API, 100+ models (requires: OPENROUTER_API_KEY)

$ caro --backend claude --dry-run -p "list pdf files"
Error: Configuration error: Failed to create Claude backend: Configuration error: ANTHROPIC_API_KEY environment variable not set

$ caro --backend bogus --dry-run -p "list pdf files"
Error: Invalid argument: Unknown backend 'bogus'
...  (still rejected, roster unchanged for unknown names)
```

## Regression guard

`cli::tests::test_validate_backend_name_matches_servable_roster` — pins
`claude`/`openrouter` to the accepted half of the roster and keeps
`static`/`mlx` in the rejected half, so a future edit to
`CLI_SERVABLE_BACKENDS` that silently drops or re-adds either half fails
the test immediately.

## Scope — addresses the #1115 follow-up, not `static`

`static` remains unwired (semantic decision: the static matcher is
currently composed *into* embedded via `.with_static_matcher()`, not a
standalone backend) — tracked separately, unaffected by this PR.

---

### 2026-07-12 repurposing note

This PR originally proposed delegating `validate_backend_name()` to
`BackendType::from_str()` directly. In the time this PR was open, #1298
merged a different, deliberate fix for the same #1115 divergence bug —
introducing `CLI_SERVABLE_BACKENDS` as the single source of truth and
**explicitly excluding** `claude`/`openrouter`/`mlx`/`static` until
`create_backend` routes to them, citing the #1081 silent-fallback
anti-pattern. Rebasing the original diff would have silently reverted
that decision. This PR was repurposed on top of current `main` to extend
`CLI_SERVABLE_BACKENDS` with `claude`/`openrouter` instead — the "follow-up"
#1298's own doc comment already called for — while adding the
embedded-fallback wiring that was missing from the original approach.
