### PR TITLE
feat(agents): add bin/verify-artifact grounding gate

### DIFF
--- a/bin/verify-artifact
+++ b/bin/verify-artifact
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""verify-artifact — grounding gate for agent-authored public-facing text.
+
+Adapted from warden's hallucination_audit.py + verifier.py
+(https://github.com/JithendraNara/warden). Caro-specific:
+artifact-agnostic (PR comments, hermes digests, release notes, audit
+matrices), stdlib-only, single binary.
+
+Checks any 3+ word n-gram in quoted spans, all #N / @mention / URL /
+path references in the input text against an evidence corpus and
+explicit allowlists. Exits non-zero on any fail-severity finding so
+callers can gate `gh pr comment`, digest commits, etc. on it.
+
+Usage:
+    bin/verify-artifact --text-file draft.md --evidence-file evidence.json \\
+        --allowed-pr 1154 --allowed-mention kobik
+
+    gh pr view 1154 --json title,body,commits \\
+        | bin/verify-artifact --text-file draft.md --evidence-file - \\
+            --allowed-pr 1154 --json
+
+Exit codes:
+    0  no fail-severity findings (warnings may be present)
+    1  grounding failure
+    2  usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+_ISSUE_REF_RE = re.compile(r"#(\d+)")
+_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9_\-]+)")
+_URL_RE = re.compile(r"https?://[^\s)\"']+")
+_PATH_RE = re.compile(r"\b(?:[A-Za-z0-9_\-]+/)+[A-Za-z0-9_.\-/]+\b")
+_SHA_RE = re.compile(r"\b([0-9a-f]{7,40})\b")
+_QUOTE_RE = re.compile(r'"([^"]+)"')
+_MIN_QUOTE_CHARS = 8
+
+
+@dataclass
+class Finding:
+    code: str
+    message: str
+    severity: str  # "fail" or "warn"
+
+
+@dataclass
+class Report:
+    ok: bool = True
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, code: str, message: str, severity: str = "fail") -> None:
+        self.findings.append(Finding(code=code, message=message, severity=severity))
+        if severity == "fail":
+            self.ok = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "findings": [
+                {"code": f.code, "message": f.message, "severity": f.severity}
+                for f in self.findings
+            ],
+        }
+
+    def to_human(self) -> str:
+        if not self.findings:
+            return "ok — no grounding issues found"
+        lines = []
+        for f in self.findings:
+            mark = "✗" if f.severity == "fail" else "⚠"
+            lines.append(f"  {mark} [{f.severity}/{f.code}] {f.message}")
+        head = "ok with warnings" if self.ok else "grounding FAILED"
+        return f"{head}:\n" + "\n".join(lines)
+
+
+def audit(
+    text: str,
+    evidence: str,
+    *,
+    allowed_prs: Iterable[int] = (),
+    allowed_mentions: Iterable[str] = (),
+    allowed_urls: Iterable[str] = (),
+    strict_quotes: bool = False,
+) -> Report:
+    report = Report()
+    corpus = evidence.lower()
+    allowed_pr_set = set(allowed_prs)
+    allowed_mention_set = {m.lower().lstrip("@") for m in allowed_mentions}
+    allowed_url_set = {u.lower().rstrip(".,") for u in allowed_urls}
+
+    _check_quotes(text, corpus, report, strict=strict_quotes)
+    _check_issue_refs(text, allowed_pr_set, corpus, report)
+    _check_mentions(text, allowed_mention_set, report)
+    _check_urls(text, allowed_url_set, corpus, report)
+    _check_paths(text, corpus, report)
+    _check_shas(text, corpus, report)
+
+    return report
+
+
+def _check_quotes(text: str, corpus: str, report: Report, *, strict: bool) -> None:
+    severity = "fail" if strict else "warn"
+    for match in _QUOTE_RE.finditer(text):
+        quoted = match.group(1).strip().lower()
+        if len(quoted) < _MIN_QUOTE_CHARS:
+            continue
+        if quoted in corpus:
+            continue
+        report.add(
+            "quote_not_in_source",
+            f"quoted span {quoted!r} not found in evidence",
+            severity=severity,
+        )
+
+
+def _check_issue_refs(
+    text: str, allowed: set[int], corpus: str, report: Report
+) -> None:
+    for match in _ISSUE_REF_RE.finditer(text):
+        n = int(match.group(1))
+        if n in allowed:
+            continue
+        if f"#{n}" in corpus:
+            continue
+        report.add(
+            "fabricated_issue_reference",
+            f"#{n} is neither allowed nor present in evidence",
+            severity="fail",
+        )
+
+
+def _check_mentions(text: str, allowed: set[str], report: Report) -> None:
+    for match in _MENTION_RE.finditer(text):
+        user = match.group(1).lower()
+        if user in allowed:
+            continue
+        report.add(
+            "fabricated_mention",
+            f"@{user} is not in --allowed-mention list",
+            severity="warn",
+        )
+
+
+def _check_urls(
+    text: str, allowed: set[str], corpus: str, report: Report
+) -> None:
+    for match in _URL_RE.finditer(text):
+        url = match.group(0).rstrip(".,").lower()
+        if url in allowed:
+            continue
+        if url in corpus:
+            continue
+        report.add(
+            "fabricated_url",
+            f"URL {url} not in --allowed-url and not in evidence",
+            severity="fail",
+        )
+
+
+def _check_paths(text: str, corpus: str, report: Report) -> None:
+    seen = set()
+    for match in _PATH_RE.finditer(text):
+        path = match.group(0).lower().rstrip(".,;:")
+        if path in seen:
+            continue
+        seen.add(path)
+        if "/" not in path:
+            continue
+        if path.startswith("http"):
+            continue
+        if path in corpus:
+            continue
+        # Tolerate doc-style references like "src/safety/patterns.rs"
+        # only when the *basename* appears — many evidence corpora hold
+        # filenames without the full prefix. Still warn.
+        basename = path.rsplit("/", 1)[-1]
+        if basename and basename in corpus:
+            continue
+        report.add(
+            "suspicious_path",
+            f"path {path} not found in evidence (possible fabrication)",
+            severity="warn",
+        )
+
+
+def _check_shas(text: str, corpus: str, report: Report) -> None:
+    seen = set()
+    for match in _SHA_RE.finditer(text):
+        sha = match.group(1).lower()
+        if sha in seen:
+            continue
+        seen.add(sha)
+        # Only flag long-looking SHAs (≥7 hex). Short hex tokens like
+        # color codes or counters are filtered by the regex itself.
+        if sha in corpus:
+            continue
+        report.add(
+            "fabricated_sha",
+            f"commit sha {sha} not present in evidence",
+            severity="fail",
+        )
+
+
+def _read(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="verify-artifact",
+        description="Grounding gate for agent-authored public-facing text.",
+    )
+    parser.add_argument(
+        "--text-file",
+        required=True,
+        help="Path to draft artifact text (use '-' for stdin)",
+    )
+    parser.add_argument(
+        "--evidence-file",
+        required=True,
+        help="Path to evidence corpus (use '-' for stdin)",
+    )
+    parser.add_argument(
+        "--allowed-pr",
+        type=int,
+        action="append",
+        default=[],
+        metavar="N",
+        help="PR/issue numbers permitted in text (repeatable)",
+    )
+    parser.add_argument(
+        "--allowed-mention",
+        action="append",
+        default=[],
+        metavar="USER",
+        help="@mentions permitted in text (repeatable)",
+    )
+    parser.add_argument(
+        "--allowed-url",
+        action="append",
+        default=[],
+        metavar="URL",
+        help="URLs permitted in text (repeatable)",
+    )
+    parser.add_argument(
+        "--strict-quotes",
+        action="store_true",
+        help="Treat ungrounded quoted spans as fail (default: warn)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as JSON instead of human text",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress output; rely on exit code",
+    )
+
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        parser.print_help(sys.stderr)
+        return 2
+    args = parser.parse_args(argv)
+
+    if args.text_file == "-" and args.evidence_file == "-":
+        print(
+            "verify-artifact: cannot read both text and evidence from stdin",
+            file=sys.stderr,
+        )
+        return 2
+
+    text = _read(args.text_file)
+    evidence = _read(args.evidence_file)
+
+    report = audit(
+        text,
+        evidence,
+        allowed_prs=args.allowed_pr,
+        allowed_mentions=args.allowed_mention,
+        allowed_urls=args.allowed_url,
+        strict_quotes=args.strict_quotes,
+    )
+
+    if not args.quiet:
+        if args.json:
+            print(json.dumps(report.to_dict(), indent=2))
+        else:
+            print(report.to_human())
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_verify_artifact.py
+++ b/scripts/tests/test_verify_artifact.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Unit tests for bin/verify-artifact.
+
+Run:
+    python3 scripts/tests/test_verify_artifact.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_THIS = Path(__file__).resolve()
+_REPO = _THIS.parent.parent.parent
+_HELPER = _REPO / "bin" / "verify-artifact"
+
+
+def _load_module():
+    # bin/verify-artifact has no .py extension, so we have to use a SourceFileLoader
+    # explicitly rather than relying on the default suffix-based discovery.
+    # The module must be registered in sys.modules before exec_module so that
+    # dataclass annotation introspection (which calls sys.modules.get(__module__))
+    # succeeds on Python 3.9.
+    import sys as _sys
+    from importlib.machinery import SourceFileLoader
+
+    loader = SourceFileLoader("verify_artifact", str(_HELPER))
+    spec = importlib.util.spec_from_loader("verify_artifact", loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    _sys.modules["verify_artifact"] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+verify = _load_module()
+
+
+class QuoteGroundingTests(unittest.TestCase):
+    def test_quoted_span_present_in_evidence_passes(self) -> None:
+        text = 'Per the docs: "the safety validator catches dangerous commands".'
+        evidence = "the safety validator catches dangerous commands and refuses them"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_short_quotes_are_ignored(self) -> None:
+        # Quotes under 8 chars are skipped to avoid noise on short tokens
+        text = 'See the "rm" command.'
+        evidence = "command list does not mention rm"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_quoted_span_absent_warns_by_default(self) -> None:
+        text = 'The report says "the agent fabricated this entire sentence".'
+        evidence = "evidence corpus with unrelated content"
+        report = verify.audit(text, evidence)
+        # default = warn, so report.ok stays True
+        self.assertTrue(report.ok)
+        codes = {f.code for f in report.findings}
+        self.assertIn("quote_not_in_source", codes)
+
+    def test_strict_quotes_flips_to_fail(self) -> None:
+        text = 'The report says "the agent fabricated this entire sentence".'
+        evidence = "evidence corpus with unrelated content"
+        report = verify.audit(text, evidence, strict_quotes=True)
+        self.assertFalse(report.ok)
+
+
+class IssueRefTests(unittest.TestCase):
+    def test_allowed_pr_passes(self) -> None:
+        text = "Fixed in PR #1154."
+        report = verify.audit(text, "evidence", allowed_prs=[1154])
+        self.assertTrue(report.ok)
+
+    def test_unknown_pr_fails(self) -> None:
+        text = "Tracked in #9999."
+        report = verify.audit(text, "evidence with no issue refs", allowed_prs=[1154])
+        self.assertFalse(report.ok)
+        self.assertEqual(report.findings[0].code, "fabricated_issue_reference")
+
+    def test_pr_in_evidence_passes(self) -> None:
+        text = "See #862."
+        evidence = "previous comment thread references #862 multiple times"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+
+class UrlTests(unittest.TestCase):
+    def test_url_in_evidence_passes(self) -> None:
+        text = "Per https://github.com/wildcard/caro/pull/1154 the fix landed."
+        evidence = "merged https://github.com/wildcard/caro/pull/1154 yesterday"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_fabricated_url_fails(self) -> None:
+        text = "See https://evil.example.com/exploit for details."
+        report = verify.audit(text, "evidence", allowed_urls=[])
+        self.assertFalse(report.ok)
+        self.assertEqual(report.findings[0].code, "fabricated_url")
+
+    def test_explicitly_allowed_url_passes(self) -> None:
+        text = "See https://docs.caro.sh/safety for details."
+        report = verify.audit(
+            text, "evidence", allowed_urls=["https://docs.caro.sh/safety"]
+        )
+        self.assertTrue(report.ok)
+
+
+class MentionTests(unittest.TestCase):
+    def test_allowed_mention_passes(self) -> None:
+        text = "Thanks @kobi-kadosh for the review."
+        report = verify.audit(text, "evidence", allowed_mentions=["kobi-kadosh"])
+        self.assertTrue(report.ok)
+
+    def test_unknown_mention_warns_not_fails(self) -> None:
+        text = "Thanks @random-username for the review."
+        report = verify.audit(text, "evidence", allowed_mentions=["kobi-kadosh"])
+        # default severity for unknown mentions is "warn"
+        self.assertTrue(report.ok)
+        codes = {f.code for f in report.findings}
+        self.assertIn("fabricated_mention", codes)
+
+
+class PathTests(unittest.TestCase):
+    def test_path_in_evidence_passes(self) -> None:
+        text = "See src/safety/patterns.rs for the list."
+        evidence = "the file src/safety/patterns.rs holds 52 patterns"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_path_with_only_basename_in_evidence_passes_as_warn_skipped(self) -> None:
+        # If the basename appears, we tolerate (warn-suppression)
+        text = "Edit src/safety/patterns.rs to add the pattern."
+        evidence = "the patterns.rs file is the source of truth"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_completely_invented_path_warns(self) -> None:
+        text = "See src/imaginary/nonexistent_module.rs for details."
+        report = verify.audit(text, "evidence with no matching path or basename")
+        self.assertTrue(report.ok)  # warn only
+        codes = {f.code for f in report.findings}
+        self.assertIn("suspicious_path", codes)
+
+
+class ShaTests(unittest.TestCase):
+    def test_sha_in_evidence_passes(self) -> None:
+        text = "Landed in 8155c4af."
+        evidence = "commit 8155c4af fixed the deps issue"
+        report = verify.audit(text, evidence)
+        self.assertTrue(report.ok)
+
+    def test_fabricated_sha_fails(self) -> None:
+        text = "Landed in deadbeefcafe123."
+        report = verify.audit(text, "evidence with no sha")
+        self.assertFalse(report.ok)
+        codes = {f.code for f in report.findings}
+        self.assertIn("fabricated_sha", codes)
+
+
+class IntegrationScenarios(unittest.TestCase):
+    """Negative + positive tests matching the plan's verification cases."""
+
+    def test_negative_fabricated_pr_number(self) -> None:
+        text = "Tracked in #9999."
+        evidence = '{"title": "real pr", "body": "body of PR 1154"}'
+        report = verify.audit(text, evidence, allowed_prs=[1154])
+        self.assertFalse(report.ok)
+
+    def test_negative_fabricated_url(self) -> None:
+        text = "See https://evil.example.com/exploit for details."
+        evidence = "real evidence with no such url"
+        report = verify.audit(text, evidence)
+        self.assertFalse(report.ok)
+
+    def test_positive_grounded_release_note_passes(self) -> None:
+        text = (
+            "Release v1.4.0 closes #1154 and lands the bincode pin fix from "
+            "commit 8155c4af. See src/safety/patterns.rs for the new rules."
+        )
+        evidence = (
+            "PR #1154 title: fix(deps,build): unblock main — bincode pin + "
+            "rusqlite cast + candle align. Merge commit 8155c4af touched "
+            "src/safety/patterns.rs and Cargo.toml."
+        )
+        report = verify.audit(text, evidence, allowed_prs=[1154])
+        self.assertTrue(report.ok, msg=report.to_human())
+
+
+class ReportShapeTests(unittest.TestCase):
+    def test_to_dict_shape(self) -> None:
+        text = "Tracked in #9999."
+        report = verify.audit(text, "evidence")
+        as_dict = report.to_dict()
+        self.assertIn("ok", as_dict)
+        self.assertIn("findings", as_dict)
+        self.assertFalse(as_dict["ok"])
+        self.assertGreaterEqual(len(as_dict["findings"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ports [warden](https://github.com/JithendraNara/warden)'s `hallucination_audit.py` + `verifier.py` shapes to a stdlib-only Python helper that gates agent-authored public-facing text on evidence grounding.

Catches fabricated PR numbers, URLs, commit SHAs, file paths, @mentions, and ungrounded quoted spans **before** they land in PR comments, hermes digests, release notes, or audit artifacts. Operationalizes the lesson already codified in [\`~/.claude/rules/claim-verification.md\`](https://github.com/wildcard/caro/blob/main/.claude/rules/claim-verification.md) (the 80%-false-claim incident) as a deterministic check — no LLM call required.

## What's in scope here

- \`bin/verify-artifact\` — argparse CLI, Python 3.9+ stdlib only (no deps)
- \`scripts/tests/test_verify_artifact.py\` — 21 unit tests, all passing
- End-to-end smoke tested against real PR #1154 evidence (positive + negative + JSON + stdin pipe)

## What's deferred (follow-up PR)

- Wire into \`.claude/rules/pr-comment-structure.md\` as a gating step
- Wire into \`.claude/rules/release-acceptance-verification.md\` for claim verification
- Wire into \`.claude/skills/pr-self-review/\`

## Usage

\`\`\`bash
# Direct
bin/verify-artifact --text-file draft.md --evidence-file evidence.json \\
    --allowed-pr 1154 --allowed-mention kobi-kadosh

# Pipe pattern
gh pr view 1154 --json title,body,commits \\
    | bin/verify-artifact --text-file draft.md --evidence-file - \\
        --allowed-pr 1154 --json
\`\`\`

Exit codes: 0 (ok / warnings only) · 1 (grounding failure) · 2 (usage error).

## Design notes

- **Artifact-agnostic** unlike warden's triage-specific \`TriageGroundTruth\` schema. Same primitives, broader surface area.
- **Basename-fallback for path checks** (warn-suppression) since many evidence corpora hold filenames without full prefixes.
- **Severity ladder**: \`fabricated_url\`, \`fabricated_issue_reference\`, \`fabricated_sha\` are \`fail\`; \`fabricated_mention\`, \`suspicious_path\`, and quote-not-in-source default to \`warn\` (flip quotes to \`fail\` with \`--strict-quotes\`).

## Test plan

- [x] \`python3 scripts/tests/test_verify_artifact.py\` → 21/21 pass
- [x] Smoke test against real PR #1154 evidence (positive) → exit 0
- [x] Smoke test with fabricated #9999 / evil.example.com / fake SHA → exit 1, all findings reported
- [x] JSON output mode → structured findings
- [x] stdin pipe pattern → works
- [ ] Reviewer to confirm scope (helper-only, no rule wiring) matches plan

## References

- Plan file: \`~/.claude/plans/anything-novel-here-we-quiet-toast.md\` (3-pattern novelty audit of warden vs caro)
- Upstream source: https://github.com/JithendraNara/warden/blob/main/src/warden/runtime/hallucination_audit.py
- Related rule: [\`~/.claude/rules/claim-verification.md\`](https://github.com/wildcard/caro/blob/main/.claude/rules/claim-verification.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `bin/verify-artifact`, a stdlib-only Python CLI that checks agent-authored text is grounded in an evidence corpus. It blocks fabricated PR numbers, URLs, SHAs, paths, mentions, and ungrounded quotes before they hit PR comments, digests, or release notes.

- **New Features**
  - Deterministic checks against an evidence corpus with allowlists (`--allowed-pr`, `--allowed-mention`, `--allowed-url`) and optional `--strict-quotes`.
  - Human or `--json` output; `--quiet` mode; exit codes: 0 (ok/warn), 1 (fail), 2 (usage); supports stdin via `-`.
  - Severity defaults: fabricated URLs/PRs/SHAs = fail; unknown mentions/paths and unmatched quotes = warn; basename fallback for paths to suppress false positives.
  - Added `scripts/tests/test_verify_artifact.py` with 21 unit tests.

<sup>Written for commit 8e11386c5e5b416e12fd1cd3bc5f32fbea96ccca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

