### PR TITLE
fix(i18n): use live OpenAI model + fail loud on zero translations

### DIFF
--- a/.github/scripts/translate-multi-backend.js
+++ b/.github/scripts/translate-multi-backend.js
@@ -177,7 +177,7 @@ class OpenAIBackend extends TranslationBackend {
       console.log(`[${locale}] [OpenAI] Translating ${fileName}...`);
 
       const response = await this.openai.chat.completions.create({
-        model: 'gpt-4-turbo-preview',
+        model: process.env.OPENAI_MODEL || 'gpt-4o',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }
@@ -562,6 +562,18 @@ async function translateAllFiles() {
   console.log(`[${targetLocale}] Translation completed!`);
   console.log(`[${targetLocale}] Summary: ${translatedCount} translated, ${skippedCount} skipped (cached), ${failedCount} failed`);
   console.log(`========================================`);
+
+  // Fail loud on total failure. Per-file errors are caught and counted above so
+  // one bad file doesn't sink the whole locale — but if EVERY attempted file
+  // failed (e.g. a dead model name 404ing on every call), the run must go red.
+  // Without this gate the workflow reports success while translating nothing,
+  // and the only artifact is package-lock drift in the auto-PR (see caro-z1rp).
+  if (translatedCount === 0 && failedCount > 0) {
+    throw new Error(
+      `[${targetLocale}] All ${failedCount} attempted file(s) failed — translated 0. ` +
+      `Treating as a fatal error so the workflow surfaces it instead of opening a no-op PR.`
+    );
+  }
 }
 
 // ============================================


### PR DESCRIPTION
Fixes the auto-translation workflow that has been silently doing nothing for weeks.

## Root cause

`.github/scripts/translate-multi-backend.js` hardcoded the **retired** model `gpt-4-turbo-preview`. Every OpenAI call 404s:

```
[ja] [OpenAI] ✗ Error: 404 The model `gpt-4-turbo-preview` does not exist or you do not have access to it.
```

The per-file `try/catch` counts the failure and `continue`s, then the script `exit(0)`. So weekly runs report **success** while translating **zero** strings. The only working-tree change left is `npm install openai` regenerating `package-lock.json`, which `peter-evans/create-pull-request` commits — that is the entire content of the open auto-translate PRs **#1125–#1138** (0 locale-file changes each, verified).

Net effect: translation coverage frozen at ~70%, and `playbook.json` (39 keys) + `waitlist.json` (10 keys) untranslated in all 14 locales.

## Fix

- Default OpenAI model → `gpt-4o` (overridable via `OPENAI_MODEL`).
- **Zero-translation gate**: if `translatedCount === 0 && failedCount > 0`, throw so the run goes **red** instead of opening a no-op PR. Per-file resilience is preserved (one bad file still does not sink a locale).

## Follow-ups (not in this PR)
- Close the no-op churn PRs #1125–#1138.
- After merge, run `translate.yml` with `force_retranslate: true` to backfill all locales (incl. the two missing namespaces).

Closes #caro-z1rp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the auto-translation workflow by switching to a live model and failing runs that translate nothing, preventing no‑op PRs. Aligns with Linear caro-z1rp.

- **Bug Fixes**
  - Default model to `gpt-4o` (configurable via `OPENAI_MODEL`).
  - Add total-failure gate: if 0 translated and >0 failed, throw so the workflow fails instead of opening a no-op PR.

<sup>Written for commit 8fb4e2f5500d1f4dbcbfe03179d3babc2e1adc1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

