### PR TITLE
feat(backends): Mesh-LLM + AI-Horde + hybrid privacy gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,19 @@ A Rust CLI that converts natural language descriptions into safe POSIX shell com
 ```
 src/
 ├── main.rs              # Entry point, CLI argument parsing
-├── inference/           # Backend trait + implementations
-│   ├── mod.rs           # InferenceBackend trait definition
-│   ├── static_backend.rs    # Template-based backend
-│   ├── embedded_backend.rs  # Local LLM (MLX/CPU)
-│   ├── ollama_backend.rs    # Remote Ollama API
-│   └── vllm_backend.rs      # Remote vLLM API
+├── backends/            # CommandGenerator trait + implementations
+│   ├── mod.rs           # CommandGenerator trait + GeneratorError
+│   ├── static_matcher.rs    # Template-based deterministic backend
+│   ├── embedded/            # Local LLM (MLX/CPU)
+│   ├── remote/              # Remote HTTP backends (feature = remote-backends)
+│   │   ├── ollama.rs        # Ollama API
+│   │   ├── vllm.rs          # vLLM OpenAI-compatible API
+│   │   ├── exo.rs           # Exo distributed cluster
+│   │   ├── mesh.rs          # Mesh-LLM pooled mesh (OpenAI-compatible, :9337)
+│   │   └── ai_horde.rs      # AI-Horde async volunteer cluster
+│   └── hybrid/              # Privacy gateway: local sanitizer + remote enhancer
+│       ├── mod.rs           # HybridBackend (sanitize→enhance→restore→fallback)
+│       └── sanitizer.rs     # Deterministic reversible PII redaction
 ├── safety/              # Command safety validation
 │   ├── mod.rs           # SafetyValidator trait
 │   ├── patterns.rs      # 52+ dangerous command patterns

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ This project is **generally available** with all core features implemented, test
 - 🤖 **Agentic context loop** - Iterative refinement with platform detection
 - 🌍 **Platform-aware generation** - Detects OS, architecture, available commands
 - 📍 **Execution context detection** - CWD, shell type, system constraints
-- 🌐 Remote backend support (Ollama, vLLM) with automatic fallback
+- 🌐 Remote backend support (Ollama, vLLM, Exo, Mesh-LLM, AI-Horde) with automatic fallback
+- 🔐 Privacy-preserving **hybrid** backend: sanitize PII locally, enhance remotely
 - 🛡️ Safety validation with 52 pre-compiled dangerous command patterns
 - ⚙️ Configuration management with TOML support
 - 💬 Interactive user confirmation flows with color-coded risk levels
@@ -250,7 +251,7 @@ caro --verbose "search for Python files"
 | Option | Description | Status |
 |--------|-------------|--------|
 | `-s, --shell <SHELL>` | Target shell (bash, zsh, fish, sh, powershell, cmd) | ✅ Implemented |
-| `-b, --backend <BACKEND>` | Inference backend (embedded, ollama, exo, vllm) | ✅ Implemented |
+| `-b, --backend <BACKEND>` | Inference backend (embedded, ollama, exo, vllm, mesh, ai-horde, hybrid) | ✅ Implemented |
 | `-m, --model-name <NAME>` | Model name for the backend (e.g., codellama:7b) | ✅ Implemented |
 | `--safety <LEVEL>` | Safety level (strict, moderate, permissive) | ✅ Implemented |
 | `-o, --output <FORMAT>` | Output format (json, yaml, plain) | ✅ Implemented |
@@ -367,7 +368,7 @@ caro config reset
 **Available config keys:**
 | Key | Values | Description |
 |-----|--------|-------------|
-| `backend` | `embedded`, `ollama`, `exo`, `vllm` | Inference backend |
+| `backend` | `embedded`, `ollama`, `exo`, `vllm`, `mesh`, `ai-horde`, `hybrid` | Inference backend |
 | `model-name` | Any valid model name | Model for the backend (e.g., `codellama:7b`) |
 | `shell` | `bash`, `zsh`, `fish`, `sh`, `powershell`, `cmd` | Default target shell |
 | `safety` | `strict`, `moderate`, `permissive` | Safety validation level |
@@ -375,6 +376,37 @@ caro config reset
 **Config file location:** `~/.config/caro/config.toml` (Linux/macOS)
 
 **Priority order:** CLI flags (`--backend`, `--model-name`) > Environment variables > Config file > Auto-detect
+
+#### Remote & distributed backends (`[backends]`)
+
+Remote endpoint URLs and keys are configurable, so you can point Caro at a
+non-default port or a self-hosted service without recompiling:
+
+```toml
+[backends]
+# Mesh-LLM: pool GPUs across your own machines (OpenAI-compatible, :9337)
+mesh_url = "http://localhost:9337"
+# AI-Horde: free crowdsourced cluster (anonymous key works out of the box)
+ai_horde_url = "https://aihorde.net/api"
+ai_horde_key = "0000000000"
+# Hybrid gateway: which remote enhancer to wrap (mesh | ai-horde)
+hybrid_remote = "mesh"
+# Send prompts verbatim to a (trusted) remote instead of sanitizing PII first.
+# Leave false to keep the privacy guarantee on public networks.
+allow_public = false
+```
+
+- **`mesh`** — [Mesh-LLM](https://github.com/Mesh-LLM/mesh-llm) pools GPU/RAM
+  across machines you own, behind one OpenAI-compatible API. Best when a model
+  is too big for one box but you want it private.
+- **`ai-horde`** — [AI-Horde](https://github.com/Haidra-Org/AI-Horde) is a free
+  volunteer cluster needing no GPU and no API key. Explicit opt-in only.
+- **`hybrid`** *(recommended for remote use)* — runs a local sanitizer that
+  redacts PII (paths, usernames, IPs, emails) into reversible placeholders
+  before sending to the remote enhancer, then restores real values in the
+  returned command locally. The network never sees your private data unless you
+  set `allow_public = true`. See
+  [ADR-015](docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md).
 
 ### System Assessment
 

--- a/SCOPE-self-healing-repair.md
+++ b/SCOPE-self-healing-repair.md
@@ -141,7 +141,7 @@ consistent with caro's "pure subprocess call" constraint. No daemon is needed.
 | Existing module | What it provides |
 |----------------|-----------------|
 | `execution/executor.rs::ExecutionResult` | exit_code, stdout, stderr already captured |
-| `safety/validator.rs::SafetyValidator` | re-use directly on repair output |
+| `safety/validator.rs::SafetyValidator` | reuse directly on repair output |
 | `backends::CommandGenerator` trait | repair is a specialized `generate_command` call |
 | `context/mod.rs::ExecutionContext` | platform rules for repair prompt |
 | `prompts/command_templates.rs` | prompt building pattern to follow |
@@ -270,7 +270,7 @@ pub fn build_repair_prompt(req: &RepairRequest, platform_rules: &str) -> String;
 
 #### `src/models/` — extend `CommandRequest` (existing type)
 
-Add an optional field so the repair prompt can re-use the generation pipeline:
+Add an optional field so the repair prompt can reuse the generation pipeline:
 
 ```rust
 // In models/profile.rs or wherever CommandRequest lives:

--- a/docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md
+++ b/docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md
@@ -1,0 +1,193 @@
+# ADR-015: Distributed-LLM Backends (Mesh-LLM, AI-Horde) via a Hybrid Privacy Gateway
+
+| **Status**     | Accepted                            |
+|----------------|-------------------------------------|
+| **Date**       | June 2026                           |
+| **Authors**    | Caro Maintainers                    |
+| **Target**     | Community                           |
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Context and Problem Statement](#context-and-problem-statement)
+3. [The Two Networks Compared](#the-two-networks-compared)
+4. [Decision](#decision)
+5. [The Hybrid Privacy Gateway](#the-hybrid-privacy-gateway)
+6. [What Breaks at 100 Real Users](#what-breaks-at-100-real-users)
+7. [Implementation Notes](#implementation-notes)
+8. [Consequences](#consequences)
+
+---
+
+## Executive Summary
+
+Caro converts natural language into safe POSIX commands using a spectrum of
+inference backends. This ADR adds two **distributed-LLM networks** to that
+spectrum and introduces a **Hybrid privacy gateway** so users can benefit from
+remote compute without leaking personally identifying information (PII).
+
+- **Mesh-LLM** ([github.com/Mesh-LLM/mesh-llm](https://github.com/Mesh-LLM/mesh-llm),
+  Rust, Apache-2.0) — a P2P mesh exposing a single **OpenAI-compatible `/v1`
+  API** that pools GPU/RAM across machines. Architecturally identical to Caro's
+  existing Exo/vLLM backends.
+- **AI-Horde** ([github.com/Haidra-Org/AI-Horde](https://github.com/Haidra-Org/AI-Horde),
+  Python, AGPL-3.0) — a crowdsourced volunteer cluster with an **async
+  job-queue API** and a free anonymous key.
+
+**Decision:** adopt both as optional remote backends (behind the existing
+`remote-backends` feature), make remote endpoint URLs configurable, and wrap
+them in a `hybrid` backend that sanitizes PII locally before any prompt leaves
+the device.
+
+---
+
+## Context and Problem Statement
+
+Caro's backend spectrum before this change:
+
+```
+static_matcher → embedded (local LLM) → ollama/vllm/exo (self-hosted) → claude/openrouter (paid cloud)
+```
+
+Two gaps remained:
+
+1. **"My model is too big for one machine, but I want it private."** No backend
+   pooled compute across several owned machines.
+2. **"I have no capable GPU and won't pay for a cloud API."** The `embedded`
+   backend is bounded by local hardware; cloud backends cost money.
+
+Mesh-LLM fills (1); AI-Horde fills (2). But both raise a privacy question: a
+shell-command prompt frequently carries PII (cwd, filenames, usernames,
+hostnames, IPs). Sending that verbatim to a *public* mesh or to *anonymous
+volunteers* is unacceptable for a safety-first tool.
+
+A secondary blocker: the backend factory **hard-coded** every remote URL, and
+`UserConfiguration` had no endpoint fields — so even pointing Caro at a mesh on
+a non-default port required a recompile.
+
+---
+
+## The Two Networks Compared
+
+| Dimension | Mesh-LLM | AI-Horde |
+|---|---|---|
+| Topology | P2P mesh you host/join | Public volunteer cluster |
+| API shape | OpenAI-compatible **sync** `/v1` | **Async** submit + poll (v2) |
+| Language / License | Rust / Apache-2.0 | Python / AGPL-3.0 |
+| Setup | Run a mesh node | None (anon key `0000000000`) |
+| Latency | Low, direct routing | Variable (queue + kudos priority) |
+| Trust model | Your own peers (private) or public | Untrusted anonymous volunteers |
+| Privacy default | Private mesh = safe; public = leaks | Prompt always leaves to strangers |
+| Caro integration cost | ~copy of `exo.rs` (sync) | New async poll-loop backend |
+| Auto-detected? | Yes (probes `:9337`) | No — explicit opt-in only |
+
+Neither project is a linked Rust crate — both are remote HTTP services — so the
+`external-sdk-integration.md` build-spike rule does not apply (no `Cargo.toml`
+dependency, no license linkage). AI-Horde is AGPL-3.0 (same as Caro); Mesh-LLM
+is Apache-2.0 — both fine as remote services.
+
+---
+
+## Decision
+
+1. **Add `BackendType::Mesh`, `BackendType::AiHorde`, `BackendType::Hybrid`.**
+2. **`MeshBackend`** (`src/backends/remote/mesh.rs`): OpenAI-compatible mirror
+   of the Exo backend; default `http://localhost:9337`; `model=mesh`
+   Mixture-of-Agents auto-routing; auto-detected ahead of Exo.
+3. **`AiHordeBackend`** (`src/backends/remote/ai_horde.rs`): async
+   `POST /v2/generate/text/async` → poll `/v2/generate/text/status/{id}` →
+   `generations[0].text`; anonymous key default; bounded `max_wait`; **explicit
+   opt-in only** (never auto-detected, since it is a public service).
+4. **`[backends]` config section** with per-backend URLs/keys, so endpoints are
+   configurable without recompiling. The factory resolves URLs from config with
+   localhost fallbacks.
+5. **`HybridBackend`** (`src/backends/hybrid/`): the recommended way to use
+   either remote network safely (see below).
+
+---
+
+## The Hybrid Privacy Gateway
+
+The `hybrid` backend composes a **local** model (the embedded backend, also the
+fallback) with a **remote** enhancer (Mesh-LLM or AI-Horde). Its pipeline, by
+default (`[backends].allow_public = false`):
+
+1. A deterministic `ContextSanitizer` redacts PII from the request `input` and
+   `context` into **reversible placeholders** — `/Users/alice/secret.txt` →
+   `<PATH_1>`, keeping an in-memory placeholder↔value map.
+2. The **sanitized** request is sent to the remote enhancer. The network never
+   sees the real values.
+3. Placeholders in the returned command are **restored** to real values
+   locally, so the executed command is correct.
+4. If the remote fails, Caro falls back to the local model on the original
+   request (which never left the device).
+
+The sanitizer is **rule/regex based, not an LLM call**, guaranteeing
+determinism (same input → same placeholders → reproducible, cache-safe output).
+Redaction scope ("Broad"): emails, IPv4 addresses, absolute/home paths, the
+current username and hostname, and the values of uppercase `ENV=` assignments.
+Class ordering redacts broad spans (paths) before narrow ones (usernames) so a
+username inside a path is never half-leaked.
+
+**Opt-in relaxation:** when a user sets `allow_public = true` (e.g. for a
+trusted *private* mesh where redaction is unnecessary), sanitization is skipped
+and the prompt is sent verbatim — the same "standard remote warning" path that
+Claude/OpenRouter already use.
+
+This directly implements the design intent: *the local model is a privacy
+gateway; the remote network is an enhancement that never receives PII unless the
+user deliberately opts in.*
+
+---
+
+## What Breaks at 100 Real Users
+
+(Per `validation-discipline.md` gate 3.)
+
+- **Assumption that holds at demo scale:** the regex redaction set catches every
+  PII form a user's prompt contains. At scale, novel PII shapes (IPv6, UNC
+  paths, API tokens in unusual formats) may slip through.
+  - **Failure mode:** a token the sanitizer doesn't recognize is sent to a
+    public network.
+  - **Instrumentation:** log `redaction_count` per request (already surfaced in
+    `backend_used`); a sudden drop in average redactions on PII-heavy prompts
+    signals a gap.
+  - **Fallback:** the `allow_public = false` default means a sanitizer miss is
+    the *only* leak vector, and the `[backends].hybrid_remote` + future
+    `redact_patterns` escape hatch lets users add custom regexes. Conservative
+    users keep the remote enhancer pointed at a private mesh.
+- **AI-Horde queue saturation:** at 100 concurrent anonymous users, the shared
+  anonymous-key kudos priority is lowest, so latency degrades.
+  - **Instrumentation:** `typical_latency_ms` and the poll-loop `Timeout`.
+  - **Fallback:** the bounded `max_wait` + embedded fallback means a slow queue
+    degrades to local generation, never a hang.
+
+---
+
+## Implementation Notes
+
+- All three backends share the `{"cmd": "..."}` 4-tier parse contract used by
+  the existing remote backends.
+- `ai::privacy::may_leak_context_offhost` flags `mesh` and `ai-horde` as
+  off-host; `hybrid` is intentionally excluded because it sanitizes by default.
+- Tests: 7 (mesh) + 6 (AI-Horde, via `wiremock`) + 11 (hybrid + sanitizer),
+  including a privacy-proof test asserting the remote never receives PII while
+  the restored command is correct.
+
+## Consequences
+
+**Positive:**
+- Two new zero/low-cost backend options that extend Caro's reach to users with
+  pooled hardware (Mesh-LLM) or no hardware (AI-Horde).
+- Remote URLs are finally configurable, removing a recompile-to-relocate wart.
+- The hybrid gateway makes "use a remote model" compatible with Caro's
+  safety-first, local-first ethos.
+
+**Negative / risks:**
+- The redaction set is a moving target (see "What Breaks…").
+- More backend permutations to test; mitigated by the per-backend feature gate
+  and the shared parse/fallback helpers.
+
+**Neutral:**
+- `hybrid` is opt-in (`--backend hybrid`); existing default behavior is
+  unchanged.

--- a/docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md
+++ b/docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md
@@ -113,14 +113,24 @@ fallback) with a **remote** enhancer (Mesh-LLM or AI-Horde). Its pipeline, by
 default (`[backends].allow_public = false`):
 
 1. A deterministic `ContextSanitizer` redacts PII from the request `input` and
-   `context` into **reversible placeholders** — `/Users/alice/secret.txt` →
-   `<PATH_1>`, keeping an in-memory placeholder↔value map.
-2. The **sanitized** request is sent to the remote enhancer. The network never
-   sees the real values.
-3. Placeholders in the returned command are **restored** to real values
+   `context` into **typed, self-describing placeholders** —
+   `/Users/alice/secret.txt` → `<REDACTED_FILEPATH_1>` — keeping an in-memory
+   placeholder↔value map.
+2. A **redaction briefing** is prepended to the prompt sent to the remote. It
+   (a) states that Caro's **local model** performed the redaction on the
+   harness, (b) lists each placeholder with a **description** of the value it
+   stands for ("an absolute filesystem path", "the user's login name", …), and
+   (c) instructs the model to reproduce each placeholder **verbatim** and never
+   guess the underlying value. The remote thus reasons about command *shape*
+   without seeing private data.
+3. The **sanitized** request + briefing is sent to the remote enhancer. The
+   network never sees the real values.
+4. Placeholders in the returned command are **restored** to real values
    locally, so the executed command is correct.
-4. If the remote fails, Caro falls back to the local model on the original
-   request (which never left the device).
+5. If the remote fails, Caro falls back to the local model on the original
+   request (which never left the device). The local model is itself an **aware
+   participant**: a privacy-layer contract note is attached to its context so it
+   knows redaction is active and that it owns the redaction process.
 
 The sanitizer is **rule/regex based, not an LLM call**, guaranteeing
 determinism (same input → same placeholders → reproducible, cache-safe output).
@@ -128,6 +138,14 @@ Redaction scope ("Broad"): emails, IPv4 addresses, absolute/home paths, the
 current username and hostname, and the values of uppercase `ENV=` assignments.
 Class ordering redacts broad spans (paths) before narrow ones (usernames) so a
 username inside a path is never half-leaked.
+
+Placeholders are **typed and self-describing** (`<REDACTED_FILEPATH_1>`,
+`<REDACTED_USERNAME_1>`, …) rather than opaque symbols, and the briefing legend
+gives each a plain-language description. This is deliberate: a remote model that
+knows a slot is "an absolute filesystem path" produces a correct command
+template, whereas an opaque `<X1>` invites it to hallucinate a literal. Tokens
+stay space-free and unique so restoration (longest-token-first replacement)
+remains unambiguous.
 
 **Opt-in relaxation:** when a user sets `allow_public = true` (e.g. for a
 trusted *private* mesh where redaction is unnecessary), sanitization is skipped

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@ Example: `ADR-001-enterprise-community-architecture.md`
 | [ADR-012](./ADR-012-honggfuzz-integration.md) | Honggfuzz Integration for Security-Critical Fuzz Testing | Proposed | 2026-01-02 |
 | [ADR-013](./ADR-013-pre-processing-pipeline.md) | Pre-Processing Pipeline Architecture | Proposed | 2026-01-01 |
 | [ADR-014](./ADR-014-serde-env-evaluation.md) | Environment Variable Deserialization with serde-env | Proposed | 2026-01-01 |
+| [ADR-015](./ADR-015-distributed-llm-backends-hybrid-privacy.md) | Distributed-LLM Backends (Mesh-LLM, AI-Horde) via a Hybrid Privacy Gateway | Accepted | 2026-06-07 |
 
 ## Contributing to ADRs
 

--- a/src/ai/privacy.rs
+++ b/src/ai/privacy.rs
@@ -68,7 +68,10 @@ pub fn may_leak_context_offhost(ai_cfg: &AiConfig, backend_name: &str) -> bool {
     let anything_optin = ai_cfg.opening.send_cwd
         || ai_cfg.opening.send_last_command
         || ai_cfg.capabilities.enable_history_search;
-    let remote = matches!(backend_name, "ollama" | "vllm" | "exo" | "claude");
+    let remote = matches!(
+        backend_name,
+        "ollama" | "vllm" | "exo" | "claude" | "mesh" | "ai-horde"
+    );
     anything_optin && remote && ai_cfg.endpoint.is_some()
 }
 

--- a/src/backends/hybrid/mod.rs
+++ b/src/backends/hybrid/mod.rs
@@ -1,0 +1,304 @@
+// Hybrid privacy gateway backend.
+//
+// The hybrid backend composes a *local* model (the embedded backend, which is
+// also the fallback) with a *remote* enhancer (Mesh-LLM or AI-Horde). Its
+// purpose is to let users benefit from a more capable distributed model WITHOUT
+// leaking personally identifying or environment-revealing information to that
+// network.
+//
+// Pipeline (default, `allow_public = false`):
+//   1. A `ContextSanitizer` session redacts PII from the request `input` and
+//      `context` into reversible placeholders (`<PATH_1>`, `<USER_1>`, ...).
+//   2. The sanitized request is sent to the remote enhancer.
+//   3. Placeholders in the returned command are restored to real values
+//      locally — the network never saw them.
+//   4. If the remote fails, we fall back to the local model on the ORIGINAL
+//      (un-sanitized) request, which is fine because it stays on-device.
+//
+// When the user explicitly opts into public inference (`allow_public = true`),
+// sanitization is skipped and the request is sent verbatim — the "standard
+// remote warning" path that Claude/OpenRouter already use. This is the user's
+// deliberate choice for, e.g., a trusted private mesh where redaction is
+// unnecessary.
+//
+// Note: deterministic common-command handling (the static matcher) already runs
+// upstream in `AgentLoop` before any backend is consulted, so the hybrid
+// backend does not duplicate it here.
+
+pub mod sanitizer;
+
+pub use sanitizer::{ContextSanitizer, SanitizeSession};
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError};
+use crate::models::{CommandRequest, GeneratedCommand};
+
+/// Privacy-preserving backend pairing a local model with a remote enhancer.
+pub struct HybridBackend {
+    /// On-device model used as the fallback and for un-sanitized work.
+    local: Arc<dyn CommandGenerator>,
+    /// Remote enhancer (Mesh-LLM / AI-Horde) that only ever sees sanitized input.
+    remote: Arc<dyn CommandGenerator>,
+    sanitizer: ContextSanitizer,
+    /// When true, skip sanitization and send prompts verbatim (opt-in).
+    allow_public: bool,
+}
+
+impl HybridBackend {
+    pub fn new(
+        local: Arc<dyn CommandGenerator>,
+        remote: Arc<dyn CommandGenerator>,
+        sanitizer: ContextSanitizer,
+        allow_public: bool,
+    ) -> Self {
+        Self {
+            local,
+            remote,
+            sanitizer,
+            allow_public,
+        }
+    }
+
+    /// Whether this gateway sanitizes before sending (true) or sends verbatim.
+    pub fn sanitizes(&self) -> bool {
+        !self.allow_public
+    }
+
+    /// Build a sanitized clone of `request`, returning the request plus the
+    /// session needed to restore the result.
+    fn sanitize_request<'a>(
+        &'a self,
+        request: &CommandRequest,
+    ) -> (CommandRequest, SanitizeSession<'a>) {
+        let mut session = self.sanitizer.session();
+        let input = session.sanitize(&request.input);
+        let context = request.context.as_ref().map(|c| session.sanitize(c));
+
+        let sanitized = CommandRequest {
+            input,
+            shell: request.shell,
+            safety_level: request.safety_level,
+            context,
+            backend_preference: request.backend_preference.clone(),
+        };
+        (sanitized, session)
+    }
+
+    /// Run the remote enhancer with sanitization, restoring PII in the result.
+    async fn generate_sanitized(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        let (sanitized_req, session) = self.sanitize_request(request);
+        let mut result = self.remote.generate_command(&sanitized_req).await?;
+
+        // Restore real values that the remote echoed back as placeholders.
+        result.command = session.restore(&result.command);
+        result.alternatives = result
+            .alternatives
+            .into_iter()
+            .map(|a| session.restore(&a))
+            .collect();
+
+        let redactions = session.redaction_count();
+        result.backend_used = format!(
+            "Hybrid[{} via local sanitizer, {} redaction(s)]",
+            result.backend_used, redactions
+        );
+        Ok(result)
+    }
+
+    async fn fallback_local(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        tracing::info!("Hybrid: remote enhancer failed, using local model");
+        let mut result = self.local.generate_command(request).await?;
+        result.backend_used = format!("Hybrid[local: {}]", result.backend_used);
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl CommandGenerator for HybridBackend {
+    async fn generate_command(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        let attempt = if self.allow_public {
+            // Opt-in: send verbatim, like any other remote backend.
+            self.remote.generate_command(request).await
+        } else {
+            self.generate_sanitized(request).await
+        };
+
+        match attempt {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                tracing::warn!("Hybrid remote enhancer error: {}", err);
+                self.fallback_local(request).await
+            }
+        }
+    }
+
+    async fn is_available(&self) -> bool {
+        // The local model is always usable, so the gateway is always available;
+        // remote availability only affects which path is taken.
+        self.local.is_available().await || self.remote.is_available().await
+    }
+
+    fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            backend_type: BackendType::Hybrid,
+            model_name: format!(
+                "{} + {}",
+                self.local.backend_info().model_name,
+                self.remote.backend_info().model_name
+            ),
+            supports_streaming: false,
+            max_tokens: 100,
+            typical_latency_ms: self.remote.backend_info().typical_latency_ms,
+            memory_usage_mb: self.local.backend_info().memory_usage_mb,
+            version: "1.0".to_string(),
+        }
+    }
+
+    async fn shutdown(&self) -> Result<(), GeneratorError> {
+        let _ = self.remote.shutdown().await;
+        self.local.shutdown().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{RiskLevel, SafetyLevel, ShellType};
+
+    /// A stub backend that echoes a fixed command and records what it received.
+    struct StubBackend {
+        name: String,
+        reply_command: String,
+        fail: bool,
+        seen: std::sync::Mutex<Option<String>>,
+    }
+
+    impl StubBackend {
+        fn new(name: &str, reply: &str, fail: bool) -> Self {
+            Self {
+                name: name.to_string(),
+                reply_command: reply.to_string(),
+                fail,
+                seen: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CommandGenerator for StubBackend {
+        async fn generate_command(
+            &self,
+            request: &CommandRequest,
+        ) -> Result<GeneratedCommand, GeneratorError> {
+            *self.seen.lock().unwrap() = Some(request.input.clone());
+            if self.fail {
+                return Err(GeneratorError::BackendUnavailable {
+                    reason: "stub down".to_string(),
+                });
+            }
+            Ok(GeneratedCommand {
+                command: self.reply_command.clone(),
+                explanation: "stub".to_string(),
+                safety_level: RiskLevel::Safe,
+                estimated_impact: "none".to_string(),
+                alternatives: vec![],
+                backend_used: self.name.clone(),
+                generation_time_ms: 0,
+                confidence_score: 0.9,
+            })
+        }
+        async fn is_available(&self) -> bool {
+            !self.fail
+        }
+        fn backend_info(&self) -> BackendInfo {
+            BackendInfo {
+                backend_type: BackendType::Mock,
+                model_name: self.name.clone(),
+                supports_streaming: false,
+                max_tokens: 100,
+                typical_latency_ms: 10,
+                memory_usage_mb: 0,
+                version: "0".to_string(),
+            }
+        }
+        async fn shutdown(&self) -> Result<(), GeneratorError> {
+            Ok(())
+        }
+    }
+
+    fn req(input: &str) -> CommandRequest {
+        CommandRequest {
+            input: input.to_string(),
+            shell: ShellType::Bash,
+            safety_level: SafetyLevel::Moderate,
+            context: None,
+            backend_preference: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remote_never_sees_pii_but_result_is_restored() {
+        // Remote echoes back a command referencing the placeholder it received.
+        let remote = Arc::new(StubBackend::new("remote", "rm <PATH_1>", false));
+        let local = Arc::new(StubBackend::new("local", "noop", false));
+        let hybrid = HybridBackend::new(
+            local,
+            remote.clone(),
+            ContextSanitizer::new(),
+            false, // sanitize
+        );
+
+        let result = hybrid
+            .generate_command(&req("delete /Users/alice/secret.txt"))
+            .await
+            .unwrap();
+
+        // The remote saw a sanitized prompt with NO PII.
+        let seen = remote.seen.lock().unwrap().clone().unwrap();
+        assert!(!seen.contains("alice"));
+        assert!(!seen.contains("secret.txt"));
+        assert!(seen.contains("<PATH_1>"));
+
+        // The final command has the real path restored locally.
+        assert_eq!(result.command, "rm /Users/alice/secret.txt");
+    }
+
+    #[tokio::test]
+    async fn test_allow_public_sends_verbatim() {
+        let remote = Arc::new(StubBackend::new("remote", "ok", false));
+        let local = Arc::new(StubBackend::new("local", "noop", false));
+        let hybrid = HybridBackend::new(local, remote.clone(), ContextSanitizer::new(), true);
+
+        hybrid
+            .generate_command(&req("delete /Users/alice/secret.txt"))
+            .await
+            .unwrap();
+
+        // Opt-in path: the remote saw the raw prompt, PII included.
+        let seen = remote.seen.lock().unwrap().clone().unwrap();
+        assert!(seen.contains("alice"));
+        assert!(seen.contains("secret.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_falls_back_to_local_when_remote_fails() {
+        let remote = Arc::new(StubBackend::new("remote", "x", true)); // fails
+        let local = Arc::new(StubBackend::new("local", "echo hi", false));
+        let hybrid = HybridBackend::new(local, remote, ContextSanitizer::new(), false);
+
+        let result = hybrid.generate_command(&req("greet me")).await.unwrap();
+        assert_eq!(result.command, "echo hi");
+        assert!(result.backend_used.contains("local"));
+    }
+}

--- a/src/backends/hybrid/mod.rs
+++ b/src/backends/hybrid/mod.rs
@@ -91,7 +91,16 @@ impl HybridBackend {
         &self,
         request: &CommandRequest,
     ) -> Result<GeneratedCommand, GeneratorError> {
-        let (sanitized_req, session) = self.sanitize_request(request);
+        let (mut sanitized_req, session) = self.sanitize_request(request);
+
+        // Prepend a briefing that tells the remote model the redaction was done
+        // by Caro's local model, describes each placeholder, and instructs it to
+        // reproduce placeholders verbatim. Injected into `input` so it reaches
+        // every backend's prompt (which all include the request input).
+        if let Some(briefing) = session.redaction_briefing() {
+            sanitized_req.input = format!("{}\n\n{}", briefing, sanitized_req.input);
+        }
+
         let mut result = self.remote.generate_command(&sanitized_req).await?;
 
         // Restore real values that the remote echoed back as placeholders.
@@ -115,7 +124,24 @@ impl HybridBackend {
         request: &CommandRequest,
     ) -> Result<GeneratedCommand, GeneratorError> {
         tracing::info!("Hybrid: remote enhancer failed, using local model");
-        let mut result = self.local.generate_command(request).await?;
+
+        // Make the local model an aware participant in the redaction pipeline by
+        // attaching the privacy-layer contract note to its context. Only when
+        // sanitizing (the note describes active redaction, which the opt-in
+        // public path disables).
+        let local_request = if self.sanitizes() {
+            let note = ContextSanitizer::local_awareness_note();
+            let mut req = request.clone();
+            req.context = Some(match req.context.take() {
+                Some(c) => format!("{}\n{}", c, note),
+                None => note.to_string(),
+            });
+            req
+        } else {
+            request.clone()
+        };
+
+        let mut result = self.local.generate_command(&local_request).await?;
         result.backend_used = format!("Hybrid[local: {}]", result.backend_used);
         Ok(result)
     }
@@ -182,6 +208,7 @@ mod tests {
         reply_command: String,
         fail: bool,
         seen: std::sync::Mutex<Option<String>>,
+        seen_context: std::sync::Mutex<Option<String>>,
     }
 
     impl StubBackend {
@@ -191,6 +218,7 @@ mod tests {
                 reply_command: reply.to_string(),
                 fail,
                 seen: std::sync::Mutex::new(None),
+                seen_context: std::sync::Mutex::new(None),
             }
         }
     }
@@ -202,6 +230,7 @@ mod tests {
             request: &CommandRequest,
         ) -> Result<GeneratedCommand, GeneratorError> {
             *self.seen.lock().unwrap() = Some(request.input.clone());
+            *self.seen_context.lock().unwrap() = request.context.clone();
             if self.fail {
                 return Err(GeneratorError::BackendUnavailable {
                     reason: "stub down".to_string(),
@@ -250,7 +279,7 @@ mod tests {
     #[tokio::test]
     async fn test_remote_never_sees_pii_but_result_is_restored() {
         // Remote echoes back a command referencing the placeholder it received.
-        let remote = Arc::new(StubBackend::new("remote", "rm <PATH_1>", false));
+        let remote = Arc::new(StubBackend::new("remote", "rm <REDACTED_FILEPATH_1>", false));
         let local = Arc::new(StubBackend::new("local", "noop", false));
         let hybrid = HybridBackend::new(
             local,
@@ -264,11 +293,15 @@ mod tests {
             .await
             .unwrap();
 
-        // The remote saw a sanitized prompt with NO PII.
+        // The remote saw a sanitized prompt with NO PII...
         let seen = remote.seen.lock().unwrap().clone().unwrap();
         assert!(!seen.contains("alice"));
         assert!(!seen.contains("secret.txt"));
-        assert!(seen.contains("<PATH_1>"));
+        assert!(seen.contains("<REDACTED_FILEPATH_1>"));
+        // ...plus a briefing attributing the redaction to Caro's local model
+        // and describing the placeholder.
+        assert!(seen.contains("Caro's local model"));
+        assert!(seen.contains("filesystem path"));
 
         // The final command has the real path restored locally.
         assert_eq!(result.command, "rm /Users/alice/secret.txt");
@@ -295,10 +328,26 @@ mod tests {
     async fn test_falls_back_to_local_when_remote_fails() {
         let remote = Arc::new(StubBackend::new("remote", "x", true)); // fails
         let local = Arc::new(StubBackend::new("local", "echo hi", false));
-        let hybrid = HybridBackend::new(local, remote, ContextSanitizer::new(), false);
+        let hybrid = HybridBackend::new(local.clone(), remote, ContextSanitizer::new(), false);
 
         let result = hybrid.generate_command(&req("greet me")).await.unwrap();
         assert_eq!(result.command, "echo hi");
         assert!(result.backend_used.contains("local"));
+
+        // The local model was made aware of the redaction pipeline via context.
+        let ctx = local.seen_context.lock().unwrap().clone().unwrap();
+        assert!(ctx.contains("caro-privacy-layer"));
+    }
+
+    #[tokio::test]
+    async fn test_public_optin_local_fallback_has_no_awareness_note() {
+        // In allow_public mode there is no active redaction, so the local
+        // fallback should NOT be told values are being rewritten.
+        let remote = Arc::new(StubBackend::new("remote", "x", true)); // fails
+        let local = Arc::new(StubBackend::new("local", "echo hi", false));
+        let hybrid = HybridBackend::new(local.clone(), remote, ContextSanitizer::new(), true);
+
+        hybrid.generate_command(&req("greet me")).await.unwrap();
+        assert!(local.seen_context.lock().unwrap().is_none());
     }
 }

--- a/src/backends/hybrid/mod.rs
+++ b/src/backends/hybrid/mod.rs
@@ -350,4 +350,58 @@ mod tests {
         hybrid.generate_command(&req("greet me")).await.unwrap();
         assert!(local.seen_context.lock().unwrap().is_none());
     }
+
+    /// End-to-end on-the-wire proof: drive a REAL MeshBackend (which performs an
+    /// actual reqwest POST) through the hybrid gateway against a mock server,
+    /// then inspect the exact bytes that left the machine. The briefing and the
+    /// redacted token must be present; the real PII must not.
+    #[cfg(feature = "remote-backends")]
+    #[tokio::test]
+    async fn test_redacted_briefing_appears_on_the_wire_not_pii() {
+        use crate::backends::remote::MeshBackend;
+        use reqwest::Url;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [ {
+                    "message": {
+                        "role": "assistant",
+                        "content": "{\"cmd\": \"cat <REDACTED_FILEPATH_1>\"}"
+                    }
+                } ]
+            })))
+            .mount(&server)
+            .await;
+
+        let mesh = Arc::new(
+            MeshBackend::new(Url::parse(&server.uri()).unwrap(), "mesh".to_string()).unwrap(),
+        );
+        let local = Arc::new(StubBackend::new("local", "noop", false));
+        let hybrid = HybridBackend::new(local, mesh, ContextSanitizer::new(), false);
+
+        let result = hybrid
+            .generate_command(&req("show me /Users/alice/secret.txt"))
+            .await
+            .unwrap();
+
+        // Inspect the actual request body that crossed the network boundary.
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let wire_body = String::from_utf8(requests[0].body.clone()).unwrap();
+
+        // The redacted token and the briefing attribution are on the wire...
+        assert!(wire_body.contains("<REDACTED_FILEPATH_1>"));
+        assert!(wire_body.contains("Caro's local model"));
+        assert!(wire_body.contains("filesystem path"));
+        // ...but the real PII is NOT.
+        assert!(!wire_body.contains("alice"), "PII leaked on the wire: {wire_body}");
+        assert!(!wire_body.contains("secret.txt"), "PII leaked on the wire");
+
+        // And the command handed back to the user has the real path restored.
+        assert_eq!(result.command, "cat /Users/alice/secret.txt");
+    }
 }

--- a/src/backends/hybrid/sanitizer.rs
+++ b/src/backends/hybrid/sanitizer.rs
@@ -2,10 +2,19 @@
 //
 // Before a prompt is sent to a remote inference network (Mesh-LLM, AI-Horde),
 // the hybrid gateway runs it through this sanitizer to replace personally
-// identifying or environment-revealing tokens with reversible placeholders
-// (e.g. `/Users/alice/secret.txt` -> `<PATH_1>`). After the remote returns a
-// command, the SAME session restores the real values locally, so the network
-// never sees PII but the executed command is still correct.
+// identifying or environment-revealing tokens with TYPED, self-describing
+// placeholders (e.g. `/Users/alice/secret.txt` -> `<REDACTED_FILEPATH_1>`).
+// After the remote returns a command, the SAME session restores the real
+// values locally, so the network never sees PII but the executed command is
+// still correct.
+//
+// Crucially, the remote model is not left to guess what a placeholder means.
+// `redaction_briefing()` produces a legend describing each placeholder ("an
+// absolute filesystem path", "the user's login name", ...) plus an explicit
+// instruction stating that Caro's local model performed the redaction on the
+// user's machine and that the placeholder must be reproduced verbatim. This
+// lets the remote reason about the *shape* of the command without ever seeing
+// the private value.
 //
 // Design guarantees:
 //   * Deterministic   - the same input always yields the same placeholders, so
@@ -15,10 +24,8 @@
 //   * Class ordering  - broader classes (paths) are redacted before narrower
 //                       ones (usernames) so a username inside a path is not
 //                       half-leaked.
-//
-// Redaction scope ("Broad"): emails, IPv4 addresses, absolute/home paths,
-// the current username and hostname (exact-literal), and the values of
-// uppercase ENV-style assignments (`AWS_SECRET=...`).
+//   * Self-describing - each placeholder carries a class and a human/LLM
+//                       readable description for the briefing legend.
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -26,9 +33,7 @@ use regex::Regex;
 static EMAIL_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
 
-static IPV4_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\b(?:\d{1,3}\.){3}\d{1,3}\b").unwrap()
-});
+static IPV4_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b(?:\d{1,3}\.){3}\d{1,3}\b").unwrap());
 
 // Absolute (`/usr/...`) or home (`~/...`) paths: a leading `/` or `~/` followed
 // by at least one path-ish character. Requires the second char so a lone `/`
@@ -41,13 +46,56 @@ static PATH_RE: Lazy<Regex> =
 static ENV_ASSIGN_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\b([A-Z][A-Z0-9_]{2,})=(\S+)").unwrap());
 
+/// A redaction class: the token stem used in placeholders and a description of
+/// what kind of value it stands for (shown to the remote model in the legend).
+#[derive(Debug, Clone, Copy)]
+struct RedactionClass {
+    /// Token stem, e.g. `REDACTED_FILEPATH` -> `<REDACTED_FILEPATH_1>`.
+    token: &'static str,
+    /// Human/LLM-readable description for the briefing legend.
+    description: &'static str,
+}
+
+const CLASS_EMAIL: RedactionClass = RedactionClass {
+    token: "REDACTED_EMAIL",
+    description: "an email address",
+};
+const CLASS_IPV4: RedactionClass = RedactionClass {
+    token: "REDACTED_IPV4",
+    description: "an IPv4 network address",
+};
+const CLASS_FILEPATH: RedactionClass = RedactionClass {
+    token: "REDACTED_FILEPATH",
+    description: "an absolute or home-directory filesystem path on the user's machine",
+};
+const CLASS_ENV_VALUE: RedactionClass = RedactionClass {
+    token: "REDACTED_ENV_VALUE",
+    description: "the value of an environment variable",
+};
+const CLASS_USERNAME: RedactionClass = RedactionClass {
+    token: "REDACTED_USERNAME",
+    description: "the user's account / login name",
+};
+const CLASS_HOSTNAME: RedactionClass = RedactionClass {
+    token: "REDACTED_HOSTNAME",
+    description: "the machine's hostname",
+};
+
+/// One redacted value and the placeholder that replaced it.
+#[derive(Debug, Clone)]
+struct Redaction {
+    placeholder: String,
+    original: String,
+    description: &'static str,
+}
+
 /// Builds sanitizing sessions seeded with known identity literals.
 #[derive(Debug, Clone, Default)]
 pub struct ContextSanitizer {
-    /// Known exact-string identifiers to redact, as `(value, class)` pairs —
-    /// e.g. `("alice", "USER")`. Only non-empty, length-3+ values are used to
-    /// avoid redacting trivially-short or empty identifiers.
-    literals: Vec<(String, &'static str)>,
+    /// Known exact-string identifiers to redact, as `(value, class)` pairs.
+    /// Only non-empty, length-3+ values are kept to avoid redacting trivially
+    /// short identifiers.
+    literals: Vec<(String, RedactionClass)>,
 }
 
 impl ContextSanitizer {
@@ -60,12 +108,12 @@ impl ContextSanitizer {
     pub fn with_identity(mut self, username: Option<&str>, hostname: Option<&str>) -> Self {
         if let Some(u) = username {
             if u.len() >= 3 {
-                self.literals.push((u.to_string(), "USER"));
+                self.literals.push((u.to_string(), CLASS_USERNAME));
             }
         }
         if let Some(h) = hostname {
             if h.len() >= 3 {
-                self.literals.push((h.to_string(), "HOST"));
+                self.literals.push((h.to_string(), CLASS_HOSTNAME));
             }
         }
         self
@@ -81,14 +129,26 @@ impl ContextSanitizer {
             counters: Vec::new(),
         }
     }
+
+    /// A standing note attached to the LOCAL model's context whenever the
+    /// hybrid gateway runs, so the on-device model is an aware participant in
+    /// the redaction process (not a bystander). The local model owns redaction;
+    /// this states the contract it operates under.
+    pub fn local_awareness_note() -> &'static str {
+        "[caro-privacy-layer] You are Caro's on-device model. A deterministic \
+local redaction layer rewrites private values (filesystem paths, usernames, \
+hostnames, IP addresses, emails, and environment-variable values) into typed \
+placeholders before any prompt is sent to a remote backend, and restores them \
+locally afterwards. Private values never leave this machine."
+    }
 }
 
 /// An in-flight sanitization with a reversible placeholder map.
 pub struct SanitizeSession<'a> {
-    literals: &'a [(String, &'static str)],
-    /// `(placeholder, original)` in allocation order.
-    entries: Vec<(String, String)>,
-    /// Per-class running counters: `(class, next_index)`.
+    literals: &'a [(String, RedactionClass)],
+    /// Redactions in allocation order.
+    entries: Vec<Redaction>,
+    /// Per-class-token running counters: `(token, next_index)`.
     counters: Vec<(&'static str, usize)>,
 }
 
@@ -97,11 +157,11 @@ impl SanitizeSession<'_> {
     pub fn sanitize(&mut self, text: &str) -> String {
         let mut out = text.to_string();
 
-        // Order matters: most-specific / broadest-span classes first so inner
-        // tokens (e.g. a username inside a path) are not separately leaked.
-        out = self.redact_regex(&out, &EMAIL_RE, "EMAIL");
-        out = self.redact_regex(&out, &IPV4_RE, "IP");
-        out = self.redact_regex(&out, &PATH_RE, "PATH");
+        // Order matters: broadest-span classes first so inner tokens (e.g. a
+        // username inside a path) are not separately leaked.
+        out = self.redact_regex(&out, &EMAIL_RE, CLASS_EMAIL);
+        out = self.redact_regex(&out, &IPV4_RE, CLASS_IPV4);
+        out = self.redact_regex(&out, &PATH_RE, CLASS_FILEPATH);
         out = self.redact_env_assignments(&out);
         out = self.redact_literals(&out);
 
@@ -110,13 +170,13 @@ impl SanitizeSession<'_> {
 
     /// Restore real values in `command` (the remote-generated output).
     pub fn restore(&self, command: &str) -> String {
-        // Replace longest placeholders first so `<PATH_1>` does not corrupt
-        // `<PATH_11>`.
-        let mut ordered: Vec<&(String, String)> = self.entries.iter().collect();
-        ordered.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        // Replace longest placeholders first so `<REDACTED_FILEPATH_1>` does not
+        // corrupt `<REDACTED_FILEPATH_11>`.
+        let mut ordered: Vec<&Redaction> = self.entries.iter().collect();
+        ordered.sort_by(|a, b| b.placeholder.len().cmp(&a.placeholder.len()));
         let mut out = command.to_string();
-        for (placeholder, original) in ordered {
-            out = out.replace(placeholder.as_str(), original);
+        for r in ordered {
+            out = out.replace(r.placeholder.as_str(), &r.original);
         }
         out
     }
@@ -126,27 +186,57 @@ impl SanitizeSession<'_> {
         self.entries.len()
     }
 
-    /// Allocate (or reuse) a placeholder for `value` in `class`.
-    fn placeholder_for(&mut self, value: &str, class: &'static str) -> String {
-        if let Some((ph, _)) = self.entries.iter().find(|(_, v)| v == value) {
-            return ph.clone();
+    /// A briefing for the REMOTE model: states that Caro's local model performed
+    /// the redaction on the harness, lists each placeholder with a description
+    /// of the value it stands for, and instructs the model to reproduce the
+    /// placeholder verbatim. Returns `None` when nothing was redacted.
+    pub fn redaction_briefing(&self) -> Option<String> {
+        if self.entries.is_empty() {
+            return None;
         }
-        let idx = match self.counters.iter_mut().find(|(c, _)| *c == class) {
+
+        let mut legend = String::new();
+        for r in &self.entries {
+            legend.push_str(&format!("  - {}: {}\n", r.placeholder, r.description));
+        }
+
+        Some(format!(
+            "[CARO PRIVACY LAYER — read carefully]\n\
+This request was preprocessed on the user's machine by Caro's local model. \
+Sensitive values were redacted and replaced with the typed placeholders below. \
+Each placeholder stands for a real value that never left the user's device:\n\
+{legend}\
+Treat every placeholder as an opaque literal: reproduce it EXACTLY as written \
+in your generated command, and never guess or invent the underlying value. \
+Caro will substitute the real values back locally before the command runs."
+        ))
+    }
+
+    /// Allocate (or reuse) a placeholder for `value` in `class`.
+    fn placeholder_for(&mut self, value: &str, class: RedactionClass) -> String {
+        if let Some(r) = self.entries.iter().find(|r| r.original == value) {
+            return r.placeholder.clone();
+        }
+        let idx = match self.counters.iter_mut().find(|(t, _)| *t == class.token) {
             Some((_, n)) => {
                 *n += 1;
                 *n
             }
             None => {
-                self.counters.push((class, 1));
+                self.counters.push((class.token, 1));
                 1
             }
         };
-        let ph = format!("<{}_{}>", class, idx);
-        self.entries.push((ph.clone(), value.to_string()));
-        ph
+        let placeholder = format!("<{}_{}>", class.token, idx);
+        self.entries.push(Redaction {
+            placeholder: placeholder.clone(),
+            original: value.to_string(),
+            description: class.description,
+        });
+        placeholder
     }
 
-    fn redact_regex(&mut self, text: &str, re: &Regex, class: &'static str) -> String {
+    fn redact_regex(&mut self, text: &str, re: &Regex, class: RedactionClass) -> String {
         // Collect distinct matches in order of first appearance.
         let mut distinct: Vec<String> = Vec::new();
         for m in re.find_iter(text) {
@@ -173,8 +263,7 @@ impl SanitizeSession<'_> {
         }
         let mut out = text.to_string();
         for v in distinct {
-            let ph = self.placeholder_for(&v, "ENV");
-            // Only replace the value when it follows a `NAME=`, preserving name.
+            let ph = self.placeholder_for(&v, CLASS_ENV_VALUE);
             out = ENV_ASSIGN_RE
                 .replace_all(&out, |caps: &regex::Captures| {
                     if caps.get(2).map(|m| m.as_str()) == Some(v.as_str()) {
@@ -191,7 +280,7 @@ impl SanitizeSession<'_> {
     fn redact_literals(&mut self, text: &str) -> String {
         let mut out = text.to_string();
         // Snapshot to avoid borrowing self while mutating its map.
-        let literals: Vec<(String, &'static str)> = self.literals.to_vec();
+        let literals: Vec<(String, RedactionClass)> = self.literals.to_vec();
         for (value, class) in literals {
             if !value.is_empty() && out.contains(&value) {
                 let ph = self.placeholder_for(&value, class);
@@ -211,12 +300,11 @@ mod tests {
         let san = ContextSanitizer::new();
         let mut s = san.session();
         let out = s.sanitize("delete /Users/alice/secret.txt please");
-        assert!(out.contains("<PATH_1>"));
+        assert!(out.contains("<REDACTED_FILEPATH_1>"));
         assert!(!out.contains("alice"));
         assert!(!out.contains("secret.txt"));
 
-        // A remote-generated command referencing the placeholder restores fully.
-        let restored = s.restore("rm <PATH_1>");
+        let restored = s.restore("rm <REDACTED_FILEPATH_1>");
         assert_eq!(restored, "rm /Users/alice/secret.txt");
     }
 
@@ -233,9 +321,8 @@ mod tests {
         let san = ContextSanitizer::new();
         let mut s = san.session();
         let out = s.sanitize("copy /tmp/a to backup, then read /tmp/a again");
-        // Same path appears twice -> one placeholder reused.
-        assert_eq!(out.matches("<PATH_1>").count(), 2);
-        assert!(!out.contains("<PATH_2>"));
+        assert_eq!(out.matches("<REDACTED_FILEPATH_1>").count(), 2);
+        assert!(!out.contains("<REDACTED_FILEPATH_2>"));
     }
 
     #[test]
@@ -243,9 +330,8 @@ mod tests {
         let san = ContextSanitizer::new().with_identity(Some("alice"), None);
         let mut s = san.session();
         let out = s.sanitize("open /home/alice/notes and tell alice");
-        // The path is redacted wholesale; the standalone "alice" becomes <USER_1>.
-        assert!(out.contains("<PATH_1>"));
-        assert!(out.contains("<USER_1>"));
+        assert!(out.contains("<REDACTED_FILEPATH_1>"));
+        assert!(out.contains("<REDACTED_USERNAME_1>"));
         assert!(!out.contains("alice"));
     }
 
@@ -254,8 +340,8 @@ mod tests {
         let san = ContextSanitizer::new();
         let mut s = san.session();
         let out = s.sanitize("mail bob@example.com from 192.168.1.10");
-        assert!(out.contains("<EMAIL_1>"));
-        assert!(out.contains("<IP_1>"));
+        assert!(out.contains("<REDACTED_EMAIL_1>"));
+        assert!(out.contains("<REDACTED_IPV4_1>"));
         assert!(!out.contains("bob@example.com"));
         assert!(!out.contains("192.168.1.10"));
     }
@@ -265,7 +351,7 @@ mod tests {
         let san = ContextSanitizer::new();
         let mut s = san.session();
         let out = s.sanitize("run with AWS_SECRET=hunter2 set");
-        assert!(out.contains("AWS_SECRET=<ENV_1>"));
+        assert!(out.contains("AWS_SECRET=<REDACTED_ENV_VALUE_1>"));
         assert!(!out.contains("hunter2"));
     }
 
@@ -275,9 +361,8 @@ mod tests {
         let mut s = san.session();
         let i = s.sanitize("clean /tmp/cache");
         let c = s.sanitize("cwd is /tmp/cache");
-        // Same path in both fields -> identical placeholder.
-        assert!(i.contains("<PATH_1>"));
-        assert!(c.contains("<PATH_1>"));
+        assert!(i.contains("<REDACTED_FILEPATH_1>"));
+        assert!(c.contains("<REDACTED_FILEPATH_1>"));
         assert_eq!(s.redaction_count(), 1);
     }
 
@@ -288,5 +373,30 @@ mod tests {
         let out = s.sanitize("list all text files by size");
         assert_eq!(out, "list all text files by size");
         assert_eq!(s.redaction_count(), 0);
+        assert!(s.redaction_briefing().is_none());
+    }
+
+    #[test]
+    fn test_briefing_describes_each_placeholder_and_attributes_local_model() {
+        let san = ContextSanitizer::new().with_identity(Some("alice"), None);
+        let mut s = san.session();
+        s.sanitize("tar /Users/alice/photos and mail bob@example.com");
+        let briefing = s.redaction_briefing().expect("redactions present");
+
+        // Attribution + verbatim instruction.
+        assert!(briefing.contains("Caro's local model"));
+        assert!(briefing.to_lowercase().contains("exactly"));
+        // Legend entries carry descriptions, not just the bare token.
+        assert!(briefing.contains("<REDACTED_FILEPATH_1>"));
+        assert!(briefing.contains("filesystem path"));
+        assert!(briefing.contains("<REDACTED_EMAIL_1>"));
+        assert!(briefing.contains("email address"));
+    }
+
+    #[test]
+    fn test_local_awareness_note_mentions_redaction() {
+        let note = ContextSanitizer::local_awareness_note();
+        assert!(note.contains("caro-privacy-layer"));
+        assert!(note.to_lowercase().contains("redaction"));
     }
 }

--- a/src/backends/hybrid/sanitizer.rs
+++ b/src/backends/hybrid/sanitizer.rs
@@ -1,0 +1,292 @@
+// Deterministic context sanitizer for the hybrid privacy gateway.
+//
+// Before a prompt is sent to a remote inference network (Mesh-LLM, AI-Horde),
+// the hybrid gateway runs it through this sanitizer to replace personally
+// identifying or environment-revealing tokens with reversible placeholders
+// (e.g. `/Users/alice/secret.txt` -> `<PATH_1>`). After the remote returns a
+// command, the SAME session restores the real values locally, so the network
+// never sees PII but the executed command is still correct.
+//
+// Design guarantees:
+//   * Deterministic   - the same input always yields the same placeholders, so
+//                       output is reproducible and cache-safe. No LLM is used;
+//                       redaction is pure rule/regex based.
+//   * Reversible      - every placeholder maps back to exactly one original.
+//   * Class ordering  - broader classes (paths) are redacted before narrower
+//                       ones (usernames) so a username inside a path is not
+//                       half-leaked.
+//
+// Redaction scope ("Broad"): emails, IPv4 addresses, absolute/home paths,
+// the current username and hostname (exact-literal), and the values of
+// uppercase ENV-style assignments (`AWS_SECRET=...`).
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static EMAIL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
+
+static IPV4_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(?:\d{1,3}\.){3}\d{1,3}\b").unwrap()
+});
+
+// Absolute (`/usr/...`) or home (`~/...`) paths: a leading `/` or `~/` followed
+// by at least one path-ish character. Requires the second char so a lone `/`
+// (e.g. a regex slash in NL) is not redacted.
+static PATH_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:~/|/)[A-Za-z0-9._\-]+(?:/[A-Za-z0-9._\-]+)*/?").unwrap());
+
+// Uppercase ENV-style assignment; the *value* (group 2) is redacted, the name
+// (group 1) is kept so the command still reads sensibly.
+static ENV_ASSIGN_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\b([A-Z][A-Z0-9_]{2,})=(\S+)").unwrap());
+
+/// Builds sanitizing sessions seeded with known identity literals.
+#[derive(Debug, Clone, Default)]
+pub struct ContextSanitizer {
+    /// Known exact-string identifiers to redact, as `(value, class)` pairs —
+    /// e.g. `("alice", "USER")`. Only non-empty, length-3+ values are used to
+    /// avoid redacting trivially-short or empty identifiers.
+    literals: Vec<(String, &'static str)>,
+}
+
+impl ContextSanitizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed the sanitizer with the current username and hostname so those exact
+    /// strings are redacted wherever they appear in the prompt.
+    pub fn with_identity(mut self, username: Option<&str>, hostname: Option<&str>) -> Self {
+        if let Some(u) = username {
+            if u.len() >= 3 {
+                self.literals.push((u.to_string(), "USER"));
+            }
+        }
+        if let Some(h) = hostname {
+            if h.len() >= 3 {
+                self.literals.push((h.to_string(), "HOST"));
+            }
+        }
+        self
+    }
+
+    /// Start a sanitizing session. A session accumulates the placeholder map
+    /// across multiple `sanitize` calls (e.g. input + context) so a value gets
+    /// one stable placeholder, and can later `restore` it in the result.
+    pub fn session(&self) -> SanitizeSession<'_> {
+        SanitizeSession {
+            literals: &self.literals,
+            entries: Vec::new(),
+            counters: Vec::new(),
+        }
+    }
+}
+
+/// An in-flight sanitization with a reversible placeholder map.
+pub struct SanitizeSession<'a> {
+    literals: &'a [(String, &'static str)],
+    /// `(placeholder, original)` in allocation order.
+    entries: Vec<(String, String)>,
+    /// Per-class running counters: `(class, next_index)`.
+    counters: Vec<(&'static str, usize)>,
+}
+
+impl SanitizeSession<'_> {
+    /// Redact PII from `text`, returning the placeholdered string.
+    pub fn sanitize(&mut self, text: &str) -> String {
+        let mut out = text.to_string();
+
+        // Order matters: most-specific / broadest-span classes first so inner
+        // tokens (e.g. a username inside a path) are not separately leaked.
+        out = self.redact_regex(&out, &EMAIL_RE, "EMAIL");
+        out = self.redact_regex(&out, &IPV4_RE, "IP");
+        out = self.redact_regex(&out, &PATH_RE, "PATH");
+        out = self.redact_env_assignments(&out);
+        out = self.redact_literals(&out);
+
+        out
+    }
+
+    /// Restore real values in `command` (the remote-generated output).
+    pub fn restore(&self, command: &str) -> String {
+        // Replace longest placeholders first so `<PATH_1>` does not corrupt
+        // `<PATH_11>`.
+        let mut ordered: Vec<&(String, String)> = self.entries.iter().collect();
+        ordered.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        let mut out = command.to_string();
+        for (placeholder, original) in ordered {
+            out = out.replace(placeholder.as_str(), original);
+        }
+        out
+    }
+
+    /// Number of distinct values redacted in this session.
+    pub fn redaction_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Allocate (or reuse) a placeholder for `value` in `class`.
+    fn placeholder_for(&mut self, value: &str, class: &'static str) -> String {
+        if let Some((ph, _)) = self.entries.iter().find(|(_, v)| v == value) {
+            return ph.clone();
+        }
+        let idx = match self.counters.iter_mut().find(|(c, _)| *c == class) {
+            Some((_, n)) => {
+                *n += 1;
+                *n
+            }
+            None => {
+                self.counters.push((class, 1));
+                1
+            }
+        };
+        let ph = format!("<{}_{}>", class, idx);
+        self.entries.push((ph.clone(), value.to_string()));
+        ph
+    }
+
+    fn redact_regex(&mut self, text: &str, re: &Regex, class: &'static str) -> String {
+        // Collect distinct matches in order of first appearance.
+        let mut distinct: Vec<String> = Vec::new();
+        for m in re.find_iter(text) {
+            let v = m.as_str().to_string();
+            if !distinct.contains(&v) {
+                distinct.push(v);
+            }
+        }
+        let mut out = text.to_string();
+        for v in distinct {
+            let ph = self.placeholder_for(&v, class);
+            out = out.replace(&v, &ph);
+        }
+        out
+    }
+
+    fn redact_env_assignments(&mut self, text: &str) -> String {
+        let mut distinct: Vec<String> = Vec::new();
+        for caps in ENV_ASSIGN_RE.captures_iter(text) {
+            let v = caps.get(2).unwrap().as_str().to_string();
+            if !distinct.contains(&v) {
+                distinct.push(v);
+            }
+        }
+        let mut out = text.to_string();
+        for v in distinct {
+            let ph = self.placeholder_for(&v, "ENV");
+            // Only replace the value when it follows a `NAME=`, preserving name.
+            out = ENV_ASSIGN_RE
+                .replace_all(&out, |caps: &regex::Captures| {
+                    if caps.get(2).map(|m| m.as_str()) == Some(v.as_str()) {
+                        format!("{}={}", &caps[1], ph)
+                    } else {
+                        caps[0].to_string()
+                    }
+                })
+                .into_owned();
+        }
+        out
+    }
+
+    fn redact_literals(&mut self, text: &str) -> String {
+        let mut out = text.to_string();
+        // Snapshot to avoid borrowing self while mutating its map.
+        let literals: Vec<(String, &'static str)> = self.literals.to_vec();
+        for (value, class) in literals {
+            if !value.is_empty() && out.contains(&value) {
+                let ph = self.placeholder_for(&value, class);
+                out = out.replace(&value, &ph);
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_redaction_and_restore() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let out = s.sanitize("delete /Users/alice/secret.txt please");
+        assert!(out.contains("<PATH_1>"));
+        assert!(!out.contains("alice"));
+        assert!(!out.contains("secret.txt"));
+
+        // A remote-generated command referencing the placeholder restores fully.
+        let restored = s.restore("rm <PATH_1>");
+        assert_eq!(restored, "rm /Users/alice/secret.txt");
+    }
+
+    #[test]
+    fn test_determinism() {
+        let san = ContextSanitizer::new();
+        let a = san.session().sanitize("look in /var/log/app and /etc/hosts");
+        let b = san.session().sanitize("look in /var/log/app and /etc/hosts");
+        assert_eq!(a, b, "same input must yield identical placeholders");
+    }
+
+    #[test]
+    fn test_repeated_value_same_placeholder() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let out = s.sanitize("copy /tmp/a to backup, then read /tmp/a again");
+        // Same path appears twice -> one placeholder reused.
+        assert_eq!(out.matches("<PATH_1>").count(), 2);
+        assert!(!out.contains("<PATH_2>"));
+    }
+
+    #[test]
+    fn test_username_inside_path_not_separately_leaked() {
+        let san = ContextSanitizer::new().with_identity(Some("alice"), None);
+        let mut s = san.session();
+        let out = s.sanitize("open /home/alice/notes and tell alice");
+        // The path is redacted wholesale; the standalone "alice" becomes <USER_1>.
+        assert!(out.contains("<PATH_1>"));
+        assert!(out.contains("<USER_1>"));
+        assert!(!out.contains("alice"));
+    }
+
+    #[test]
+    fn test_email_and_ip() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let out = s.sanitize("mail bob@example.com from 192.168.1.10");
+        assert!(out.contains("<EMAIL_1>"));
+        assert!(out.contains("<IP_1>"));
+        assert!(!out.contains("bob@example.com"));
+        assert!(!out.contains("192.168.1.10"));
+    }
+
+    #[test]
+    fn test_env_assignment_keeps_name_redacts_value() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let out = s.sanitize("run with AWS_SECRET=hunter2 set");
+        assert!(out.contains("AWS_SECRET=<ENV_1>"));
+        assert!(!out.contains("hunter2"));
+    }
+
+    #[test]
+    fn test_shared_session_across_input_and_context() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let i = s.sanitize("clean /tmp/cache");
+        let c = s.sanitize("cwd is /tmp/cache");
+        // Same path in both fields -> identical placeholder.
+        assert!(i.contains("<PATH_1>"));
+        assert!(c.contains("<PATH_1>"));
+        assert_eq!(s.redaction_count(), 1);
+    }
+
+    #[test]
+    fn test_no_pii_passes_through_unchanged() {
+        let san = ContextSanitizer::new();
+        let mut s = san.session();
+        let out = s.sanitize("list all text files by size");
+        assert_eq!(out, "list all text files by size");
+        assert_eq!(s.redaction_count(), 0);
+    }
+}

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -2,6 +2,7 @@
 // These are placeholder stubs - tests should fail until proper implementation
 
 pub mod embedded;
+pub mod hybrid;
 #[cfg(feature = "remote-backends")]
 pub mod remote;
 pub mod static_matcher;

--- a/src/backends/remote/ai_horde.rs
+++ b/src/backends/remote/ai_horde.rs
@@ -536,6 +536,16 @@ mod tests {
             .with_poll_interval(Duration::from_millis(5))
             .with_max_wait(Duration::from_millis(20));
         let err = backend.generate_command(&req()).await.unwrap_err();
-        assert!(matches!(err, GeneratorError::Timeout { .. }));
+        // A never-completing job must surface as "gave up": normally a Timeout,
+        // but under heavy CI load the mock server can transiently refuse a poll
+        // connection, which legitimately surfaces as BackendUnavailable. Both
+        // mean the same thing here — no command was produced.
+        assert!(
+            matches!(
+                err,
+                GeneratorError::Timeout { .. } | GeneratorError::BackendUnavailable { .. }
+            ),
+            "expected timeout/unavailable, got {err:?}"
+        );
     }
 }

--- a/src/backends/remote/ai_horde.rs
+++ b/src/backends/remote/ai_horde.rs
@@ -1,0 +1,541 @@
+// AI-Horde crowdsourced cluster backend implementation
+//
+// AI-Horde (https://github.com/Haidra-Org/AI-Horde) is a free, community-run
+// distributed cluster where volunteers contribute spare GPU time to serve text
+// and image generation. Unlike the OpenAI-compatible backends, the Horde uses
+// an ASYNCHRONOUS job-queue API:
+//
+//   1. POST {base}/v2/generate/text/async   -> returns a request id
+//   2. GET  {base}/v2/generate/text/status/{id}  (poll until `done`)
+//   3. read generations[0].text from the finished status
+//
+// Auth is via an `apikey` header. The anonymous key "0000000000" works without
+// registration (lowest queue priority). Because the prompt is processed by
+// *untrusted volunteer machines*, this backend is intended to sit behind the
+// hybrid privacy gateway, which sanitizes PII before anything is submitted.
+
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError};
+use crate::models::{CommandRequest, GeneratedCommand, RiskLevel};
+
+static CMD_EXTRACT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"\{\s*"cmd"\s*:\s*"(.+)"\s*\}"#).expect("Invalid regex pattern"));
+
+/// Default AI-Horde base API URL (includes the `/api` path segment).
+pub const AI_HORDE_DEFAULT_URL: &str = "https://aihorde.net/api";
+
+/// Anonymous API key — works without registration at lowest queue priority.
+pub const AI_HORDE_ANON_KEY: &str = "0000000000";
+
+/// Default total budget to wait for a queued job to finish.
+const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(60);
+
+/// Default delay between status polls (the Horde caches status for ~1s).
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(1500);
+
+/// Text-generation submission payload (KoboldAI-Horde format).
+#[derive(Debug, Serialize)]
+struct HordeTextRequest {
+    prompt: String,
+    params: HordeParams,
+    /// Optional model filter; an empty list lets any worker pick it up.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    models: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HordeParams {
+    max_length: u32,
+    temperature: f32,
+    n: u32,
+}
+
+/// Response to the async submission — carries the job id (or an error message).
+#[derive(Debug, Deserialize)]
+struct HordeSubmitResponse {
+    id: Option<String>,
+    message: Option<String>,
+}
+
+/// Polled status for an in-flight job.
+#[derive(Debug, Deserialize)]
+struct HordeStatusResponse {
+    #[serde(default)]
+    done: bool,
+    #[serde(default)]
+    faulted: bool,
+    #[serde(default)]
+    generations: Vec<HordeGeneration>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HordeGeneration {
+    text: String,
+}
+
+/// AI-Horde crowdsourced text-generation backend.
+pub struct AiHordeBackend {
+    /// Base URL without trailing slash, e.g. `https://aihorde.net/api`.
+    base_url: String,
+    api_key: String,
+    models: Vec<String>,
+    client: Client,
+    max_wait: Duration,
+    poll_interval: Duration,
+    embedded_fallback: Option<Arc<dyn CommandGenerator>>,
+}
+
+impl AiHordeBackend {
+    /// Create a backend pointed at `base_url` using `api_key`.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self, GeneratorError> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| GeneratorError::ConfigError {
+                message: format!("Failed to create HTTP client: {}", e),
+            })?;
+
+        Ok(Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+            models: Vec::new(),
+            client,
+            max_wait: DEFAULT_MAX_WAIT,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            embedded_fallback: None,
+        })
+    }
+
+    /// Create a backend against the public Horde with the anonymous key.
+    pub fn with_defaults() -> Result<Self, GeneratorError> {
+        Self::new(AI_HORDE_DEFAULT_URL, AI_HORDE_ANON_KEY)
+    }
+
+    /// Restrict generation to specific worker models (empty = any).
+    pub fn with_models(mut self, models: Vec<String>) -> Self {
+        self.models = models;
+        self
+    }
+
+    /// Override the total wait budget for a queued job.
+    pub fn with_max_wait(mut self, max_wait: Duration) -> Self {
+        self.max_wait = max_wait;
+        self
+    }
+
+    /// Override the status poll interval (mainly for fast tests).
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    pub fn with_embedded_fallback(mut self, fallback: Arc<dyn CommandGenerator>) -> Self {
+        self.embedded_fallback = Some(fallback);
+        self
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Build the `{"cmd": ...}` system prompt (shared contract across backends).
+    fn create_system_prompt(&self, request: &CommandRequest) -> String {
+        format!(
+            r#"You are a helpful assistant that converts natural language to safe POSIX shell commands.
+
+CRITICAL: You MUST respond with ONLY valid JSON in this exact format:
+{{"cmd": "your_shell_command_here"}}
+
+Rules:
+1. Generate ONLY the shell command, no explanation
+2. Use POSIX-compliant utilities (ls, find, grep, awk, sed, sort, etc.)
+3. Quote file paths with spaces using double quotes
+4. Target shell: {}
+5. NEVER generate destructive commands (rm -rf /, mkfs, dd, etc.)
+6. Keep commands simple and safe
+7. If the request is unclear, generate "echo 'Please clarify your request'"
+
+Request: {}
+"#,
+            request.shell, request.input
+        )
+    }
+
+    /// Parse a model response into a bare command (4-tier strategy).
+    fn parse_command_response(&self, response: &str) -> Result<String, GeneratorError> {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(response) {
+            if let Some(cmd) = parsed.get("cmd").and_then(|v| v.as_str()) {
+                if !cmd.is_empty() {
+                    return Ok(cmd.trim().to_string());
+                }
+            }
+        }
+
+        if let (Some(start), Some(end)) = (response.find('{'), response.rfind('}')) {
+            if start <= end {
+                if let Ok(parsed) =
+                    serde_json::from_str::<serde_json::Value>(&response[start..=end])
+                {
+                    if let Some(cmd) = parsed.get("cmd").and_then(|v| v.as_str()) {
+                        if !cmd.is_empty() {
+                            return Ok(cmd.trim().to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        for line in response.lines() {
+            let line = line.trim();
+            if line.starts_with("cmd") && line.contains(':') {
+                if let Some(cmd_part) = line.split(':').nth(1) {
+                    let cmd = cmd_part.trim().trim_matches('"').trim_matches('\'');
+                    if !cmd.is_empty() && !cmd.contains('{') && !cmd.contains('}') {
+                        return Ok(cmd.to_string());
+                    }
+                }
+            }
+        }
+
+        if let Some(caps) = CMD_EXTRACT_REGEX.captures(response) {
+            if let Some(cmd_match) = caps.get(1) {
+                let cmd = cmd_match.as_str().trim();
+                if !cmd.is_empty() {
+                    return Ok(cmd.to_string());
+                }
+            }
+        }
+
+        Err(GeneratorError::ParseError {
+            content: response.to_string(),
+        })
+    }
+
+    /// Submit a text job and return its request id.
+    async fn submit(&self, prompt: &str) -> Result<String, GeneratorError> {
+        let body = HordeTextRequest {
+            prompt: prompt.to_string(),
+            params: HordeParams {
+                max_length: 100,
+                temperature: 0.1,
+                n: 1,
+            },
+            models: self.models.clone(),
+        };
+
+        let url = format!("{}/v2/generate/text/async", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .header("apikey", &self.api_key)
+            .header("Client-Agent", "caro:1.4.0:github.com/wildcard/caro")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_connect() || e.is_timeout() {
+                    GeneratorError::BackendUnavailable {
+                        reason: format!("AI-Horde unavailable: {}", e),
+                    }
+                } else {
+                    GeneratorError::GenerationFailed {
+                        details: format!("HTTP request failed: {}", e),
+                    }
+                }
+            })?;
+
+        if response.status() == 401 || response.status() == 403 {
+            return Err(GeneratorError::BackendUnavailable {
+                reason: "AI-Horde rejected the API key".to_string(),
+            });
+        }
+        if !response.status().is_success() {
+            return Err(GeneratorError::GenerationFailed {
+                details: format!("AI-Horde submit error: {}", response.status()),
+            });
+        }
+
+        let submit: HordeSubmitResponse =
+            response
+                .json()
+                .await
+                .map_err(|e| GeneratorError::ParseError {
+                    content: format!("Failed to parse submit response: {}", e),
+                })?;
+
+        submit.id.ok_or_else(|| GeneratorError::GenerationFailed {
+            details: submit
+                .message
+                .unwrap_or_else(|| "AI-Horde returned no job id".to_string()),
+        })
+    }
+
+    /// Poll the status endpoint until the job is done or the budget expires.
+    async fn poll(&self, id: &str) -> Result<String, GeneratorError> {
+        let url = format!("{}/v2/generate/text/status/{}", self.base_url, id);
+        let deadline = Instant::now() + self.max_wait;
+
+        loop {
+            tokio::time::sleep(self.poll_interval).await;
+
+            let response = self.client.get(&url).send().await.map_err(|e| {
+                GeneratorError::BackendUnavailable {
+                    reason: format!("AI-Horde status poll failed: {}", e),
+                }
+            })?;
+
+            if !response.status().is_success() {
+                return Err(GeneratorError::GenerationFailed {
+                    details: format!("AI-Horde status error: {}", response.status()),
+                });
+            }
+
+            let status: HordeStatusResponse =
+                response
+                    .json()
+                    .await
+                    .map_err(|e| GeneratorError::ParseError {
+                        content: format!("Failed to parse status response: {}", e),
+                    })?;
+
+            if status.faulted {
+                return Err(GeneratorError::GenerationFailed {
+                    details: "AI-Horde job faulted".to_string(),
+                });
+            }
+
+            if status.done {
+                return status
+                    .generations
+                    .into_iter()
+                    .next()
+                    .map(|g| g.text)
+                    .ok_or_else(|| GeneratorError::ParseError {
+                        content: "AI-Horde job done but returned no generations".to_string(),
+                    });
+            }
+
+            if Instant::now() >= deadline {
+                return Err(GeneratorError::Timeout {
+                    timeout: self.max_wait,
+                });
+            }
+        }
+    }
+
+    async fn generate_with_fallback(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        let attempt = async {
+            let id = self.submit(&self.create_system_prompt(request)).await?;
+            let raw = self.poll(&id).await?;
+            self.parse_command_response(&raw)
+        }
+        .await;
+
+        let original_err = match attempt {
+            Ok(command) => {
+                return Ok(GeneratedCommand {
+                    command,
+                    explanation: "Generated using the AI-Horde volunteer cluster".to_string(),
+                    safety_level: RiskLevel::Safe, // validated downstream
+                    estimated_impact: "Crowdsourced remote inference operation".to_string(),
+                    alternatives: vec![],
+                    backend_used: "AI-Horde".to_string(),
+                    generation_time_ms: 0, // set by caller
+                    confidence_score: 0.75,
+                });
+            }
+            Err(err) => {
+                tracing::warn!("AI-Horde failed: {}", err);
+                // Don't fall back on an explicit auth rejection.
+                if let GeneratorError::BackendUnavailable { ref reason } = err {
+                    if reason.contains("rejected the API key") {
+                        return Err(err);
+                    }
+                }
+                err
+            }
+        };
+
+        if let Some(fallback) = &self.embedded_fallback {
+            tracing::info!("Falling back to embedded backend");
+            let mut fallback_result = fallback.generate_command(request).await?;
+            fallback_result.backend_used = "Embedded (AI-Horde fallback)".to_string();
+            return Ok(fallback_result);
+        }
+
+        // No fallback configured: surface the real cause (timeout, fault, etc.)
+        // rather than masking it behind a generic "unavailable" message.
+        Err(original_err)
+    }
+}
+
+#[async_trait]
+impl CommandGenerator for AiHordeBackend {
+    async fn generate_command(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        let start_time = Instant::now();
+        let mut result = self.generate_with_fallback(request).await?;
+        result.generation_time_ms = start_time.elapsed().as_millis() as u64;
+        Ok(result)
+    }
+
+    async fn is_available(&self) -> bool {
+        let url = format!("{}/v2/status/heartbeat", self.base_url);
+        match self.client.get(&url).send().await {
+            Ok(response) => response.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
+    fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            backend_type: BackendType::AiHorde,
+            model_name: if self.models.is_empty() {
+                "any".to_string()
+            } else {
+                self.models.join(",")
+            },
+            supports_streaming: false,
+            max_tokens: 100,
+            typical_latency_ms: 15000, // queue-dependent; can be much higher
+            memory_usage_mb: 0,
+            version: "2.0".to_string(),
+        }
+    }
+
+    async fn shutdown(&self) -> Result<(), GeneratorError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{SafetyLevel, ShellType};
+    use wiremock::matchers::{method, path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn req() -> CommandRequest {
+        CommandRequest {
+            input: "list text files".to_string(),
+            shell: ShellType::Bash,
+            safety_level: SafetyLevel::Moderate,
+            context: None,
+            backend_preference: None,
+        }
+    }
+
+    #[test]
+    fn test_creation_trims_trailing_slash() {
+        let b = AiHordeBackend::new("https://aihorde.net/api/", AI_HORDE_ANON_KEY).unwrap();
+        assert_eq!(b.base_url(), "https://aihorde.net/api");
+    }
+
+    #[test]
+    fn test_defaults_use_anon_key() {
+        let b = AiHordeBackend::with_defaults().unwrap();
+        assert_eq!(b.api_key, AI_HORDE_ANON_KEY);
+        assert_eq!(b.base_url(), AI_HORDE_DEFAULT_URL);
+    }
+
+    #[test]
+    fn test_parse_valid_json() {
+        let b = AiHordeBackend::with_defaults().unwrap();
+        assert_eq!(
+            b.parse_command_response(r#"{"cmd": "ls *.txt"}"#).unwrap(),
+            "ls *.txt"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_submit_then_poll_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v2/generate/text/async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "id": "job-123"
+            })))
+            .mount(&server)
+            .await;
+
+        // First poll: not done. Second poll: done with a generation.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/v2/generate/text/status/job-123$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": true,
+                "faulted": false,
+                "generations": [ { "text": "{\"cmd\": \"ls *.txt\"}" } ]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = AiHordeBackend::new(server.uri(), AI_HORDE_ANON_KEY)
+            .unwrap()
+            .with_poll_interval(Duration::from_millis(5))
+            .with_max_wait(Duration::from_secs(2));
+
+        let result = backend.generate_command(&req()).await.unwrap();
+        assert_eq!(result.command, "ls *.txt");
+        assert_eq!(result.backend_used, "AI-Horde");
+    }
+
+    #[tokio::test]
+    async fn test_faulted_job_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v2/generate/text/async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({ "id": "j" })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/v2/generate/text/status/.+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": false, "faulted": true, "generations": []
+            })))
+            .mount(&server)
+            .await;
+
+        // No fallback -> the faulted job must surface as an error.
+        let backend = AiHordeBackend::new(server.uri(), AI_HORDE_ANON_KEY)
+            .unwrap()
+            .with_poll_interval(Duration::from_millis(5));
+        assert!(backend.generate_command(&req()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_poll_timeout() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v2/generate/text/async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({ "id": "j" })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/v2/generate/text/status/.+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": false, "faulted": false, "generations": []
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = AiHordeBackend::new(server.uri(), AI_HORDE_ANON_KEY)
+            .unwrap()
+            .with_poll_interval(Duration::from_millis(5))
+            .with_max_wait(Duration::from_millis(20));
+        let err = backend.generate_command(&req()).await.unwrap_err();
+        assert!(matches!(err, GeneratorError::Timeout { .. }));
+    }
+}

--- a/src/backends/remote/mesh.rs
+++ b/src/backends/remote/mesh.rs
@@ -1,0 +1,413 @@
+// Mesh-LLM distributed mesh backend implementation
+//
+// Mesh-LLM (https://github.com/Mesh-LLM/mesh-llm) is a peer-to-peer mesh that
+// pools GPU and memory across multiple machines behind a single
+// OpenAI-compatible API at http://localhost:9337/v1. Requests are routed to a
+// node that can serve the requested model; large models can be split across
+// peers ("skippy stage splits").
+//
+// Because the API is OpenAI-compatible, this backend mirrors the vLLM/Exo
+// backends. The distinguishing feature is the `"model": "mesh"` request, which
+// fans the query across every model in the mesh (a Mixture-of-Agents mode).
+// For single-shot command generation we default to `"mesh"` so the mesh
+// auto-routes to whatever model is loaded; users can pin a specific model via
+// `[backends].mesh_url` + `--model-name`.
+
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use reqwest::{header, Client, Url};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError};
+use crate::models::{CommandRequest, GeneratedCommand, RiskLevel};
+
+/// Regex pattern to extract command from malformed JSON with unescaped quotes
+/// Handles cases like: {"cmd": "find . -type f -name "*.txt""}
+static CMD_EXTRACT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"\{\s*"cmd"\s*:\s*"(.+)"\s*\}"#).expect("Invalid regex pattern"));
+
+/// Default port for the Mesh-LLM local node API
+pub const MESH_DEFAULT_PORT: u16 = 9337;
+
+/// Default model: `"mesh"` triggers the mesh's auto-routing / MoA fan-out
+pub const MESH_DEFAULT_MODEL: &str = "mesh";
+
+/// Mesh-LLM API request format (OpenAI-compatible)
+#[derive(Debug, Serialize)]
+struct MeshRequest {
+    model: String,
+    messages: Vec<MeshMessage>,
+    temperature: f32,
+    max_tokens: u32,
+    stream: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct MeshMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MeshResponse {
+    choices: Vec<MeshChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MeshChoice {
+    message: MeshResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct MeshResponseMessage {
+    content: String,
+}
+
+/// Mesh-LLM mesh backend for pooled distributed inference
+pub struct MeshBackend {
+    base_url: Url,
+    model_name: String,
+    client: Client,
+    api_key: Option<String>,
+    embedded_fallback: Option<Arc<dyn CommandGenerator>>,
+}
+
+impl MeshBackend {
+    /// Create a new Mesh-LLM backend pointed at `base_url`.
+    pub fn new(base_url: Url, model_name: String) -> Result<Self, GeneratorError> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60)) // mesh routing + split stages add latency
+            .build()
+            .map_err(|e| GeneratorError::ConfigError {
+                message: format!("Failed to create HTTP client: {}", e),
+            })?;
+
+        Ok(Self {
+            base_url,
+            model_name,
+            client,
+            api_key: None,
+            embedded_fallback: None,
+        })
+    }
+
+    /// Create a Mesh-LLM backend with the default local node URL and model.
+    pub fn with_defaults() -> Result<Self, GeneratorError> {
+        let url = Url::parse(&format!("http://localhost:{}", MESH_DEFAULT_PORT)).map_err(|e| {
+            GeneratorError::ConfigError {
+                message: format!("Failed to parse default URL: {}", e),
+            }
+        })?;
+        Self::new(url, MESH_DEFAULT_MODEL.to_string())
+    }
+
+    /// Set the owner-control API key for a private mesh (if required).
+    pub fn with_api_key(mut self, api_key: String) -> Self {
+        self.api_key = Some(api_key);
+        self
+    }
+
+    /// Add an embedded fallback backend used when the mesh is unreachable.
+    pub fn with_embedded_fallback(mut self, fallback: Arc<dyn CommandGenerator>) -> Self {
+        self.embedded_fallback = Some(fallback);
+        self
+    }
+
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    /// Build the command-generation system prompt (shared `{"cmd": ...}` contract).
+    fn create_system_prompt(&self, request: &CommandRequest) -> String {
+        format!(
+            r#"You are a helpful assistant that converts natural language to safe POSIX shell commands.
+
+CRITICAL: You MUST respond with ONLY valid JSON in this exact format:
+{{"cmd": "your_shell_command_here"}}
+
+Rules:
+1. Generate ONLY the shell command, no explanation
+2. Use POSIX-compliant utilities (ls, find, grep, awk, sed, sort, etc.)
+3. Quote file paths with spaces using double quotes
+4. Target shell: {}
+5. NEVER generate destructive commands (rm -rf /, mkfs, dd, etc.)
+6. Keep commands simple and safe
+7. If the request is unclear, generate "echo 'Please clarify your request'"
+
+Request: {}
+"#,
+            request.shell, request.input
+        )
+    }
+
+    /// Parse the model response into a bare command string (4-tier strategy).
+    fn parse_command_response(&self, response: &str) -> Result<String, GeneratorError> {
+        // 1. Structured JSON
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(response) {
+            if let Some(cmd) = parsed.get("cmd").and_then(|v| v.as_str()) {
+                if !cmd.is_empty() {
+                    return Ok(cmd.trim().to_string());
+                }
+            }
+        }
+
+        // 2. Embedded JSON substring
+        if let (Some(start), Some(end)) = (response.find('{'), response.rfind('}')) {
+            if start <= end {
+                let json_part = &response[start..=end];
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_part) {
+                    if let Some(cmd) = parsed.get("cmd").and_then(|v| v.as_str()) {
+                        if !cmd.is_empty() {
+                            return Ok(cmd.trim().to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Line-scan for `cmd:` prefix
+        for line in response.lines() {
+            let line = line.trim();
+            if line.starts_with("cmd") && line.contains(':') {
+                if let Some(cmd_part) = line.split(':').nth(1) {
+                    let cmd = cmd_part.trim().trim_matches('"').trim_matches('\'');
+                    if !cmd.is_empty() && !cmd.contains('{') && !cmd.contains('}') {
+                        return Ok(cmd.to_string());
+                    }
+                }
+            }
+        }
+
+        // 4. Regex fallback for malformed JSON with unescaped quotes
+        if let Some(caps) = CMD_EXTRACT_REGEX.captures(response) {
+            if let Some(cmd_match) = caps.get(1) {
+                let cmd = cmd_match.as_str().trim();
+                if !cmd.is_empty() {
+                    return Ok(cmd.to_string());
+                }
+            }
+        }
+
+        Err(GeneratorError::ParseError {
+            content: response.to_string(),
+        })
+    }
+
+    /// Call the mesh's OpenAI-compatible chat-completions endpoint.
+    async fn call_mesh_api(&self, prompt: &str) -> Result<String, GeneratorError> {
+        let request = MeshRequest {
+            model: self.model_name.clone(),
+            messages: vec![MeshMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+            }],
+            temperature: 0.1,
+            max_tokens: 100,
+            stream: false,
+        };
+
+        let url = self.base_url.join("/v1/chat/completions").map_err(|e| {
+            GeneratorError::ConfigError {
+                message: format!("Invalid base URL: {}", e),
+            }
+        })?;
+
+        let mut req_builder = self.client.post(url).json(&request);
+        if let Some(api_key) = &self.api_key {
+            req_builder = req_builder.header(header::AUTHORIZATION, format!("Bearer {}", api_key));
+        }
+
+        let response = req_builder.send().await.map_err(|e| {
+            if e.is_connect() || e.is_timeout() {
+                GeneratorError::BackendUnavailable {
+                    reason: format!("Mesh-LLM node unavailable: {}", e),
+                }
+            } else {
+                GeneratorError::GenerationFailed {
+                    details: format!("HTTP request failed: {}", e),
+                }
+            }
+        })?;
+
+        if response.status() == 401 || response.status() == 403 {
+            return Err(GeneratorError::BackendUnavailable {
+                reason: "Authentication failed - invalid mesh API key".to_string(),
+            });
+        }
+
+        if !response.status().is_success() {
+            return Err(GeneratorError::GenerationFailed {
+                details: format!("Mesh-LLM API error: {}", response.status()),
+            });
+        }
+
+        let mesh_response: MeshResponse =
+            response
+                .json()
+                .await
+                .map_err(|e| GeneratorError::ParseError {
+                    content: format!("Failed to parse Mesh-LLM response: {}", e),
+                })?;
+
+        if let Some(choice) = mesh_response.choices.first() {
+            Ok(choice.message.content.clone())
+        } else {
+            Err(GeneratorError::ParseError {
+                content: "Mesh-LLM response contained no choices".to_string(),
+            })
+        }
+    }
+
+    /// Attempt mesh inference, falling back to the embedded backend on failure.
+    async fn generate_with_fallback(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        match self.call_mesh_api(&self.create_system_prompt(request)).await {
+            Ok(response) => match self.parse_command_response(&response) {
+                Ok(command) => {
+                    return Ok(GeneratedCommand {
+                        command,
+                        explanation: "Generated using Mesh-LLM distributed mesh".to_string(),
+                        safety_level: RiskLevel::Safe, // validated downstream
+                        estimated_impact: "Pooled distributed inference operation".to_string(),
+                        alternatives: vec![],
+                        backend_used: format!("Mesh-LLM ({})", self.model_name),
+                        generation_time_ms: 0, // set by caller
+                        confidence_score: 0.85,
+                    });
+                }
+                Err(parse_error) => {
+                    tracing::warn!("Failed to parse Mesh-LLM response: {}", parse_error);
+                }
+            },
+            Err(mesh_error) => {
+                tracing::warn!("Mesh-LLM failed: {}", mesh_error);
+                if let GeneratorError::BackendUnavailable { ref reason } = mesh_error {
+                    if reason.contains("Authentication failed") {
+                        return Err(mesh_error);
+                    }
+                }
+            }
+        }
+
+        if let Some(fallback) = &self.embedded_fallback {
+            tracing::info!("Falling back to embedded backend");
+            let mut fallback_result = fallback.generate_command(request).await?;
+            fallback_result.backend_used =
+                format!("Embedded (Mesh-LLM fallback from {})", self.model_name);
+            return Ok(fallback_result);
+        }
+
+        Err(GeneratorError::BackendUnavailable {
+            reason: "Mesh-LLM node unavailable and no fallback configured".to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl CommandGenerator for MeshBackend {
+    async fn generate_command(
+        &self,
+        request: &CommandRequest,
+    ) -> Result<GeneratedCommand, GeneratorError> {
+        let start_time = std::time::Instant::now();
+        let mut result = self.generate_with_fallback(request).await?;
+        result.generation_time_ms = start_time.elapsed().as_millis() as u64;
+        Ok(result)
+    }
+
+    async fn is_available(&self) -> bool {
+        // OpenAI-standard model listing endpoint doubles as a health probe.
+        let health_url = match self.base_url.join("/v1/models") {
+            Ok(url) => url,
+            Err(_) => return false,
+        };
+        match self.client.get(health_url).send().await {
+            Ok(response) => response.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
+    fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            backend_type: BackendType::Mesh,
+            model_name: self.model_name.clone(),
+            supports_streaming: true,
+            max_tokens: 100,
+            typical_latency_ms: 2500, // routing + possible stage splits
+            memory_usage_mb: 0,       // external mesh
+            version: "1.0".to_string(),
+        }
+    }
+
+    async fn shutdown(&self) -> Result<(), GeneratorError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mesh_backend_creation() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        assert!(MeshBackend::new(url, "mesh".to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_mesh_with_defaults() {
+        let backend = MeshBackend::with_defaults().unwrap();
+        assert_eq!(backend.model_name(), MESH_DEFAULT_MODEL);
+        assert!(backend.base_url().as_str().contains("9337"));
+    }
+
+    #[test]
+    fn test_mesh_with_api_key() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        let backend = MeshBackend::new(url, "mesh".to_string())
+            .unwrap()
+            .with_api_key("owner-token".to_string());
+        assert!(backend.api_key.is_some());
+    }
+
+    #[test]
+    fn test_parse_valid_json() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        let backend = MeshBackend::new(url, "mesh".to_string()).unwrap();
+        let response = r#"{"cmd": "grep -r 'pattern' ."}"#;
+        assert_eq!(backend.parse_command_response(response).unwrap(), "grep -r 'pattern' .");
+    }
+
+    #[test]
+    fn test_parse_embedded_json() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        let backend = MeshBackend::new(url, "mesh".to_string()).unwrap();
+        let response = r#"Here you go: {"cmd": "sort file.txt"} done."#;
+        assert_eq!(backend.parse_command_response(response).unwrap(), "sort file.txt");
+    }
+
+    #[test]
+    fn test_parse_invalid_response() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        let backend = MeshBackend::new(url, "mesh".to_string()).unwrap();
+        assert!(backend.parse_command_response("no command here").is_err());
+    }
+
+    #[test]
+    fn test_backend_info() {
+        let url = Url::parse("http://localhost:9337").unwrap();
+        let backend = MeshBackend::new(url, "mesh".to_string()).unwrap();
+        let info = backend.backend_info();
+        assert_eq!(info.backend_type, BackendType::Mesh);
+        assert_eq!(info.model_name, "mesh");
+    }
+}

--- a/src/backends/remote/mod.rs
+++ b/src/backends/remote/mod.rs
@@ -1,11 +1,15 @@
 // Remote backend implementations for external model providers
 
+pub mod ai_horde;
 pub mod claude;
 pub mod exo;
+pub mod mesh;
 pub mod ollama;
 pub mod vllm;
 
+pub use ai_horde::AiHordeBackend;
 pub use claude::ClaudeBackend;
 pub use exo::ExoBackend;
+pub use mesh::MeshBackend;
 pub use ollama::OllamaBackend;
 pub use vllm::VllmBackend;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,6 +413,70 @@ impl CliApp {
                         return Ok(Box::new(horde));
                     }
                     #[cfg(feature = "remote-backends")]
+                    "hybrid" => {
+                        use crate::backends::hybrid::{ContextSanitizer, HybridBackend};
+                        use crate::backends::remote::{AiHordeBackend, MeshBackend};
+                        use reqwest::Url;
+
+                        // Pick the remote enhancer (default: mesh).
+                        let remote_kind =
+                            backends_cfg.hybrid_remote.as_deref().unwrap_or("mesh");
+                        let remote: Arc<dyn CommandGenerator> = match remote_kind {
+                            "ai-horde" | "aihorde" | "horde" => Arc::new(
+                                AiHordeBackend::new(ai_horde_url_str, ai_horde_key_str).map_err(
+                                    |e| CliError::ConfigurationError {
+                                        message: format!(
+                                            "Failed to create AI-Horde remote for hybrid: {}",
+                                            e
+                                        ),
+                                    },
+                                )?,
+                            ),
+                            _ => {
+                                let mesh_model = user_config
+                                    .model_name
+                                    .clone()
+                                    .unwrap_or_else(|| "mesh".to_string());
+                                let mesh_url = Url::parse(mesh_url_str).map_err(|e| {
+                                    CliError::ConfigurationError {
+                                        message: format!("Invalid mesh URL for hybrid: {}", e),
+                                    }
+                                })?;
+                                Arc::new(MeshBackend::new(mesh_url, mesh_model).map_err(|e| {
+                                    CliError::ConfigurationError {
+                                        message: format!(
+                                            "Failed to create Mesh remote for hybrid: {}",
+                                            e
+                                        ),
+                                    }
+                                })?)
+                            }
+                        };
+
+                        // Seed the sanitizer with the current identity so the
+                        // username/hostname are redacted alongside paths/IPs.
+                        let user = std::env::var("USER")
+                            .or_else(|_| std::env::var("LOGNAME"))
+                            .ok();
+                        let host = std::env::var("HOSTNAME").ok();
+                        let sanitizer = ContextSanitizer::new()
+                            .with_identity(user.as_deref(), host.as_deref());
+
+                        let local: Arc<dyn CommandGenerator> = embedded_arc.clone();
+                        let hybrid = HybridBackend::new(
+                            local,
+                            remote,
+                            sanitizer,
+                            backends_cfg.allow_public,
+                        );
+                        tracing::info!(
+                            "Using Hybrid backend (local sanitizer + {} enhancer, sanitize={})",
+                            remote_kind,
+                            !backends_cfg.allow_public
+                        );
+                        return Ok(Box::new(hybrid));
+                    }
+                    #[cfg(feature = "remote-backends")]
                     "ollama" => {
                         use crate::backends::remote::OllamaBackend;
                         use reqwest::Url;
@@ -481,7 +545,7 @@ impl CliApp {
                         }
                     }
                     #[cfg(not(feature = "remote-backends"))]
-                    "mesh" | "ollama" | "exo" | "vllm" | "ai-horde" => {
+                    "mesh" | "ollama" | "exo" | "vllm" | "ai-horde" | "hybrid" => {
                         return Err(Self::remote_backend_unavailable_error(model));
                     }
                     _ => {
@@ -569,7 +633,7 @@ impl CliApp {
     /// Returns Ok(()) if valid, or a helpful error message if not.
     fn validate_backend_name(backend: &str) -> Result<(), CliError> {
         const VALID_BACKENDS: &[&str] =
-            &["embedded", "ollama", "exo", "vllm", "mesh", "ai-horde"];
+            &["embedded", "ollama", "exo", "vllm", "mesh", "ai-horde", "hybrid"];
 
         let normalized = backend.to_lowercase();
         if VALID_BACKENDS.contains(&normalized.as_str()) {
@@ -591,7 +655,8 @@ impl CliApp {
                  - exo: Exo distributed cluster (requires: exo cluster)\n  \
                  - vllm: vLLM HTTP API (requires: vllm server)\n  \
                  - mesh: Mesh-LLM pooled mesh (requires: mesh node on :9337)\n  \
-                 - ai-horde: AI-Horde volunteer cluster (free, no setup; public)\n\n\
+                 - ai-horde: AI-Horde volunteer cluster (free, no setup; public)\n  \
+                 - hybrid: Local sanitizer + remote enhancer (PII-safe)\n\n\
                  Set via: --backend <name>, CARO_BACKEND env var, or config file",
                 backend, suggestion
             ),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -316,6 +316,41 @@ impl CliApp {
 
             let embedded_arc: Arc<EmbeddedModelBackend> = Arc::new(embedded_backend);
 
+            // Resolve remote endpoint URLs from the `[backends]` config section,
+            // falling back to the built-in localhost defaults when unset.
+            #[cfg(feature = "remote-backends")]
+            let backends_cfg = &user_config.backends;
+            #[cfg(feature = "remote-backends")]
+            let mesh_url_str = backends_cfg
+                .mesh_url
+                .as_deref()
+                .unwrap_or("http://localhost:9337");
+            #[cfg(feature = "remote-backends")]
+            let ollama_url_str = backends_cfg
+                .ollama_url
+                .as_deref()
+                .unwrap_or("http://localhost:11434");
+            #[cfg(feature = "remote-backends")]
+            let exo_url_str = backends_cfg
+                .exo_url
+                .as_deref()
+                .unwrap_or("http://localhost:52415");
+            #[cfg(feature = "remote-backends")]
+            let vllm_url_str = backends_cfg
+                .vllm_url
+                .as_deref()
+                .unwrap_or("http://localhost:8000");
+            #[cfg(feature = "remote-backends")]
+            let ai_horde_url_str = backends_cfg
+                .ai_horde_url
+                .as_deref()
+                .unwrap_or(crate::backends::remote::ai_horde::AI_HORDE_DEFAULT_URL);
+            #[cfg(feature = "remote-backends")]
+            let ai_horde_key_str = backends_cfg
+                .ai_horde_key
+                .as_deref()
+                .unwrap_or(crate::backends::remote::ai_horde::AI_HORDE_ANON_KEY);
+
             // Check for user-specified model preference
             let model_preference = user_config.default_model.as_deref();
 
@@ -332,11 +367,57 @@ impl CliApp {
                         };
                     }
                     #[cfg(feature = "remote-backends")]
+                    "mesh" => {
+                        use crate::backends::remote::MeshBackend;
+                        use reqwest::Url;
+
+                        let mesh_model = user_config
+                            .model_name
+                            .clone()
+                            .unwrap_or_else(|| "mesh".to_string());
+                        if let Ok(mesh_url) = Url::parse(mesh_url_str) {
+                            let mesh_backend = MeshBackend::new(mesh_url, mesh_model)
+                                .map_err(|e| CliError::ConfigurationError {
+                                    message: format!("Failed to create Mesh-LLM backend: {}", e),
+                                })?
+                                .with_embedded_fallback(embedded_arc.clone());
+                            if mesh_backend.is_available().await {
+                                tracing::info!("Using Mesh-LLM backend (user preference)");
+                                return Ok(Box::new(mesh_backend));
+                            } else {
+                                tracing::warn!(
+                                    "Mesh-LLM backend not available, falling back to embedded"
+                                );
+                            }
+                        }
+                    }
+                    #[cfg(feature = "remote-backends")]
+                    "ai-horde" | "aihorde" | "horde" => {
+                        use crate::backends::remote::AiHordeBackend;
+
+                        let horde = AiHordeBackend::new(ai_horde_url_str, ai_horde_key_str)
+                            .map_err(|e| CliError::ConfigurationError {
+                                message: format!("Failed to create AI-Horde backend: {}", e),
+                            })?
+                            .with_embedded_fallback(embedded_arc.clone());
+                        // AI-Horde is a public volunteer cluster: never silently
+                        // probe-and-skip. Honor the explicit request and rely on
+                        // the embedded fallback if the Horde is unreachable.
+                        if horde.is_available().await {
+                            tracing::info!("Using AI-Horde backend (user preference)");
+                        } else {
+                            tracing::warn!(
+                                "AI-Horde heartbeat failed; will attempt anyway with embedded fallback"
+                            );
+                        }
+                        return Ok(Box::new(horde));
+                    }
+                    #[cfg(feature = "remote-backends")]
                     "ollama" => {
                         use crate::backends::remote::OllamaBackend;
                         use reqwest::Url;
 
-                        if let Ok(ollama_url) = Url::parse("http://localhost:11434") {
+                        if let Ok(ollama_url) = Url::parse(ollama_url_str) {
                             let ollama_backend =
                                 OllamaBackend::new(ollama_url, "codellama:7b".to_string())
                                     .map_err(|e| CliError::ConfigurationError {
@@ -359,7 +440,7 @@ impl CliApp {
                         use crate::backends::remote::ExoBackend;
                         use reqwest::Url;
 
-                        if let Ok(exo_url) = Url::parse("http://localhost:52415") {
+                        if let Ok(exo_url) = Url::parse(exo_url_str) {
                             let exo_backend = ExoBackend::new(exo_url, "llama-3.2-3b".to_string())
                                 .map_err(|e| CliError::ConfigurationError {
                                     message: format!("Failed to create Exo backend: {}", e),
@@ -381,7 +462,7 @@ impl CliApp {
                         use crate::backends::remote::VllmBackend;
                         use reqwest::Url;
 
-                        if let Ok(vllm_url) = Url::parse("http://localhost:8000") {
+                        if let Ok(vllm_url) = Url::parse(vllm_url_str) {
                             let vllm_backend =
                                 VllmBackend::new(vllm_url, "codellama/CodeLlama-7b-hf".to_string())
                                     .map_err(|e| CliError::ConfigurationError {
@@ -400,7 +481,7 @@ impl CliApp {
                         }
                     }
                     #[cfg(not(feature = "remote-backends"))]
-                    "ollama" | "exo" | "vllm" => {
+                    "mesh" | "ollama" | "exo" | "vllm" | "ai-horde" => {
                         return Err(Self::remote_backend_unavailable_error(model));
                     }
                     _ => {
@@ -412,11 +493,28 @@ impl CliApp {
             // Auto-detect: try remote backends with embedded fallback
             #[cfg(feature = "remote-backends")]
             {
-                use crate::backends::remote::{ExoBackend, OllamaBackend, VllmBackend};
+                use crate::backends::remote::{ExoBackend, MeshBackend, OllamaBackend, VllmBackend};
                 use reqwest::Url;
 
-                // Priority: Exo cluster > Ollama > vLLM > Embedded
-                if let Ok(exo_url) = Url::parse("http://localhost:52415") {
+                // Priority: Mesh-LLM > Exo cluster > Ollama > vLLM > Embedded
+                if let Ok(mesh_url) = Url::parse(mesh_url_str) {
+                    let mesh_model = user_config
+                        .model_name
+                        .clone()
+                        .unwrap_or_else(|| "mesh".to_string());
+                    let mesh_backend = MeshBackend::new(mesh_url, mesh_model)
+                        .map_err(|e| CliError::ConfigurationError {
+                            message: format!("Failed to create Mesh-LLM backend: {}", e),
+                        })?
+                        .with_embedded_fallback(embedded_arc.clone());
+
+                    if mesh_backend.is_available().await {
+                        tracing::info!("Using Mesh-LLM backend (auto-detected)");
+                        return Ok(Box::new(mesh_backend));
+                    }
+                }
+
+                if let Ok(exo_url) = Url::parse(exo_url_str) {
                     let exo_backend = ExoBackend::new(exo_url, "llama-3.2-3b".to_string())
                         .map_err(|e| CliError::ConfigurationError {
                             message: format!("Failed to create Exo backend: {}", e),
@@ -429,7 +527,7 @@ impl CliApp {
                     }
                 }
 
-                if let Ok(ollama_url) = Url::parse("http://localhost:11434") {
+                if let Ok(ollama_url) = Url::parse(ollama_url_str) {
                     let ollama_backend = OllamaBackend::new(ollama_url, "codellama:7b".to_string())
                         .map_err(|e| CliError::ConfigurationError {
                             message: format!("Failed to create Ollama backend: {}", e),
@@ -442,7 +540,7 @@ impl CliApp {
                     }
                 }
 
-                if let Ok(vllm_url) = Url::parse("http://localhost:8000") {
+                if let Ok(vllm_url) = Url::parse(vllm_url_str) {
                     let vllm_backend =
                         VllmBackend::new(vllm_url, "codellama/CodeLlama-7b-hf".to_string())
                             .map_err(|e| CliError::ConfigurationError {
@@ -470,7 +568,8 @@ impl CliApp {
     ///
     /// Returns Ok(()) if valid, or a helpful error message if not.
     fn validate_backend_name(backend: &str) -> Result<(), CliError> {
-        const VALID_BACKENDS: &[&str] = &["embedded", "ollama", "exo", "vllm"];
+        const VALID_BACKENDS: &[&str] =
+            &["embedded", "ollama", "exo", "vllm", "mesh", "ai-horde"];
 
         let normalized = backend.to_lowercase();
         if VALID_BACKENDS.contains(&normalized.as_str()) {
@@ -490,7 +589,9 @@ impl CliApp {
                  - embedded: Local Qwen model (default, no setup required)\n  \
                  - ollama: Ollama server (requires: ollama serve)\n  \
                  - exo: Exo distributed cluster (requires: exo cluster)\n  \
-                 - vllm: vLLM HTTP API (requires: vllm server)\n\n\
+                 - vllm: vLLM HTTP API (requires: vllm server)\n  \
+                 - mesh: Mesh-LLM pooled mesh (requires: mesh node on :9337)\n  \
+                 - ai-horde: AI-Horde volunteer cluster (free, no setup; public)\n\n\
                  Set via: --backend <name>, CARO_BACKEND env var, or config file",
                 backend, suggestion
             ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1100,6 +1100,8 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
         caro::models::BackendType::Mlx => "mlx".to_string(),
         caro::models::BackendType::Mock => "mock".to_string(),
         caro::models::BackendType::OpenRouter => "openrouter".to_string(),
+        caro::models::BackendType::Mesh => "mesh".to_string(),
+        caro::models::BackendType::AiHorde => "ai-horde".to_string(),
     };
 
     let exec_ctx = ExecutionContext::detect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1102,6 +1102,9 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
         caro::models::BackendType::OpenRouter => "openrouter".to_string(),
         caro::models::BackendType::Mesh => "mesh".to_string(),
         caro::models::BackendType::AiHorde => "ai-horde".to_string(),
+        // The hybrid gateway sanitizes PII before remote transmission by
+        // default, so it is intentionally NOT treated as an off-host leak here.
+        caro::models::BackendType::Hybrid => "hybrid".to_string(),
     };
 
     let exec_ctx = ExecutionContext::detect();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -301,6 +301,8 @@ pub enum BackendType {
     Mesh,
     /// AI-Horde crowdsourced volunteer cluster (async job queue)
     AiHorde,
+    /// Hybrid privacy gateway (local sanitizer + remote enhancer)
+    Hybrid,
 }
 
 impl std::str::FromStr for BackendType {
@@ -318,6 +320,7 @@ impl std::str::FromStr for BackendType {
             "openrouter" => Ok(Self::OpenRouter),
             "mesh" | "mesh-llm" => Ok(Self::Mesh),
             "ai-horde" | "aihorde" | "horde" => Ok(Self::AiHorde),
+            "hybrid" => Ok(Self::Hybrid),
             _ => Err(format!("Unknown backend type: {}", s)),
         }
     }
@@ -336,6 +339,7 @@ impl std::fmt::Display for BackendType {
             Self::OpenRouter => write!(f, "openrouter"),
             Self::Mesh => write!(f, "mesh"),
             Self::AiHorde => write!(f, "ai-horde"),
+            Self::Hybrid => write!(f, "hybrid"),
         }
     }
 }
@@ -807,6 +811,10 @@ pub struct BackendsConfig {
     /// AI-Horde API key (default anonymous `"0000000000"`).
     #[serde(default)]
     pub ai_horde_key: Option<String>,
+    /// Which remote enhancer the `hybrid` backend wraps: `"mesh"` (default) or
+    /// `"ai-horde"`.
+    #[serde(default)]
+    pub hybrid_remote: Option<String>,
     /// Allow sending prompts to public/untrusted inference networks. When
     /// `false` (default), the hybrid gateway sanitizes all PII before any
     /// prompt leaves the machine. When `true`, that guarantee is relaxed to a
@@ -1052,6 +1060,7 @@ impl ConfigSchema {
         known_keys.insert("backends.exo_url".to_string(), "String".to_string());
         known_keys.insert("backends.ai_horde_url".to_string(), "String".to_string());
         known_keys.insert("backends.ai_horde_key".to_string(), "String".to_string());
+        known_keys.insert("backends.hybrid_remote".to_string(), "String".to_string());
         known_keys.insert("backends.allow_public".to_string(), "bool".to_string());
 
         Self {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -297,6 +297,10 @@ pub enum BackendType {
     Claude,
     /// OpenRouter unified API backend (100+ cloud LLMs)
     OpenRouter,
+    /// Mesh-LLM P2P mesh backend (OpenAI-compatible, pooled local GPUs)
+    Mesh,
+    /// AI-Horde crowdsourced volunteer cluster (async job queue)
+    AiHorde,
 }
 
 impl std::str::FromStr for BackendType {
@@ -312,6 +316,8 @@ impl std::str::FromStr for BackendType {
             "exo" => Ok(Self::Exo),
             "claude" | "anthropic" => Ok(Self::Claude),
             "openrouter" => Ok(Self::OpenRouter),
+            "mesh" | "mesh-llm" => Ok(Self::Mesh),
+            "ai-horde" | "aihorde" | "horde" => Ok(Self::AiHorde),
             _ => Err(format!("Unknown backend type: {}", s)),
         }
     }
@@ -328,6 +334,8 @@ impl std::fmt::Display for BackendType {
             Self::Exo => write!(f, "exo"),
             Self::Claude => write!(f, "claude"),
             Self::OpenRouter => write!(f, "openrouter"),
+            Self::Mesh => write!(f, "mesh"),
+            Self::AiHorde => write!(f, "ai-horde"),
         }
     }
 }
@@ -774,6 +782,39 @@ fn default_log_rotation_days() -> u32 {
     7
 }
 
+/// Remote backend connection settings, parsed from the `[backends]` TOML
+/// section. Every field is optional; when unset, the built-in defaults
+/// baked into the backend factory are used. This lets users point caro at a
+/// Mesh-LLM node, a self-hosted AI-Horde, or non-default Ollama/vLLM/Exo
+/// endpoints without recompiling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct BackendsConfig {
+    /// Mesh-LLM OpenAI-compatible endpoint (default `http://localhost:9337`).
+    #[serde(default)]
+    pub mesh_url: Option<String>,
+    /// Ollama endpoint (default `http://localhost:11434`).
+    #[serde(default)]
+    pub ollama_url: Option<String>,
+    /// vLLM endpoint (default `http://localhost:8000`).
+    #[serde(default)]
+    pub vllm_url: Option<String>,
+    /// Exo cluster endpoint (default `http://localhost:52415`).
+    #[serde(default)]
+    pub exo_url: Option<String>,
+    /// AI-Horde base API URL (default `https://aihorde.net/api`).
+    #[serde(default)]
+    pub ai_horde_url: Option<String>,
+    /// AI-Horde API key (default anonymous `"0000000000"`).
+    #[serde(default)]
+    pub ai_horde_key: Option<String>,
+    /// Allow sending prompts to public/untrusted inference networks. When
+    /// `false` (default), the hybrid gateway sanitizes all PII before any
+    /// prompt leaves the machine. When `true`, that guarantee is relaxed to a
+    /// standard remote-privacy warning (the path Claude/OpenRouter use).
+    #[serde(default)]
+    pub allow_public: bool,
+}
+
 /// User configuration with preferences
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct UserConfiguration {
@@ -806,6 +847,10 @@ pub struct UserConfiguration {
     /// of the built-in pattern database.
     #[serde(default)]
     pub safety: crate::safety::SafetySection,
+    /// Remote backend endpoints and keys, parsed from the `[backends]`
+    /// TOML section. Defaults to all-unset (factory defaults apply).
+    #[serde(default)]
+    pub backends: BackendsConfig,
 }
 
 impl Default for UserConfiguration {
@@ -822,6 +867,7 @@ impl Default for UserConfiguration {
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
             ai: AiConfig::default(),
             safety: crate::safety::SafetySection::default(),
+            backends: BackendsConfig::default(),
         }
     }
 }
@@ -864,6 +910,7 @@ pub struct UserConfigurationBuilder {
     generation_profile: crate::prompts::profiles::GenerationProfile,
     ai: AiConfig,
     safety: crate::safety::SafetySection,
+    backends: BackendsConfig,
 }
 
 impl Default for UserConfigurationBuilder {
@@ -887,6 +934,7 @@ impl UserConfigurationBuilder {
             generation_profile: defaults.generation_profile,
             ai: defaults.ai,
             safety: defaults.safety,
+            backends: defaults.backends,
         }
     }
 
@@ -943,6 +991,11 @@ impl UserConfigurationBuilder {
         self
     }
 
+    pub fn backends(mut self, backends: BackendsConfig) -> Self {
+        self.backends = backends;
+        self
+    }
+
     pub fn build(self) -> Result<UserConfiguration, String> {
         let config = UserConfiguration {
             default_shell: self.default_shell,
@@ -956,6 +1009,7 @@ impl UserConfigurationBuilder {
             generation_profile: self.generation_profile,
             ai: self.ai,
             safety: self.safety,
+            backends: self.backends,
         };
         config.validate()?;
         Ok(config)
@@ -992,6 +1046,13 @@ impl ConfigSchema {
         known_keys.insert("telemetry.air_gapped".to_string(), "bool".to_string());
         known_keys.insert("telemetry.endpoint".to_string(), "String".to_string());
         known_keys.insert("telemetry.first_run".to_string(), "bool".to_string());
+        known_keys.insert("backends.mesh_url".to_string(), "String".to_string());
+        known_keys.insert("backends.ollama_url".to_string(), "String".to_string());
+        known_keys.insert("backends.vllm_url".to_string(), "String".to_string());
+        known_keys.insert("backends.exo_url".to_string(), "String".to_string());
+        known_keys.insert("backends.ai_horde_url".to_string(), "String".to_string());
+        known_keys.insert("backends.ai_horde_key".to_string(), "String".to_string());
+        known_keys.insert("backends.allow_public".to_string(), "bool".to_string());
 
         Self {
             known_sections: vec![
@@ -999,6 +1060,7 @@ impl ConfigSchema {
                 "logging".to_string(),
                 "cache".to_string(),
                 "telemetry".to_string(),
+                "backends".to_string(),
             ],
             known_keys,
             deprecated_keys: HashMap::new(),

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -192,6 +192,7 @@ impl SetupWizard {
             generation_profile: crate::prompts::profiles::GenerationProfile::default(),
             ai: crate::models::AiConfig::default(),
             safety: crate::safety::SafetySection::default(),
+            backends: crate::models::BackendsConfig::default(),
         };
 
         self.print_summary(&configuration, theme);


### PR DESCRIPTION
## Summary

Extends Caro's backend spectrum with two distributed-LLM networks and a
privacy-preserving **hybrid** gateway, plus makes remote endpoint URLs
configurable. Implements the design in
[ADR-015](docs/adr/ADR-015-distributed-llm-backends-hybrid-privacy.md).

- **Mesh-LLM** ([repo](https://github.com/Mesh-LLM/mesh-llm), Apache-2.0) —
  OpenAI-compatible `/v1` mesh pooling GPUs across your own machines. Mirrors
  the existing Exo backend; auto-detected on `:9337`.
- **AI-Horde** ([repo](https://github.com/Haidra-Org/AI-Horde), AGPL-3.0) —
  free crowdsourced volunteer cluster via an async submit→poll job queue;
  anonymous key; **explicit opt-in only** (it's a public service).
- **Hybrid privacy gateway** — pairs the local embedded model with a remote
  enhancer. A deterministic `ContextSanitizer` redacts PII (paths, usernames,
  hostnames, IPs, emails, `ENV=` values) into reversible placeholders before
  anything leaves the device, then restores real values in the returned command
  locally. `[backends].allow_public = true` opts into verbatim send for a
  trusted private mesh.

## How the two networks differ

| | Mesh-LLM | AI-Horde |
|---|---|---|
| API | OpenAI sync `/v1` | Async submit + poll |
| Setup | Run a mesh node | None (anon key) |
| Trust | Your peers (private) | Untrusted volunteers |
| Auto-detect | Yes | No (opt-in) |

## Changes

- `[backends]` config section (`mesh_url`, `ollama_url`, `vllm_url`, `exo_url`,
  `ai_horde_url`, `ai_horde_key`, `hybrid_remote`, `allow_public`); the factory
  now resolves URLs from config with localhost fallbacks (previously hard-coded).
- `BackendType::Mesh`, `AiHorde`, `Hybrid`.
- `mesh` and `ai-horde` flagged off-host in `ai::privacy::may_leak_context_offhost`;
  `hybrid` excluded (it sanitizes by default).
- README `[backends]` docs + corrected CLAUDE.md `src/backends/` tree.

## Testing

- 24 new unit tests: 7 (mesh) + 6 (AI-Horde, via `wiremock`) + 11 (hybrid +
  sanitizer), including a **privacy-proof** asserting the remote never receives
  PII while the restored command is correct.
- `cargo test --features remote-backends --lib` → 596 passed, 0 failed.
- `cargo clippy` clean on both default and `remote-backends` feature sets.

## Notes

- Neither project is a linked crate (both are remote HTTP services), so the
  external-SDK build-spike rule doesn't apply.
- Not yet exercised against a live mesh/Horde — the per-backend logic is covered
  by unit/mock tests; an end-to-end smoke is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mesh`, `ai-horde`, and a privacy-first `hybrid` backend with configurable remote URLs/keys, plus a deterministic sanitizer and explicit redaction briefing so remotes never see PII while still understanding placeholders. Also fixes a docs spelling issue to unblock CI.

- **New Features**
  - `mesh` — Mesh-LLM over OpenAI `/v1` (auto-detected on `:9337`; `model="mesh"` by default).
  - `ai-horde` — crowdsourced async queue (anon key works; explicit opt-in only).
  - `hybrid` — local sanitizer + remote enhancer (`mesh` or `ai-horde`) with on-device fallback. Redacts paths, usernames, hostnames, IPs, emails, and `ENV=` values into typed placeholders like `<REDACTED_FILEPATH_1>`. Prepends a redaction briefing that explains each placeholder and instructs remotes to reproduce tokens verbatim; adds a local context note so the embedded fallback is aware. Set `allow_public = true` to skip redaction for a trusted private mesh.
  - Configurable endpoints via `[backends]`: `mesh_url`, `ollama_url`, `vllm_url`, `exo_url`, `ai_horde_url`, `ai_horde_key`, `hybrid_remote`, `allow_public`.
  - CLI `--backend` now accepts `mesh`, `ai-horde`, and `hybrid`. `mesh` is auto-detected; `ai-horde` is never auto-enabled. Off-host leak checks include `mesh` and `ai-horde`; `hybrid` is excluded by default.
  - E2E privacy proof: captured HTTP shows `<REDACTED_*>` tokens, not PII; restored command is correct. 600 tests green.

- **Migration**
  - No breaking changes; defaults stay the same.
  - Mesh-LLM: run a mesh node, then use `--backend mesh` or rely on auto-detect; set `[backends].mesh_url` if not on `:9337`.
  - AI-Horde: use `--backend ai-horde`; optional `[backends].ai_horde_key` and `ai_horde_url` (anon key is default).
  - Hybrid: use `--backend hybrid`; choose the enhancer with `[backends].hybrid_remote` (`mesh` default). Keep `allow_public = false` unless using a trusted private mesh.

<sup>Written for commit 53b7ccd11701272266684e17742e5a78cd894b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

