### PR TITLE
docs(discovery): correct local-context-indexing audit + add outreach templates

### DIFF
--- a/docs/discovery/README.md
+++ b/docs/discovery/README.md
@@ -22,6 +22,52 @@ claims all live here as operational artifacts.
 | [`v2.0-validation-audit.md`](./v2.0-validation-audit.md) | Retroactive audit of Karo, Dogma, voice synthesis, self-healing, local context indexing |
 | `transcripts/` | Anonymized first-hand user-interview transcripts (one file per interview) |
 
+## Candidate sourcing
+
+The validation-discipline rule requires 20 first-hand interview
+transcripts per new product line. That requires *finding* the
+participants. Caro does not yet have a Discord, an email list, or
+an in-app prompt for interview recruitment — these are all surfaces
+the founder has to assemble.
+
+**Important calibration finding (2026-05-31)**: GitHub Issues filed
+by the project's own maintainers (and especially those tagged
+"Source: Claude Code session") do **NOT** count as user-pain signal.
+They are *founder-and-model* planning notes. Re-check any "anecdotal
+user demand" before relying on it: if `@wildcard` is the issue
+author, the signal is internal, not external.
+
+The legitimate outreach surfaces below — in rough order of warm-
+lead strength — are where real first-hand transcripts come from.
+
+| Surface | Approximate cohort size | Outreach friction | Notes |
+| --- | --- | --- | --- |
+| **Waitlist** (Turso DB) | ~247 | low | Per-tier segmentation via `source` field (e.g. `pricing-enterprise` is a Stage-3 demand signal worth interviewing) |
+| **GitHub stargazers** | ~34 | medium | Smaller pool but high-intent — they bookmarked the project |
+| **Direct network DMs** | n (founder's network) | low–medium | Highest-quality transcripts but most selection-biased; mark cohort explicitly in synthesis |
+| **Issue / PR contributors** | n (external only) | medium | Filter out `@wildcard` authorship; remaining commenters are external users with real pain |
+| **Twitter / Mastodon / LinkedIn replies** | unbounded | high | Slow signal; Hermes weekly competitive-intel scan can surface candidates |
+| **Hermes competitive-intel signal-scan** | n per scan | medium | `.hermes/messages/` candidate-users output (gap in `docs/launch-os.md` — surface needs to be built) |
+
+**Drafted outreach templates** live in
+[`outreach-templates.md`](./outreach-templates.md) — one template per
+surface, calibrated to be honest about the ask ("we're validating a
+hypothesis, this is not a sales pitch") and short enough to copy-paste-
+personalize before sending.
+
+**Rules for outreach**:
+- The founder (or a delegated human maintainer) sends the message,
+  not an AI agent. Per Gate 1 of `.claude/rules/validation-discipline.md`,
+  "first-hand means *you* talked to them".
+- Each outreach is personalized — at minimum naming the specific issue,
+  star, or comment that flagged the recipient. Templates are starting
+  points, not bulk-send drafts.
+- No more than 1 outreach per recipient per quarter — these are real
+  people, not a database. The waitlist Turso DB tracks outreach
+  history (add an `outreach_log` column when this becomes >50/quarter).
+- Decline gracefully when ignored. Silence is data — it tells you the
+  cohort isn't engaged enough to be the right cohort.
+
 ## How to add a transcript
 
 1. Run the interview using the [`caro.discovery`

--- a/docs/discovery/outreach-templates.md
+++ b/docs/discovery/outreach-templates.md
@@ -1,0 +1,172 @@
+# Discovery Outreach Templates
+
+Starting points for the founder to personalize and send. Each
+template is **a draft**, not a final message. Per
+[`README.md` § Candidate sourcing](./README.md#candidate-sourcing),
+the founder (or a delegated human maintainer) sends the actual
+outreach.
+
+## Why these are templates, not bulk sends
+
+The validation-discipline rule's Gate 1 says: *"First-hand means
+**you** talked to them."* A bulk-send blast is not an interview
+recruitment — it's spam, and it'll burn the cohort before they ever
+agree to talk. Each template below is calibrated to be:
+
+- **Honest about the ask** — "we're validating a hypothesis", not
+  "you have to try our product"
+- **Short** — under 200 words so the recipient can read it on a
+  phone screen
+- **Personalized at minimum** with the recipient's specific
+  signal (issue number, star date, post they made, etc.)
+- **Easy to decline** — explicit "no worries if not interested"
+
+## Template 1 — Waitlist segmented outreach
+
+**Use when**: contacting a person who joined the waitlist with a
+specific `source` value that maps to a hypothesis you're validating
+(e.g. `pricing-enterprise` → CISO-track interview for
+`enterprise-dashboard` hypothesis).
+
+**Subject**: A quick 20-min chat about your terminal workflow?
+
+> Hi {{anon_first_name_or_handle}},
+>
+> Thanks for joining the Caro waitlist on {{date}}. You signed up
+> via the {{source}} CTA, which is exactly the kind of signal I
+> want to dig into before we build the {{feature_or_tier}} side of
+> Caro.
+>
+> I'm running 20 short interviews to validate the hypothesis
+> behind that direction before we ship anything. They're 20–30
+> minutes, recorded if you consent (anonymized in our public
+> discovery repo, your handle hashed), and they're emphatically
+> not a sales pitch — Caro's Community edition is and will stay
+> free under AGPL-3.0.
+>
+> If you'd be up for it, here's my calendar: {{calendly_link}}.
+> If not, no worries — I won't email you again unprompted.
+>
+> Either way, your waitlist signup is appreciated and you'll
+> get the launch announcement when we hit GA.
+>
+> Kobi
+
+## Template 2 — GitHub stargazer outreach
+
+**Use when**: contacting a recent GitHub stargazer who has visible
+public activity in adjacent tools (shell-AI, dev-tools, Rust CLIs)
+that suggests they have shell-command pain.
+
+**Channel**: GitHub Discussions DM, or — if their GitHub profile
+links to their preferred channel (Twitter / website email) — there.
+
+> Hi {{anon_handle}},
+>
+> I noticed you starred [caro](https://github.com/wildcard/caro)
+> on {{date}}, and your public {{Rust / dev-tools / shell-AI}}
+> activity on {{repo_or_topic}} suggests you might run into the
+> exact kind of "I know what I want but not the syntax" friction
+> Caro is built around.
+>
+> I'm running a small batch of structured interviews (20–30 min)
+> to validate which v2.0 features are worth building. Specifically
+> right now I'm trying to surface real first-hand pain around
+> {{hypothesis_in_one_sentence}}.
+>
+> Would you be willing to do one? It's anonymized in our public
+> discovery repo (your handle gets hashed), no sales pitch
+> attached — Community Caro is free forever under AGPL-3.0.
+>
+> Calendar: {{calendly_link}}. Or just reply here with a
+> "yes / no / maybe later" and I'll take it from there.
+>
+> — Kobi
+
+## Template 3 — Direct network / "warm intro" outreach
+
+**Use when**: reaching out to someone in your personal/professional
+network — a former colleague, a known power-user, an OSS
+collaborator on an adjacent project.
+
+**Channel**: whatever you usually use with them (DM, Signal, email,
+Slack).
+
+> Hey {{first_name}} —
+>
+> Caro shipped 1.4.0 last month and I'm starting structured
+> discovery work on v2.0 before committing to features. Specifically
+> trying to surface real first-hand pain around
+> {{hypothesis_in_one_sentence}}.
+>
+> Would you do a 20–30 min interview? It's qualitative, no sales
+> pitch, and the transcript goes in our public discovery repo
+> anonymized — your handle gets hashed, your company gets
+> generalized to "{{industry}}-co" unless you tell me otherwise.
+>
+> Heads up: you're closer to my network than the average
+> interviewee, so I'll flag you as "warm cohort" in the synthesis
+> so we don't kid ourselves about generalizability — but your
+> signal is still useful because you actually use a terminal
+> every day.
+>
+> Up for it? {{calendly_link}} or just pick a time.
+>
+> — Kobi
+
+## Template 4 — Public reply to a shell-AI complaint
+
+**Use when**: someone on Twitter / Mastodon / Hacker News / Reddit
+posts a public complaint about shell-AI tools that matches a
+hypothesis you're validating.
+
+**Channel**: reply in the original thread, NOT a DM. DMs from
+strangers chasing a complaint feel pushy; public replies on the
+same thread are conversational.
+
+> Caro maintainer here — your point about
+> {{specific_thing_they_said}} is exactly the kind of signal
+> I'm trying to ground v2.0 in. We're doing 20 structured
+> interviews per feature direction before committing to build,
+> and your shape of pain matches the {{hypothesis_id}} hypothesis
+> we're testing.
+>
+> If you'd be up for a 20-min conversation, my calendar's at
+> {{calendly_link}} — no sales pitch, Caro Community is free
+> under AGPL-3.0, transcript would be anonymized in our public
+> discovery repo.
+>
+> No pressure if not — your public comment alone is useful
+> signal.
+
+## Anti-patterns
+
+- **Mass mail-merge** to the full 247-person waitlist. Spam, will
+  burn the list.
+- **Multiple unanswered follow-ups.** One ask, one decline-or-silence,
+  then move on. Silence is data.
+- **Citing internal docs in cold outreach.** "Per ADR-001…" and
+  "per validation-discipline.md…" are great in internal contexts
+  and confusing in cold outreach. Translate to plain English.
+- **Promising features in exchange for interviews.** That biases
+  the response — the interview becomes a sales conversation in
+  disguise. Caro doesn't trade access for testimonials.
+- **AI-drafted outreach sent without personalization.** If the
+  template's `{{slot}}` placeholders ship unfilled, the recipient
+  knows. Always personalize.
+
+## What goes in the transcript
+
+After the interview, capture per the rules in
+[`README.md`](./README.md#how-to-add-a-transcript) and
+[`interview-template.md`](./interview-template.md). The outreach
+message itself doesn't go in the transcript — only the conversation
+that follows.
+
+## See also
+
+- [`README.md`](./README.md) — anonymization rules, candidate sourcing
+- [`interview-template.md`](./interview-template.md) — the question
+  script the interview itself follows
+- [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md) —
+  the rule this outreach serves

--- a/docs/discovery/v2.0-validation-audit.md
+++ b/docs/discovery/v2.0-validation-audit.md
@@ -162,24 +162,31 @@ Chroma DB indexing" (#166), epic #504 ChromaDB
 **Claim**: users want Caro to know about their open repo / shell
 history / cwd state when generating commands.
 **Audit**:
-- Gate 1: **0 transcripts.** This is the highest-likelihood validated
-  hypothesis of the set — anecdotally requested in GitHub Issues
-  (#152, #166) — but anecdotes are not transcripts.
-- Gate 2: **GitHub-issue signal is not survey-shaped, but it's not
-  20 transcripts either.** Per Gate 1, the issues are evidence
-  inputs (users have pain), not evidence outputs (users want this
-  specific solution).
+- Gate 1: **0 transcripts.** Initially scored as "highest-likelihood
+  validated hypothesis of the set — anecdotally requested in GitHub
+  Issues #152 and #166". **Correction (2026-05-31)**: re-inspecting
+  those issues, *both are authored by `@wildcard` himself*, sourced
+  from his own Claude Code planning sessions — not from external user
+  reports. There is no external "user request" signal here; the
+  apparent demand was the founder and a model conversing with
+  themselves. This actually *strengthens* the validation-discipline
+  rule's case: what looked like user demand was AI-amplified
+  confirmation bias. Re-scored from "strongest a-priori" to
+  "unvalidated and harder to source than expected".
+- Gate 2: **n/a.** With Gate 1 re-scored, there is no Gate 2 evidence
+  to assess.
 - Gate 3: **Not present.** Privacy implications of local indexing,
   staleness handling, and cross-repo confusion modes are not named.
 - Gate 4: **Not run.**
 - Gate 5: **n/a.**
-- **Verdict**: **Research-only**, *but* with the strongest a-priori
-  signal of the v2.0 set — interview these users first.
+- **Verdict**: **Research-only.** The hypothesis still deserves
+  testing, but the priority drops from P0 to P1/P2 because there is
+  no warm-lead cohort.
 
-**Discovery-debt action**: open beads issue
-`discovery-debt/local-context-indexing-20-transcripts`. Highest
-priority. Re-interview the existing GitHub Issue authors as
-transcript candidates.
+**Discovery-debt action**: see issue #1189. Outreach surfaces named
+in [`docs/discovery/README.md` § Candidate sourcing](./README.md#candidate-sourcing).
+Re-interviewing the GitHub Issue authors does NOT apply (founder is
+the author).
 
 ## Summary
 
@@ -199,12 +206,20 @@ plan's success criterion).
 2. **Update ROADMAP.md** to move the 5 product lines into a
    `## Research (unvalidated)` section above the v2.0 milestone, and
    add a `Validation:` field pointing back to this audit
-3. **Sequence interview work** in priority order: local-context-indexing
-   (strongest a-priori signal), enterprise-dashboard (drives
-   dogma-rules scope), karo-distributed, self-healing, voice-synthesis
-   (highest a-priori risk)
+3. **Sequence interview work** in priority order (revised 2026-05-31
+   after the local-context-indexing correction above):
+   enterprise-dashboard (drives dogma-rules scope; CISO outreach is a
+   defined surface via the pricing-enterprise waitlist CTA),
+   local-context-indexing (downgraded from P0 — no warm leads, must
+   source from waitlist / stargazers / direct outreach),
+   karo-distributed, self-healing, voice-synthesis (highest a-priori
+   risk).
 4. **Devil's-advocate review** of voice-synthesis and self-healing
-   *before* interview design begins
+   *before* interview design begins.
+5. **Source candidate users** per the surfaces named in
+   [`README.md` § Candidate sourcing](./README.md#candidate-sourcing).
+   The founder-authored-issue path is closed — most warm-lead intuitions
+   need to be re-checked the same way (am I the original poster?).
 
 ## See also
 


### PR DESCRIPTION
Followup to the merged founder's-playbook adaptation (#1174 → `f8e16e7`). Two things changed after the merge:

1. **Audit correction**: when preparing to draft discovery outreach for the `local-context-indexing` hypothesis, I re-read GitHub issues #152, #166, and #504 — the audit had named them as warm-lead candidates. **All three are authored by `@wildcard`** from his own Claude Code planning sessions. The "anecdotal user demand" was founder-and-model conversing with themselves, not external users. This is honestly a perfect demonstration of the confirmation-bias failure mode the validation-discipline rule exists to catch.
2. **Outreach scaffolding**: discovery work needs candidate-sourcing surfaces and personalized outreach drafts. Adds both.

## Changes

- **EDIT** `docs/discovery/v2.0-validation-audit.md` — corrects the `local-context-indexing` section. Re-scores from "strongest a-priori signal" (P0) to "unvalidated and harder to source than expected" (P1/P2). Updates the follow-up actions sequencing so `enterprise-dashboard` (with the pricing-enterprise waitlist as a defined surface) becomes the highest-priority discovery target instead.
- **EDIT** `docs/discovery/README.md` — adds a "Candidate sourcing" section naming the real outreach surfaces (247-person waitlist, GitHub stargazers, direct network DMs, external issue/PR commenters, public-reply threads, Hermes signal-scan) with notes on cohort warmth and selection bias. Includes the calibration finding ("`@wildcard`-authored issues are internal planning, not user signal") so future agents don't repeat the mistake.
- **NEW** `docs/discovery/outreach-templates.md` — 4 personalized draft templates (waitlist segmented, stargazer, warm-intro, public-reply). Each calibrated to be honest about the ask, mobile-read length, easy to decline. Per Gate 1 of `validation-discipline.md`, **the founder sends the outreach, not an AI agent** — these are starting points, not bulk-send drafts. Includes an anti-patterns section (mass mail-merge, unfilled slot placeholders, promising-features-for-interviews).

## What this PR does NOT do

- **Does not post any outreach.** Templates are drafts in the repo for human review and personalization before sending.
- **Does not update issue #1189.** That comment is deferred until you've personally validated the rewritten audit. Updating the issue is a separate action you control.
- **Does not modify the validation-discipline rule itself.** The rule is correct as written; the audit's *application* of it was overly optimistic about issue-author warmth.

## Test plan

- [x] `grep -c "wildcard" docs/discovery/v2.0-validation-audit.md` finds the correction note
- [x] `grep -c "Candidate sourcing" docs/discovery/README.md` finds the new section
- [x] `grep -c "Anti-patterns" docs/discovery/outreach-templates.md` finds the anti-patterns guardrails
- [x] No `cargo`/website code touched — doc-only PR, CI failure shape should match #1174's (Vercel polyfill + pre-existing Rust chain)

---
_Generated by [Claude Code](https://claude.ai/code/session_013gBSYJMo8qVFxV8iMzbKiP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2.0 discovery audit for local-context-indexing (issues were founder-authored, not user signal) and adds sourcing guidance plus outreach templates to run interviews. This lowers that hypothesis’s priority and moves enterprise-dashboard to the top for discovery.

- **Bug Fixes**
  - Corrected `docs/discovery/v2.0-validation-audit.md`: Gate 1 re-scored after confirming issues #152/#166/#504 were authored by `@wildcard`; local-context-indexing drops from P0 to P1/P2; removed “re-interview issue authors”; updated sequencing to prioritize enterprise-dashboard and linked to real sourcing surfaces.

- **New Features**
  - Added “Candidate sourcing” to `docs/discovery/README.md`: names real outreach surfaces (waitlist, stargazers, external contributors, public replies, Hermes scan) with warmth/selection-bias notes and the calibration that `@wildcard` issues are internal signal.
  - Introduced `docs/discovery/outreach-templates.md`: four short, personalized drafts (waitlist, stargazer, warm intro, public reply) plus anti-patterns; clarifies the founder sends outreach, not bulk sends.

<sup>Written for commit eb8dfe84169bd64e739d72c7e839179c6ba1f1bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

