### PR TITLE
feat(rules): require verify-artifact for agent-authored public text

### DIFF
--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -32,17 +32,21 @@ These rules govern how code is written, reviewed, and released.
    First PR for any non-trivial external SDK is a build-spike (license,
    MSRV, optional feature flag, code-ref smoke, two verification builds);
    architecture lands only after the spike merges green.
+6. **[verify-artifact.md](./verify-artifact.md)** — Agent-authored
+   public-facing text (PR comments, Hermes digests, release notes,
+   acceptance audits) must pass `bin/verify-artifact` grounding before
+   posting; block on exit code 1.
 
 ## Tier 3 — Workflow hygiene
 
 These rules govern session ergonomics and surface-level conventions. They
 yield to anything in Tier 1 or Tier 2.
 
-6. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
+7. **[good-boy-scout.md](./good-boy-scout.md)** — Leave code better than you
    found it; do not gold-plate.
-7. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
+8. **[quick-actions-footer.md](./quick-actions-footer.md)** — Append a
    Quick-Actions footer when stopping for user input.
-8. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
+9. **[astro-esbuild-shell-syntax.md](./astro-esbuild-shell-syntax.md)** —
    Escape `{` in shell snippets inside `.astro` / `.jsx` / `.tsx` templates
    (esbuild treats it as a JSX expression boundary).
 

--- a/.claude/rules/verify-artifact.md
+++ b/.claude/rules/verify-artifact.md
@@ -1,0 +1,88 @@
+# Verify Agent-Authored Artifacts Before Posting
+
+**APPLIES TO**: Any agent (Claude Code, Hermes, ml-ds-engineer, qa-agent, …)
+producing public-facing text — PR comments, GitHub Release bodies, Hermes
+daily digests in `.hermes/digests/`, release-acceptance audit artifacts in
+`.claude/releases/`, beta-test reports in `.claude/beta-testing/`.
+
+Codified after porting warden's `hallucination_audit.py` shape to
+`bin/verify-artifact` (PR #1187). The helper is a stdlib-only Python
+grounding gate that exits non-zero when a draft contains a PR/issue
+reference, URL, commit SHA, file path, or @mention not present in the
+supplied evidence corpus.
+
+## The rule
+
+Before posting any agent-authored artifact that names concrete entities
+(PR numbers, SHAs, URLs, file paths, user handles), pipe the draft and
+its evidence corpus through `bin/verify-artifact`. **Block on exit
+code 1.**
+
+```bash
+# Pre-PR-comment pattern
+gh pr view <PR> --json title,body,commits \
+  | bin/verify-artifact \
+      --text-file draft.md \
+      --evidence-file - \
+      --allowed-pr <PR>
+# exit 0 → proceed with `gh pr comment`
+# exit 1 → fix the draft, re-verify, retry
+```
+
+This operationalizes [`~/.claude/rules/claim-verification.md`](../../.claude/rules/claim-verification.md)'s
+"80%-false-claim" lesson as a deterministic check instead of a habit.
+
+## Required for
+
+| Artifact | Evidence corpus to supply |
+|----------|---------------------------|
+| `gh pr comment <PR>` body | `gh pr view <PR> --json title,body,commits,comments` |
+| `gh pr review` body | same as above, plus the diff if claims reference code |
+| Hermes daily digest (`.hermes/digests/<date>.md`) | concatenated `gh pr list` + `gh issue list` JSON for that day |
+| Release-acceptance audit (`.claude/releases/v<VERSION>-acceptance.md`) | CHANGELOG entry + verifier command outputs |
+| `gh release create/edit` body | CHANGELOG section being shipped |
+| Beta-test report posted to GH | the test session transcript |
+
+## When to flip `--strict-quotes`
+
+Default behavior treats ungrounded quoted spans as `warn` (not `fail`),
+because agents often paraphrase. Use `--strict-quotes` when the artifact
+explicitly cites the evidence (e.g. an audit matrix's "verifier output"
+column or a release note quoting the CHANGELOG). In those contexts
+paraphrase is a bug.
+
+## Recommended allowlists
+
+| Flag | When to use |
+|------|-------------|
+| `--allowed-pr <N>` | The PR/issue being commented on. Always pass the canonical number. |
+| `--allowed-mention <USER>` | The original author + reviewers known from evidence. |
+| `--allowed-url <URL>` | Whitelisted docs URLs (caro.sh, docs.caro.sh) that won't appear in PR evidence. |
+
+## Exit codes
+
+| Code | Meaning | Caller action |
+|------|---------|---------------|
+| 0 | OK (warnings may be present) | Proceed |
+| 1 | Grounding failure | Block; fix draft; retry |
+| 2 | Usage error | Fix invocation |
+
+## What this rule does NOT replace
+
+- It does not check spelling, grammar, or tone.
+- It does not check whether claims are *true*, only that referenced
+  entities exist in the supplied evidence. Garbage evidence produces
+  garbage "OK".
+- It does not replace `~/.claude/rules/pr-comment-structure.md` —
+  artifacts must still follow the canonical `\`[agent]\`` / identity /
+  body / details template.
+
+## See also
+
+- `bin/verify-artifact --help` — full flag reference
+- `scripts/tests/test_verify_artifact.py` — 21 test cases worth reading as
+  examples of what passes and what fails
+- `~/.claude/rules/claim-verification.md` — the global rule this
+  operationalizes
+- Upstream inspiration: [JithendraNara/warden](https://github.com/JithendraNara/warden)
+  `runtime/hallucination_audit.py`


### PR DESCRIPTION
## Summary

Stacked on #1187. Wires the new \`bin/verify-artifact\` helper into caro's constitution as a Tier-2 engineering-discipline rule, so future agents producing public-facing text (PR comments, Hermes digests, release notes, acceptance audits) **must** pass grounding verification before posting.

## What changes

- New file: \`.claude/rules/verify-artifact.md\` — the rule itself, with worked examples, allowlist guidance, exit-code semantics, and what the gate does NOT cover
- \`.claude/rules/constitution.md\` — registers the new rule as Tier-2 item #6, shifts good-boy-scout / quick-actions-footer / astro-esbuild-shell-syntax to 7/8/9

## Why Tier 2

Tier 2 is "engineering discipline: how code is written, reviewed, **released**." This rule guards what we publish externally — wrong tier would be Tier 3 (session ergonomics), but a fabricated PR# in a public comment is closer to a release-version-alignment violation than a missing footer.

## Out of scope (followups)

The user's global \`~/.claude/rules/pr-comment-structure.md\` and \`~/.claude/rules/release-acceptance-verification.md\` should reference \`bin/verify-artifact\` too. That belongs in a \`dotfiles-claude\` PR, not here — opened as a separate followup. See PR #1187 comment for the suggested dotfiles patch.

## Verification

- [x] Documented invocation in \`verify-artifact.md\` smoke-tested against real PR #1154 data: exit 0
- [x] Constitution renumbering preserves precedence semantics (Tier-1 #1, Tier-2 #2-6, Tier-3 #7-9)
- [ ] Reviewer to confirm Tier 2 placement matches intent

## Depends on

- #1187 — ships \`bin/verify-artifact\`. Merge that first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require grounding verification via `bin/verify-artifact` for all agent-authored public text before posting. Adds a Tier-2 constitution rule and a rule doc; blocks on exit code 1.

- **New Features**
  - Added `.claude/rules/verify-artifact.md` with scope, examples, `--strict-quotes`, allowlists, and exit codes.
  - Registered the rule in `.claude/rules/constitution.md` as Tier-2 #6 for PR comments, Hermes digests, release notes, and acceptance audits.

- **Dependencies**
  - Depends on PR #1187, which ships `bin/verify-artifact`.

<sup>Written for commit 0bd58aaaa5ab6c5aabac9ba723f376b140c67104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

