### PR TITLE
chore(demo): refresh caro-demo video — drift in tokens.css + safety/patterns.rs

### DIFF
--- a/demos/remotion-video/src/scenes/SceneSafety.tsx
+++ b/demos/remotion-video/src/scenes/SceneSafety.tsx
@@ -104,7 +104,7 @@ export const SceneSafety: React.FC = () => {
       </div>
 
       <Caption
-        text="52+ patterns. Blocked before damage."
+        text="67+ patterns. Blocked before damage."
         startFrame={150}
         emphasis={{ word: "Blocked", color: colors.danger }}
       />

--- a/demos/remotion-video/src/tokens.ts
+++ b/demos/remotion-video/src/tokens.ts
@@ -1,16 +1,18 @@
 // Mirrored from website/src/ui/tokens.css. Keep in sync if the site rebrands.
 // This file intentionally has no imports — Remotion's build is isolated from
 // the Astro website's build.
+// Last synced: 2026-06-01 — brand migrated from orange (#ff8c42) to signal red (#ef3333);
+// terminal prompt migrated from teal (#4ec9b0) to highlighter yellow (#fcfc62).
 
 export const colors = {
   bgDeep: "#0a0a0f",
   bgTerminal: "#1a1a2e",
   bgChrome: "#16161c",
   borderSubtle: "#1e1e24",
-  accent: "#ff8c42",
-  accentDark: "#ff6b35",
-  accentSoft: "rgba(255, 107, 53, 0.12)",
-  prompt: "#4ec9b0",
+  accent: "#ef3333",      // --caro-red-500 (was #ff8c42 orange)
+  accentDark: "#e63636",  // --caro-red-600 (was #ff6b35)
+  accentSoft: "rgba(239, 51, 51, 0.12)",
+  prompt: "#fcfc62",      // --caro-yellow-400 (was #4ec9b0 teal)
   command: "#9cdcfe",
   success: "#22c55e",
   danger: "#ef4444",


### PR DESCRIPTION
## Drift Report (2026-06-01 monthly check)

`demos/remotion-video/scripts/check-drift.sh --human` detected drift in 4 watched files:

```
caro-demo drift check
  last rendered: 2026-04-26T02:07:00Z (commit 4c45fc56)
  total watched: 7  ok: 3  drifted: 4  missing: 0

  ⚠ DRIFTED: website/src/ui/tokens.css
  ✓ website/src/components/landing/LPDemo.astro
  ⚠ DRIFTED: src/main.rs
  ✓ .claude/beta-testing/test-cases.yaml
  ⚠ DRIFTED: src/safety/patterns.rs
  ⚠ DRIFTED: homebrew-tap/README.md
  ✓ install.sh
```

**Classification: Cosmetic-but-visible** → human review required before merge.

---

## Side-by-side: what changed

### Scene 3 caption (safety/patterns.rs)

| | Before | After |
|---|---|---|
| Caption text | `52+ patterns. Blocked before damage.` | `67+ patterns. Blocked before damage.` |
| DangerPattern count | 52 | 67 |

Source file updated: `SceneSafety.tsx` line 107.

### All scenes (website/src/ui/tokens.css — brand palette migration)

The brand migrated from the orange/teal palette to the "paper-and-ink" palette (signal red + highlighter yellow). The Remotion `tokens.ts` previously mirrored the old values.

| Token | Old hex | New hex | What it colors |
|---|---|---|---|
| `accent` | `#ff8c42` (orange) | `#ef3333` (signal red, `--caro-red-500`) | Caro suggestions, primary CTA |
| `accentDark` | `#ff6b35` | `#e63636` (`--caro-red-600`) | Hover / secondary brand |
| `accentSoft` | `rgba(255,107,53,0.12)` | `rgba(239,51,51,0.12)` | Soft accent overlay |
| `prompt` | `#4ec9b0` (teal) | `#fcfc62` (highlighter yellow, `--caro-yellow-400`) | Shell prompt `$` |

Source file updated: `tokens.ts` lines 10–13.

### src/main.rs + homebrew-tap/README.md — non-video-relevant

- `src/main.rs` changed (new features, refactors) but the block-message format `✗ command blocked by safety validator (Critical)` is **unchanged**. No scene text update needed.
- `homebrew-tap/README.md` updated the `VERSION=1.4.0` in the maintainers section only. The actual brew install command `brew install wildcard/caro/caro` is unchanged. Scene 4's `cargo install caro` line is unchanged.

---

## ⚠ Render blocked — action required from a local Mac

The remote CI container has no Chrome or FFmpeg, so `render-and-ship.sh` could not be run. **This PR contains source-file changes only — the MP4 and poster are NOT updated yet.**

To complete this refresh, someone with a Mac (Chrome ships with macOS) must:

```bash
git fetch origin chore/caro-demo-refresh-2026-06
git checkout chore/caro-demo-refresh-2026-06

# Render (takes ~30s on M-series)
cd demos/remotion-video
npm install --prefer-offline
npx remotion render CaroDemo \
  ../../website/public/caro-demo.mp4 \
  --codec=h264 --crf=23 --image-format=jpeg
npx remotion still CaroDemo \
  ../../website/public/caro-demo-poster.png \
  --frame=60

# Verify poster changed visually (new red accent, yellow prompt)
open ../../website/public/caro-demo-poster.png

# Refresh the manifest and commit render outputs
cd ../..
demos/remotion-video/scripts/render-and-ship.sh --skip-install
git add website/public/caro-demo.mp4 website/public/caro-demo-poster.png \
        demos/remotion-video/.baseline-manifest.json
git commit -m "chore(demo): re-render caro-demo video — brand + pattern drift"
git push
```

After the render commit lands on this branch, CI will pass and you can squash-merge.

---

_Triggered by: [`.claude/skills/caro-demo-video/SKILL.md`](../../demos/remotion-video/../../../.claude/skills/caro-demo-video/SKILL.md) monthly maintenance routine (2026-06-01). Render blocked in remote environment — see above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Db9GEnCGR5RCdTgE78WRxA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Caro demo video source to match the new brand palette (signal red + highlighter yellow) and the updated safety pattern count. Updates `demos/remotion-video/src/tokens.ts` and changes Scene 3 caption from "52+" to "67+"; no behavior changes.

- **Migration**
  - Render locally on macOS (CI lacks Chrome/FFmpeg): from `demos/remotion-video`, run `npm i`, then `npx remotion render CaroDemo ../../website/public/caro-demo.mp4 --codec=h264 --crf=23 --image-format=jpeg` and `npx remotion still CaroDemo ../../website/public/caro-demo-poster.png --frame=60` (or `demos/remotion-video/scripts/render-and-ship.sh --skip-install`).
  - Commit `website/public/caro-demo.mp4`, `website/public/caro-demo-poster.png`, and `demos/remotion-video/.baseline-manifest.json`, then push.

<sup>Written for commit 3cf58d467a0a611d1e7422fa20655f1fb50d9cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

