### PR TITLE
fix(deps,knowledge): unblock CI — home MSRV, arrow alignment, embedder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,16 +275,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
 dependencies = [
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
  "arrow-csv",
- "arrow-data 56.2.0",
+ "arrow-data",
  "arrow-ipc",
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "arrow-string",
 ]
@@ -295,10 +295,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "num",
 ]
@@ -310,32 +310,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
 dependencies = [
  "ahash",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
-dependencies = [
- "ahash",
- "arrow-buffer 58.1.0",
- "arrow-data 58.1.0",
- "arrow-schema 58.1.0",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-complex",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -350,27 +332,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-buffer"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
 name = "arrow-cast"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "atoi",
  "base64 0.22.1",
@@ -388,9 +358,9 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array",
  "arrow-cast",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -403,23 +373,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
 dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-data"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
-dependencies = [
- "arrow-buffer 58.1.0",
- "arrow-schema 58.1.0",
- "half",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -428,10 +385,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
@@ -444,11 +401,11 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.13.0",
@@ -466,10 +423,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
 ]
 
@@ -479,10 +436,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
 ]
 
@@ -498,22 +455,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-schema"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
-
-[[package]]
 name = "arrow-select"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
 dependencies = [
  "ahash",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
 ]
 
@@ -523,10 +474,10 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "memchr",
  "num",
@@ -1557,8 +1508,8 @@ version = "1.4.0"
 dependencies = [
  "agentmesh",
  "anyhow",
- "arrow-array 58.1.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-schema",
  "assert_cmd",
  "async-trait",
  "bincode",
@@ -2487,7 +2438,7 @@ checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
 dependencies = [
  "arrow",
  "arrow-ipc",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "bzip2 0.6.1",
@@ -2807,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
 dependencies = [
  "arrow",
- "arrow-buffer 56.2.0",
+ "arrow-buffer",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -3041,7 +2992,7 @@ dependencies = [
  "ahash",
  "arrow",
  "arrow-ord",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3070,7 +3021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
 dependencies = [
  "arrow",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -3846,7 +3797,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffdff7a2d68d22afc0657eddde3e946371ce7cfe730a3f78a5ed44ea5b1cb2e"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array",
  "rand 0.9.2",
 ]
 
@@ -4164,9 +4115,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d1884b17253d8572e88833c282fcbb442365e4ae5f9052ced2831608253436c"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "geo-traits",
  "geoarrow-schema",
  "num-traits",
@@ -4180,8 +4131,8 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67d3b543bc3ebeffdc204b67d69b8f9fcd33d76269ddd4a4618df99f053a934"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "geo",
  "geo-traits",
  "geoarrow-array",
@@ -4194,7 +4145,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f1b18b1c9a44ecd72be02e53d6e63bbccfdc8d1765206226af227327e2be6e"
 dependencies = [
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "geo-traits",
  "serde",
  "serde_json",
@@ -4208,8 +4159,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d676b8d8b5f391ab4270ba31e9b599ee2c3d780405a38e272a0a7565ea189c"
 dependencies = [
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-schema",
  "datafusion",
  "geo",
  "geo-traits",
@@ -4528,11 +4479,11 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4833,7 +4784,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5309,12 +5260,12 @@ checksum = "e8c439decbc304e180748e34bb6d3df729069a222e83e74e2185c38f107136e9"
 dependencies = [
  "arrow",
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-ipc",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "async-recursion",
  "async-trait",
@@ -5374,11 +5325,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ee5508b225456d3d56998eaeef0d8fbce5ea93856df47b12a94d2e74153210"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "bytes",
  "getrandom 0.2.17",
@@ -5405,9 +5356,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8856abad92e624b75cd57a04703f6441948a239463bdf973f2ac1924b0bcdbe"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "async-trait",
  "byteorder",
  "bytes",
@@ -5444,10 +5395,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8835308044cef5467d7751be87fcbefc2db01c22370726a8704bd62991693f"
 dependencies = [
  "arrow",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-ord",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "async-trait",
  "chrono",
@@ -5476,9 +5427,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612de1e888bb36f6bf51196a6eb9574587fdf256b1759a4c50e643e00d5f96d0"
 dependencies = [
  "arrow",
- "arrow-array 56.2.0",
+ "arrow-array",
  "arrow-cast",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "chrono",
  "futures",
  "half",
@@ -5495,11 +5446,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b456b29b135d3c7192602e516ccade38b5483986e121895fa43cf1fdb38bf60"
 dependencies = [
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "bytemuck",
  "byteorder",
@@ -5534,10 +5485,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab1538d14d5bb3735b4222b3f5aff83cfa59cc6ef7cdd3dd9139e4c77193c80b"
 dependencies = [
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "async-recursion",
  "async-trait",
@@ -5582,9 +5533,9 @@ checksum = "0ea84613df6fa6b9168a1f056ba4f9cb73b90a1b452814c6fd4b3529bcdbfc78"
 dependencies = [
  "arrow",
  "arrow-arith",
- "arrow-array 56.2.0",
+ "arrow-array",
  "arrow-ord",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "async-channel 2.5.0",
  "async-recursion",
@@ -5645,11 +5596,11 @@ checksum = "6b3fc4c1d941fceef40a0edbd664dbef108acfc5d559bb9e7f588d0c733cbc35"
 dependencies = [
  "arrow",
  "arrow-arith",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-data",
+ "arrow-schema",
  "arrow-select",
  "async-recursion",
  "async-trait",
@@ -5685,9 +5636,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ffbc5ce367fbf700a69de3fe0612ee1a11191a64a632888610b6bacfa0f63"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "cc",
  "deepsize",
  "half",
@@ -5719,7 +5670,7 @@ checksum = "ee713505576f6b1988a491f77c7ca8b0cf7090a393598e63c85079fa70a53ebf"
 dependencies = [
  "arrow",
  "arrow-ipc",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "futures",
@@ -5757,10 +5708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fdb2d56bfa4d1511c765fa0cc00fdaa37e5d2d1cd2f57b3c6355d9072177052"
 dependencies = [
  "arrow",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-ipc",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "async-trait",
  "aws-credential-types",
  "aws-sdk-dynamodb",
@@ -5797,8 +5748,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ccb1a4a9284435c6a8c02c8c06e7e041bece0d7f722152159353cf55dc51e3"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array",
+ "arrow-schema",
  "lance-arrow",
  "num-traits",
  "rand 0.9.2",
@@ -5812,12 +5763,12 @@ checksum = "9217d7d3a1f4e088bdedaad9b4fa79045b077e07f961f1cd3ec6f90850c425f2"
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 56.2.0",
+ "arrow-array",
  "arrow-cast",
- "arrow-data 56.2.0",
+ "arrow-data",
  "arrow-ipc",
  "arrow-ord",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "async-trait",
  "bytes",
@@ -7245,12 +7196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
 dependencies = [
  "ahash",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
- "arrow-data 56.2.0",
+ "arrow-data",
  "arrow-ipc",
- "arrow-schema 56.2.0",
+ "arrow-schema",
  "arrow-select",
  "base64 0.22.1",
  "brotli",
@@ -10917,7 +10868,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -10927,23 +10878,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -10958,32 +10896,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,15 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,11 +2092,10 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
- "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -2114,7 +2104,6 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
- "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -2126,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -7148,16 +7137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ dirs = "6"
 which = "8.0"
 os_info = "3.14"
 sysinfo = "0.33"
-home = "=0.5.12"  # Pin to avoid edition2024 requirement in 0.5.11+
+home = "=0.5.9"  # Pin: 0.5.11+ needs edition2024, 0.5.12 needs rustc 1.88 > MSRV 1.85
 time-core = "=0.1.7"  # Pin to avoid MSRV incompatibility in 0.1.8+
 
 # Model integration (Hugging Face Hub)
@@ -104,7 +104,7 @@ futures = "0.3"
 # Knowledge index (local vector database)
 lancedb = { version = "0.23", optional = true }
 fastembed = { version = "5", optional = true }
-arrow-array = { version = "58.1", optional = true }
+arrow-array = { version = "56.2", optional = true }  # must match arrow-schema + lancedb's arrow 56
 arrow-schema = { version = "56.2", optional = true }
 chromadb = { version = "2.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ regex = "1.12"
 tempfile = "3.27"
 serial_test = "3"
 proptest = "1"
-criterion = { version = "=0.8.2", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.85
+criterion = { version = "=0.7.0", features = ["html_reports"] }  # Pin: 0.8+ requires rustc 1.86, above MSRV 1.85 (0.7.0 = rustc 1.80)
 futures = "0.3"
 serde_yaml = "0.9"
 env_logger = "0.11"

--- a/src/agent/pipeline/filters.rs
+++ b/src/agent/pipeline/filters.rs
@@ -95,7 +95,10 @@ mod tests {
     #[tokio::test]
     async fn safety_filter_passes_safe() {
         let f = SafetyFilter;
-        assert!(f.filter(&cand_with_risk(Some(RiskLevel::Safe))).await.is_none());
+        assert!(f
+            .filter(&cand_with_risk(Some(RiskLevel::Safe)))
+            .await
+            .is_none());
     }
 
     #[tokio::test]
@@ -149,7 +152,10 @@ mod tests {
         let f = ValidationFilter;
         // Default: validation_passed = false, validation_error = None
         let reason = f.filter(&Candidate::new("x", "t")).await;
-        assert!(reason.is_some(), "should reject when validation not hydrated");
+        assert!(
+            reason.is_some(),
+            "should reject when validation not hydrated"
+        );
         assert!(reason.unwrap().contains("not hydrated"));
     }
 }

--- a/src/agent/pipeline/hydrators.rs
+++ b/src/agent/pipeline/hydrators.rs
@@ -90,7 +90,11 @@ impl SafetyHydrator {
 #[async_trait]
 impl Hydrator for SafetyHydrator {
     async fn hydrate(&self, c: &mut Candidate) {
-        match self.validator.validate_command(&c.command, self.shell).await {
+        match self
+            .validator
+            .validate_command(&c.command, self.shell)
+            .await
+        {
             Ok(result) => {
                 c.features.safety_confidence = result.confidence_score;
                 c.features.risk_level = Some(result.risk_level);

--- a/src/agent/pipeline/sources.rs
+++ b/src/agent/pipeline/sources.rs
@@ -50,14 +50,12 @@ impl BackendSource {
 impl CandidateSource for BackendSource {
     async fn produce(&self, prompt: &str) -> Result<Candidate, PipelineError> {
         let request = CommandRequest::new(prompt, self.shell);
-        let generated =
-            self.backend
-                .generate_command(&request)
-                .await
-                .map_err(|e| PipelineError::SourceFailed {
-                    name: self.label.clone(),
-                    message: e.to_string(),
-                })?;
+        let generated = self.backend.generate_command(&request).await.map_err(|e| {
+            PipelineError::SourceFailed {
+                name: self.label.clone(),
+                message: e.to_string(),
+            }
+        })?;
 
         let mut candidate = Candidate::new(generated.command, self.label.clone());
         candidate.features.llm_confidence = generated.confidence_score as f32;

--- a/src/knowledge/embedder.rs
+++ b/src/knowledge/embedder.rs
@@ -5,10 +5,14 @@
 use crate::knowledge::{KnowledgeError, Result};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use std::path::Path;
+use std::sync::Mutex;
 
 /// Text embedder using sentence transformers
 pub struct Embedder {
-    model: TextEmbedding,
+    // fastembed's `TextEmbedding::embed` takes `&mut self`, but the embedder is
+    // shared behind `Arc<KnowledgeIndex>`, so we keep a `&self` API via interior
+    // mutability rather than rippling `&mut` through every caller.
+    model: Mutex<TextEmbedding>,
 }
 
 impl Embedder {
@@ -25,7 +29,9 @@ impl Embedder {
         let model = TextEmbedding::try_new(options)
             .map_err(|e| KnowledgeError::EmbedderInit(e.to_string()))?;
 
-        Ok(Self { model })
+        Ok(Self {
+            model: Mutex::new(model),
+        })
     }
 
     /// Create embedder with quantized model for faster inference
@@ -39,13 +45,19 @@ impl Embedder {
         let model = TextEmbedding::try_new(options)
             .map_err(|e| KnowledgeError::EmbedderInit(e.to_string()))?;
 
-        Ok(Self { model })
+        Ok(Self {
+            model: Mutex::new(model),
+        })
     }
 
     /// Generate embeddings for a list of texts
     pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
-        self.model
-            .embed(texts.to_vec(), None)
+        let mut model = self
+            .model
+            .lock()
+            .map_err(|e| KnowledgeError::EmbeddingFailed(format!("embedder lock poisoned: {e}")))?;
+        model
+            .embed(texts, None)
             .map_err(|e| KnowledgeError::EmbeddingFailed(e.to_string()))
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -145,7 +145,9 @@ impl std::fmt::Display for GeneratedCommand {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum RiskLevel {
     Safe,

--- a/src/prompts/minimal.rs
+++ b/src/prompts/minimal.rs
@@ -120,8 +120,7 @@ mod tests {
 
     #[test]
     fn test_minimal_prompt_with_context() {
-        let request =
-            CommandRequest::new("list files", ShellType::Bash).with_context("cwd: /tmp");
+        let request = CommandRequest::new("list files", ShellType::Bash).with_context("cwd: /tmp");
         let prompt = build_minimal_prompt(&request);
         assert!(prompt.contains("cwd: /tmp"));
     }

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -130,11 +130,11 @@ impl std::fmt::Display for PromptStyle {
 pub use capability_profile::{AwkType, CapabilityProfile, DetectedShell, ProfileType, StatFormat};
 pub use command_templates::{CommandTemplate, TemplateLibrary};
 pub use explainer_prompt::ExplainerPromptBuilder;
+pub use minimal::build_minimal_prompt;
 pub use profiles::{
     AlternativeCommand, CommandExplanation, GenerationProfile, OptionExplanation, ProfileConfig,
     UsageExample,
 };
-pub use minimal::build_minimal_prompt;
 pub use smollm_prompt::{CommandOutput, PromptResponse, RepairPromptBuilder, SmolLMPromptBuilder};
 pub use validation::{
     CommandValidator, RiskLevel, ValidationError, ValidationErrorCode, ValidationResult,

--- a/tests/custom_patterns_toml.rs
+++ b/tests/custom_patterns_toml.rs
@@ -82,14 +82,18 @@ pattern = 'aws\s+s3\s+rb\s+s3://prod-'
 risk_level = "high"
 description = "Remove prod S3 bucket"
 "#;
-    let validator =
-        validator_from_toml("", Some(patterns)).expect("validator builds from sibling patterns.toml");
+    let validator = validator_from_toml("", Some(patterns))
+        .expect("validator builds from sibling patterns.toml");
     let result = validator
         .validate_command("aws s3 rb s3://prod-customer-data --force", ShellType::Bash)
         .await
         .expect("validate");
 
-    assert!(!result.allowed, "sibling pattern should block: {:?}", result);
+    assert!(
+        !result.allowed,
+        "sibling pattern should block: {:?}",
+        result
+    );
 }
 
 #[tokio::test]
@@ -117,7 +121,8 @@ async fn user_pattern_severity_capped_at_high() {
         description: "User pattern claiming Critical".to_string(),
         shell_specific: None,
     };
-    let err = validate_user_pattern(&pat).expect_err("Critical should be rejected for user pattern");
+    let err =
+        validate_user_pattern(&pat).expect_err("Critical should be rejected for user pattern");
     assert!(
         err.to_lowercase().contains("critical")
             || err.to_lowercase().contains("severity")

--- a/tests/cve_enforcement.rs
+++ b/tests/cve_enforcement.rs
@@ -6,9 +6,9 @@
 //! other code touch.
 
 use caro::models::{RiskLevel, SafetyLevel, ShellType};
-use caro::safety::{SafetyConfig, SafetyValidator};
 #[cfg(feature = "cve-rules")]
 use caro::safety::CVE_COMPILED;
+use caro::safety::{SafetyConfig, SafetyValidator};
 
 /// The canonical xz-utils backdoor trigger — the pattern that motivated
 /// this whole pipeline. Covered by `data/cve_rules/CVE-2024-3094.yaml`.


### PR DESCRIPTION
## What & why

CI is red on `main` (Lint & Format + MSRV checks) due to **dependency drift**, independent of any feature work — this blocks every PR. Closes the compile/MSRV failures tracked in **caro-enve**.

## Three fixes

1. **`home` MSRV** — pin `=0.5.9` (rust-version 1.70) instead of `=0.5.12`, which requires **rustc 1.88** and broke `MSRV Check (Rust 1.85)`. 0.5.9 is the last pre-edition2024 release, matching the existing pin's stated intent and the `time-core = "=0.1.7"` precedent.
2. **arrow alignment** — `arrow-array` `58.1` → `56.2` to match `arrow-schema = "56.2"` and the `lancedb → lance → datafusion` stack (all require arrow **56**). The split pulled two `arrow-schema` versions, so `arrow_schema::ArrowError` (56) and `arrow_schema::error::ArrowError` (58) were *distinct types* — the `E0271/E0277/E0599/E0308` cascade that failed the Lint job's `clippy --all-features` compile. Lock now resolves a single arrow.
3. **embedder** — fastembed v5's `TextEmbedding::embed` takes `&mut self`, but the embedder is shared behind `Arc<KnowledgeIndex>`. Wrapped the model in a `Mutex` (interior mutability) rather than rippling `&mut` through every caller (`E0596`). Dropped an unnecessary `to_vec` for `clippy -D warnings`.

## Verification

- `cargo check --no-default-features --features embedded-cpu` → green (home downgrade safe).
- `cargo check --features knowledge` → green (arrow + embedder).
- `cargo clippy --no-default-features --features embedded-cpu,knowledge,chromadb,remote-backends,cve-rules --all-targets -- -D warnings` → **green**.
- `embedded-mlx`'s native `mlx-sys` build isn't reproducible in the sandbox (Metal toolchain); it's unaffected by these pure dependency-version changes and was **not** in the original CI error set — this PR's own CI run exercises the full `--all-features` command.

## Scope

Pure dependency-drift / compile unblock. The remaining red `Unit Tests` failures (`test_allowlist_functionality`, `test_dangerous_command_executes_with_confirm_flag`) are a **separate** root cause (stale-test-vs-security-policy + env-dependent model output), tracked separately — not addressed here to keep this PR a clean, reviewable deps fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI by fixing dependency drift, the embedder compile break, and formatting drift. Pins `home` and `criterion` for MSRV, aligns Arrow crates, and runs rustfmt to restore green Lint/Format and MSRV checks.

- **Dependencies**
  - Pin `home` to `=0.5.9` to meet MSRV 1.85.
  - Pin `criterion` to `=0.7.0` to meet MSRV 1.85.
  - Align Arrow to 56: `arrow-array` `58.1` → `56.2` to match `arrow-schema` and the `lancedb`/`lance`/`datafusion` stack.

- **Bug Fixes**
  - Wrap `fastembed` `TextEmbedding` in a `Mutex` to handle its `&mut self` API behind shared `Arc<KnowledgeIndex>`. Removed an extra allocation to satisfy clippy.
  - Ran cargo fmt to fix pre-existing formatting drift and unblock the Lint & Format step.

<sup>Written for commit bdc820745621f0b35c64515d423f3b48f814ca61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

