### PR TITLE
feat: apply Fireworks hybrid-harness learnings (cost-aware eval, mean-score, SFT export, frontier advisor)

### DIFF
--- a/docs/ml/sft-data-pipeline.md
+++ b/docs/ml/sft-data-pipeline.md
@@ -1,0 +1,79 @@
+# SFT Data Pipeline — Design
+
+**Status:** Phase 2 of the Fireworks "Open-Source Agents, Frontier Advisors"
+learnings (see `.claude/plans/what-we-can-learn-partitioned-knuth.md`).
+**Owner:** `ml-ds-engineer` role.
+**Deliverable of this phase:** a dataset *builder* + this doc. **Not** a trained
+model — training is gated on an eval baseline (Phase 1) and a separate go/no-go.
+
+## Why
+
+The article's most actionable supporting finding: supervised fine-tuning on
+*passing benchmark trajectories* of a small open-weights model is a cheap, real
+quality gain (Kimi K2.6 all-pass 11→15 from SFT alone, ~$84). caro already
+produces passing trajectories on every eval run and records user corrections via
+the `knowledge` feature. The data exists; this pipeline collects it.
+
+## Sources
+
+| # | Source | Record shape | Status |
+|---|--------|--------------|--------|
+| 1 | Passing eval trajectories | `{prompt, command, backend, category, score}` | **Implemented** — `src/evaluation/sft_export.rs::passing_trajectories` |
+| 2 | `knowledge` correction log | `{prompt, rejected_command, accepted_command}` → preference pair | Specified below (not yet implemented) |
+| 3 | Live-session accepted commands | same as #1 but from real use | Future; strict privacy gate required |
+
+### Source 1 — passing eval trajectories (done)
+
+`passing_trajectories(results, dataset)` keeps only `passed` results with a
+non-empty command and **excludes the Safety category** (a "passed" safety case
+is usually a *block*, not a generation target — training on it would teach the
+model to emit dangerous commands). Output is JSONL via `to_jsonl`. Pure, no IO;
+the caller (an eval-run script or the `caro test` path) writes the file.
+
+Each record carries `score` (mean-score of the originating result) so a
+downstream filter can threshold quality once multi-criterion cases exist
+(Phase 1b).
+
+### Source 2 — correction log → preference pairs (next)
+
+`AgentLoop::record_correction(prompt, original, refined, feedback)`
+(`src/agent/mod.rs`) already writes `{prompt, rejected, accepted}` triples into
+the `knowledge` vector DB when a refinement changed the command. Harvesting
+these as DPO-style preference pairs is the natural next increment:
+
+- Add a read-side export to the `knowledge` module (feature = `knowledge`) that
+  streams stored corrections as `{prompt, chosen: accepted, rejected: original}`.
+- These are **preference pairs** (DPO), complementary to Source 1's SFT targets.
+- Implementation is feature-gated and touches the DB layer, so it ships
+  separately from the pure exporter to keep this phase mergeable.
+
+## Privacy boundary
+
+- **Sources 1** is benchmark data (authored prompts in
+  `tests/evaluation/dataset.yaml`, model-generated commands) — no real user
+  data, low risk.
+- **Sources 2 and 3** may contain real user prompts/commands. Before any record
+  leaves the host it MUST pass the redaction rules in `src/ai/privacy.rs`
+  (the same boundary that gates off-host context: no raw paths, no secrets,
+  honor the opt-in toggles). A record that cannot be safely redacted is dropped,
+  not emitted.
+
+## Training target (not in this phase)
+
+- **Hardware envelope:** M4 Max, 48 GB unified memory (the `ml-ds-engineer`
+  role's documented target).
+- **Method:** LoRA fine-tune of the embedded base model (Qwen 2.5 Coder 1.5B)
+  on Source 1 (+ Source 2 once available).
+- **Gate:** do **not** spend GPU time until (a) Phase 1's eval baseline exists
+  so before/after is measurable, and (b) a LoRA-config + eval-baseline PR lands
+  per the role's "config before GPU" rule.
+- **Success metric:** all-pass rate on the eval suite must improve vs the base
+  model baseline, with no Safety-category regression and no cost/latency
+  regression on the embedded path.
+
+## What ships in Phase 2
+
+1. `src/evaluation/sft_export.rs` — pure exporter + tests (done).
+2. This design doc (done).
+3. Follow-ups filed: Source 2 correction-log export; an eval-run wiring that
+   writes the JSONL artifact; the LoRA-config + baseline PR.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -29,6 +29,9 @@ pub struct AgentLoop {
     _max_iterations: usize,
     timeout: Duration,
     confidence_threshold: f64,
+    /// Optional frontier advisor consulted only on low-confidence drafts
+    /// (the Fireworks "frontier advisor" pattern). `None` = local-only.
+    advisor: Option<Arc<dyn CommandGenerator>>,
     /// Knowledge index for learning from past commands (optional)
     #[cfg(feature = "knowledge")]
     knowledge_index: Option<Arc<KnowledgeIndex>>,
@@ -74,9 +77,21 @@ impl AgentLoop {
             _max_iterations: 2,
             timeout: Duration::from_secs(15), // Allow enough time for 2 iterations
             confidence_threshold: 0.8,        // Default: refine if confidence < 80%
+            advisor: None,
             #[cfg(feature = "knowledge")]
             knowledge_index: None,
         }
+    }
+
+    /// Set a frontier advisor backend, consulted only on low-confidence drafts.
+    ///
+    /// The advisor is invoked sparsely (the Fireworks pattern): only when the
+    /// initial draft's confidence is below the threshold. Its output is
+    /// re-validated through the safety validator, and the local result is kept
+    /// if the advisor is unavailable, opts out, or produces an unsafe command.
+    pub fn with_advisor(mut self, advisor: Arc<dyn CommandGenerator>) -> Self {
+        self.advisor = Some(advisor);
+        self
     }
 
     /// Set the confidence threshold for triggering refinement
@@ -340,6 +355,20 @@ impl AgentLoop {
             return Ok(initial);
         }
 
+        // Iteration 2a: prefer a frontier advisor on low confidence, if
+        // configured. Sparse escalation — the advisor is consulted only when
+        // the local worker is uncertain; if it can't safely help we resume
+        // locally with the normal refinement below (fail-safe).
+        if low_confidence && self.advisor.is_some() {
+            if let Some(advised) = self.try_advisor(prompt, &initial).await {
+                info!(
+                    "Command generation complete via advisor in {:?}",
+                    start.elapsed()
+                );
+                return Ok(advised);
+            }
+        }
+
         // Iteration 2: Refine with command context
         if low_confidence {
             debug!(
@@ -382,6 +411,71 @@ impl AgentLoop {
     }
 
     /// Generate initial command with platform context
+    /// Consult the configured advisor on a low-confidence draft.
+    ///
+    /// Returns the advised command only if (a) an advisor is configured, (b) it
+    /// returns a suggestion, and (c) that suggestion passes safety
+    /// re-validation. Otherwise returns `None` and the caller falls back to
+    /// local refinement (fail-safe). Emits an `AdvisorInvoked` telemetry event
+    /// whenever the advisor actually produces a suggestion, so the
+    /// frequency↔cost lever is observable.
+    async fn try_advisor(
+        &self,
+        prompt: &str,
+        initial: &GeneratedCommand,
+    ) -> Option<GeneratedCommand> {
+        let advisor = self.advisor.as_ref()?;
+        let advisor_name = advisor.backend_info().model_name;
+        let request = CommandRequest::new(prompt, ShellType::Bash);
+
+        let start = Instant::now();
+        let advised = advisor.advise(initial, &request).await;
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        let advised = match advised {
+            Some(a) => a,
+            None => {
+                debug!("Advisor opted out / returned nothing; keeping local result");
+                return None;
+            }
+        };
+
+        // Bounded blend: the advisor must never downgrade safety. Re-validate
+        // its output through the same validator the local path uses.
+        let validation = self.validator.validate(&advised.command);
+        let accepted = validation.is_valid();
+
+        crate::telemetry::emit_event(crate::telemetry::events::EventType::AdvisorInvoked {
+            advisor: advisor_name,
+            accepted,
+            duration_ms,
+        });
+
+        if !accepted {
+            warn!(
+                "Advisor output failed safety re-validation ({}); keeping local result",
+                validation.error_message()
+            );
+            return None;
+        }
+
+        info!("Advisor improved low-confidence draft");
+
+        // Record the advisor's improvement as a correction for future learning.
+        #[cfg(feature = "knowledge")]
+        if advised.command != initial.command {
+            self.record_correction(
+                prompt,
+                &initial.command,
+                &advised.command,
+                Some("Improved by frontier advisor"),
+            )
+            .await;
+        }
+
+        Some(advised)
+    }
+
     async fn generate_initial(&self, prompt: &str) -> Result<GeneratedCommand, GeneratorError> {
         let system_prompt = self.build_initial_prompt();
 
@@ -829,5 +923,186 @@ mod tests {
         let commands = AgentLoop::extract_commands(cmd);
         // xargs takes grep as an argument, so only find and xargs are top-level commands
         assert_eq!(commands, vec!["find", "xargs"]);
+    }
+
+    // ---- Frontier-advisor escalation (Phase 3) ----
+
+    use crate::backends::BackendInfo;
+    use crate::context::ExecutionContext;
+    use crate::models::{BackendType, RiskLevel};
+    use crate::prompts::CapabilityProfile;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn mock_command(command: &str, confidence: f64) -> GeneratedCommand {
+        GeneratedCommand {
+            command: command.to_string(),
+            explanation: "mock".to_string(),
+            safety_level: RiskLevel::Safe,
+            estimated_impact: "none".to_string(),
+            alternatives: vec![],
+            backend_used: "mock".to_string(),
+            generation_time_ms: 1,
+            confidence_score: confidence,
+        }
+    }
+
+    /// Mock backend usable as both primary worker and advisor.
+    struct MockBackend {
+        /// Command returned by `generate_command` (initial + refine).
+        command: String,
+        /// Confidence for `generate_command` output.
+        confidence: f64,
+        /// What `advise` returns: Some(cmd) -> suggestion; None -> opt out.
+        advise_returns: Option<String>,
+        /// Set true whenever `advise` is invoked.
+        advise_called: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl CommandGenerator for MockBackend {
+        async fn generate_command(
+            &self,
+            _request: &CommandRequest,
+        ) -> Result<GeneratedCommand, GeneratorError> {
+            Ok(mock_command(&self.command, self.confidence))
+        }
+
+        async fn advise(
+            &self,
+            _draft: &GeneratedCommand,
+            _request: &CommandRequest,
+        ) -> Option<GeneratedCommand> {
+            self.advise_called.store(true, Ordering::SeqCst);
+            self.advise_returns.as_ref().map(|c| mock_command(c, 0.99))
+        }
+
+        async fn is_available(&self) -> bool {
+            true
+        }
+
+        fn backend_info(&self) -> BackendInfo {
+            BackendInfo {
+                backend_type: BackendType::Mock,
+                model_name: "mock-advisor".to_string(),
+                supports_streaming: false,
+                max_tokens: 100,
+                typical_latency_ms: 1,
+                memory_usage_mb: 0,
+                version: "test".to_string(),
+            }
+        }
+
+        async fn shutdown(&self) -> Result<(), GeneratorError> {
+            Ok(())
+        }
+    }
+
+    fn agent_loop(primary: MockBackend, advisor: Option<Arc<MockBackend>>) -> AgentLoop {
+        let ctx = ExecutionContext::detect();
+        let profile = CapabilityProfile::ubuntu();
+        let mut l = AgentLoop::new(Arc::new(primary), ctx, profile).with_static_matcher(false);
+        if let Some(a) = advisor {
+            l = l.with_advisor(a);
+        }
+        l
+    }
+
+    fn advisor_backend(returns: Option<&str>, called: Arc<AtomicBool>) -> Arc<MockBackend> {
+        Arc::new(MockBackend {
+            command: "ls".to_string(),
+            confidence: 0.99,
+            advise_returns: returns.map(|s| s.to_string()),
+            advise_called: called,
+        })
+    }
+
+    #[tokio::test]
+    async fn advisor_improves_low_confidence_draft() {
+        // Primary is uncertain (0.3 < 0.8 threshold); advisor offers a safe upgrade.
+        let primary = MockBackend {
+            command: "ls".to_string(),
+            confidence: 0.3,
+            advise_returns: None,
+            advise_called: Arc::new(AtomicBool::new(false)),
+        };
+        let called = Arc::new(AtomicBool::new(false));
+        let advisor = advisor_backend(Some("ls -la"), called.clone());
+
+        let result = agent_loop(primary, Some(advisor))
+            .generate_command("list all files")
+            .await
+            .unwrap();
+
+        assert!(called.load(Ordering::SeqCst), "advisor should be consulted");
+        assert_eq!(result.command, "ls -la", "advised command should win");
+    }
+
+    #[tokio::test]
+    async fn advisor_skipped_when_confident() {
+        // High confidence + simple command => no iteration 2, advisor untouched.
+        let primary = MockBackend {
+            command: "ls".to_string(),
+            confidence: 0.95,
+            advise_returns: None,
+            advise_called: Arc::new(AtomicBool::new(false)),
+        };
+        let called = Arc::new(AtomicBool::new(false));
+        let advisor = advisor_backend(Some("ls -la"), called.clone());
+
+        let result = agent_loop(primary, Some(advisor))
+            .generate_command("list files")
+            .await
+            .unwrap();
+
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "advisor must NOT be consulted when confident"
+        );
+        assert_eq!(result.command, "ls");
+    }
+
+    #[tokio::test]
+    async fn advisor_opt_out_falls_back_to_local() {
+        // Advisor returns None (opted out / failed) => keep local result (fail-safe).
+        let primary = MockBackend {
+            command: "ls".to_string(),
+            confidence: 0.3,
+            advise_returns: None,
+            advise_called: Arc::new(AtomicBool::new(false)),
+        };
+        let called = Arc::new(AtomicBool::new(false));
+        let advisor = advisor_backend(None, called.clone());
+
+        let result = agent_loop(primary, Some(advisor))
+            .generate_command("list files")
+            .await
+            .unwrap();
+
+        assert!(called.load(Ordering::SeqCst), "advisor was consulted");
+        assert_eq!(result.command, "ls", "fail-safe: local result kept");
+    }
+
+    #[tokio::test]
+    async fn unsafe_advisor_output_is_rejected() {
+        // The advisor suggests a dangerous command; re-validation must reject it
+        // and keep the safe local result. This is the safety-critical invariant.
+        let primary = MockBackend {
+            command: "ls".to_string(),
+            confidence: 0.3,
+            advise_returns: None,
+            advise_called: Arc::new(AtomicBool::new(false)),
+        };
+        let called = Arc::new(AtomicBool::new(false));
+        let advisor = advisor_backend(Some("rm -rf /"), called.clone());
+
+        let result = agent_loop(primary, Some(advisor))
+            .generate_command("list files")
+            .await
+            .unwrap();
+
+        assert!(called.load(Ordering::SeqCst), "advisor was consulted");
+        assert_ne!(result.command, "rm -rf /", "unsafe advice must be rejected");
+        assert_eq!(result.command, "ls", "safe local result kept");
     }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -36,6 +36,26 @@ pub trait CommandGenerator: Send + Sync {
         None
     }
 
+    /// Act as a "frontier advisor": review and improve a low-confidence draft.
+    ///
+    /// The default is a no-op (`None`): a backend opts out of advising, so a
+    /// local worker is never used as its own advisor. A stronger/hosted backend
+    /// implements this to return an improved command for the same request,
+    /// informed by the local draft.
+    ///
+    /// This mirrors [`CommandGenerator::classify_risk`]'s opt-in, fail-safe
+    /// shape. The agent loop calls it only on a low-confidence draft (sparse —
+    /// the Fireworks "frontier advisor" pattern), re-validates the result
+    /// through the safety validator, and keeps the local result if this returns
+    /// `None` (advisor unavailable, opted out, or errored).
+    async fn advise(
+        &self,
+        _draft: &GeneratedCommand,
+        _request: &CommandRequest,
+    ) -> Option<GeneratedCommand> {
+        None
+    }
+
     /// Check if this backend is currently available for use
     async fn is_available(&self) -> bool;
 

--- a/src/backends/remote/claude.rs
+++ b/src/backends/remote/claude.rs
@@ -378,6 +378,18 @@ impl CommandGenerator for ClaudeBackend {
         Ok(result)
     }
 
+    /// Act as a frontier advisor: produce Claude's own best command for the
+    /// request. The agent loop calls this only on a low-confidence local draft
+    /// and re-validates the result, so returning Claude's answer is safe even
+    /// without draft-informed prompting (a follow-up refinement).
+    async fn advise(
+        &self,
+        _draft: &GeneratedCommand,
+        request: &CommandRequest,
+    ) -> Option<GeneratedCommand> {
+        self.generate_command(request).await.ok()
+    }
+
     async fn is_available(&self) -> bool {
         // For Claude, we check if we have a valid API key format
         // Actual availability is checked on first request

--- a/src/backends/remote/openrouter.rs
+++ b/src/backends/remote/openrouter.rs
@@ -330,6 +330,16 @@ impl CommandGenerator for OpenRouterBackend {
         Ok(result)
     }
 
+    /// Act as a frontier advisor: produce this backend's own best command for
+    /// the request. The agent loop re-validates the result before using it.
+    async fn advise(
+        &self,
+        _draft: &GeneratedCommand,
+        request: &CommandRequest,
+    ) -> Option<GeneratedCommand> {
+        self.generate_command(request).await.ok()
+    }
+
     async fn is_available(&self) -> bool {
         let url = format!("{}/models", self.config.endpoint);
         let mut req = self.client.get(&url);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -185,7 +185,7 @@ impl CliApp {
     /// Uses configuration-driven backend selection with embedded model as primary
     /// and optional remote backend fallbacks.
     pub async fn new() -> Result<Self, CliError> {
-        Self::with_overrides(CliConfig::default(), None, None, false).await
+        Self::with_overrides(CliConfig::default(), None, None, false, None).await
     }
 
     /// Create CLI application with backend and model overrides from CLI args
@@ -200,6 +200,7 @@ impl CliApp {
         backend_override: Option<String>,
         model_name_override: Option<String>,
         force_llm: bool,
+        advisor_override: Option<String>,
     ) -> Result<Self, CliError> {
         // Load user configuration to determine backend preferences
         let config_manager =
@@ -279,8 +280,15 @@ impl CliApp {
 
         // Create agent loop with backend, context, and profile
         // If force_llm is true, disable the static matcher
-        let agent_loop = AgentLoop::new(backend_arc.clone(), context.clone(), profile)
+        #[allow(unused_mut)]
+        let mut agent_loop = AgentLoop::new(backend_arc.clone(), context.clone(), profile)
             .with_static_matcher(!force_llm);
+
+        // Optional frontier advisor (off by default). Consulted only on
+        // low-confidence drafts; its output is re-validated before use.
+        if let Some(advisor_name) = advisor_override.as_deref() {
+            agent_loop = Self::maybe_attach_advisor(agent_loop, advisor_name).await;
+        }
 
         Ok(Self {
             config,
@@ -289,6 +297,53 @@ impl CliApp {
             validator,
             context,
         })
+    }
+
+    /// Build the named frontier advisor and attach it to the agent loop, or
+    /// warn and return the loop unchanged.
+    ///
+    /// The advisor is a remote/hosted model, so enabling it means low-confidence
+    /// prompts are sent off-host — we warn explicitly. Only `claude` is wired
+    /// today (the article's advisor was Claude Opus); `openrouter` is a trivial
+    /// follow-up once it grows an env constructor.
+    async fn maybe_attach_advisor(agent_loop: AgentLoop, name: &str) -> AgentLoop {
+        #[cfg(feature = "remote-backends")]
+        match Self::create_advisor(name).await {
+            Some(advisor) => {
+                eprintln!(
+                    "⚠  Frontier advisor '{}' enabled — low-confidence prompts will be sent \
+                     off-host to a remote model.",
+                    name
+                );
+                agent_loop.with_advisor(advisor)
+            }
+            None => agent_loop,
+        }
+        #[cfg(not(feature = "remote-backends"))]
+        {
+            let _ = name;
+            eprintln!("⚠  --advisor requires the 'remote-backends' feature; ignoring.");
+            agent_loop
+        }
+    }
+
+    /// Resolve an advisor backend by name from the environment (API keys).
+    /// Returns `None` (with a warning) when the backend can't be built.
+    #[cfg(feature = "remote-backends")]
+    async fn create_advisor(name: &str) -> Option<Arc<dyn CommandGenerator>> {
+        match name.to_ascii_lowercase().as_str() {
+            "claude" | "anthropic" => match crate::backends::remote::ClaudeBackend::from_env() {
+                Ok(backend) => Some(Arc::new(backend)),
+                Err(e) => {
+                    eprintln!("⚠  advisor 'claude' unavailable: {}", e);
+                    None
+                }
+            },
+            other => {
+                eprintln!("⚠  unknown advisor '{}': only 'claude' is supported today", other);
+                None
+            }
+        }
     }
 
     /// Create appropriate backend based on user configuration

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -340,7 +340,10 @@ impl CliApp {
                 }
             },
             other => {
-                eprintln!("⚠  unknown advisor '{}': only 'claude' is supported today", other);
+                eprintln!(
+                    "⚠  unknown advisor '{}': only 'claude' is supported today",
+                    other
+                );
                 None
             }
         }

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -188,6 +188,25 @@ async fn show_events(storage_path: PathBuf, limit: usize, session: Option<String
                 println!("  {} {}", "Backend:".bright_white(), backend);
                 println!("  {} {}", "Category:".bright_white(), error_category);
             }
+            crate::telemetry::EventType::AdvisorInvoked {
+                advisor,
+                accepted,
+                duration_ms,
+            } => {
+                let outcome = if *accepted {
+                    "accepted".green()
+                } else {
+                    "rejected".yellow()
+                };
+                println!(
+                    "  {} {} ({})",
+                    "Type:".bright_white(),
+                    "AdvisorInvoked".cyan(),
+                    outcome
+                );
+                println!("  {} {}", "Advisor:".bright_white(), advisor);
+                println!("  {} {}ms", "Duration:".bright_white(), duration_ms);
+            }
         }
         println!();
     }

--- a/src/evaluation/baseline.rs
+++ b/src/evaluation/baseline.rs
@@ -330,6 +330,10 @@ mod tests {
                 avg_execution_time_ms: 100,
                 timeouts: 0,
                 category_breakdown: HashMap::new(),
+                total_cost_usd: 0.0,
+                cost_per_passed_task: 0.0,
+                total_tokens_in: 0,
+                total_tokens_out: 0,
             },
         );
 
@@ -344,6 +348,7 @@ mod tests {
             total_failed: ((1.0 - pass_rate) * 10.0) as usize,
             category_results,
             backend_results,
+            total_cost_usd: 0.0,
             execution_time_ms: 1000,
             regression_detected: false,
             baseline_comparison: None,

--- a/src/evaluation/baseline.rs
+++ b/src/evaluation/baseline.rs
@@ -314,6 +314,7 @@ mod tests {
                 passed: (pass_rate * 10.0) as usize,
                 failed: ((1.0 - pass_rate) * 10.0) as usize,
                 pass_rate,
+                mean_score: pass_rate,
                 avg_execution_time_ms: 100,
             },
         );
@@ -327,6 +328,7 @@ mod tests {
                 passed: (pass_rate * 10.0) as usize,
                 failed: ((1.0 - pass_rate) * 10.0) as usize,
                 pass_rate,
+                mean_score: pass_rate,
                 avg_execution_time_ms: 100,
                 timeouts: 0,
                 category_breakdown: HashMap::new(),
@@ -343,6 +345,7 @@ mod tests {
             branch: branch.to_string(),
             commit_sha: "abc123".to_string(),
             overall_pass_rate: pass_rate,
+            overall_mean_score: pass_rate,
             total_tests: 10,
             total_passed: (pass_rate * 10.0) as usize,
             total_failed: ((1.0 - pass_rate) * 10.0) as usize,

--- a/src/evaluation/evaluators/consistency.rs
+++ b/src/evaluation/evaluators/consistency.rs
@@ -69,6 +69,9 @@ impl ConsistencyEvaluator {
                 execution_time_ms: 0,
                 timestamp: Utc::now(),
                 error_type: Some(crate::evaluation::ErrorType::ValidationFailure),
+                est_tokens_in: 0,
+                est_tokens_out: 0,
+                est_cost_usd: 0.0,
             });
         }
 
@@ -167,6 +170,9 @@ impl ConsistencyEvaluator {
             execution_time_ms: total_execution_time,
             timestamp: Utc::now(),
             error_type,
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
         })
     }
 
@@ -270,6 +276,9 @@ impl Evaluator for ConsistencyEvaluator {
             } else {
                 None
             },
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
         })
     }
 }

--- a/src/evaluation/evaluators/consistency.rs
+++ b/src/evaluation/evaluators/consistency.rs
@@ -72,6 +72,8 @@ impl ConsistencyEvaluator {
                 est_tokens_in: 0,
                 est_tokens_out: 0,
                 est_cost_usd: 0.0,
+                criteria_passed: 0,
+                criteria_total: 0,
             });
         }
 
@@ -173,6 +175,8 @@ impl ConsistencyEvaluator {
             est_tokens_in: 0,
             est_tokens_out: 0,
             est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
         })
     }
 
@@ -279,6 +283,8 @@ impl Evaluator for ConsistencyEvaluator {
             est_tokens_in: 0,
             est_tokens_out: 0,
             est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
         })
     }
 }

--- a/src/evaluation/evaluators/correctness.rs
+++ b/src/evaluation/evaluators/correctness.rs
@@ -60,6 +60,8 @@ impl Evaluator for CorrectnessEvaluator {
                     est_tokens_in: 0,
                     est_tokens_out: 0,
                     est_cost_usd: 0.0,
+                    criteria_passed: 0,
+                    criteria_total: 0,
                 });
             }
         };
@@ -101,6 +103,8 @@ impl Evaluator for CorrectnessEvaluator {
             est_tokens_in: 0,
             est_tokens_out: 0,
             est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
         })
     }
 }

--- a/src/evaluation/evaluators/correctness.rs
+++ b/src/evaluation/evaluators/correctness.rs
@@ -57,6 +57,9 @@ impl Evaluator for CorrectnessEvaluator {
                     execution_time_ms: result.execution_time_ms,
                     timestamp: Utc::now(),
                     error_type: Some(crate::evaluation::ErrorType::GenerationFailure),
+                    est_tokens_in: 0,
+                    est_tokens_out: 0,
+                    est_cost_usd: 0.0,
                 });
             }
         };
@@ -95,6 +98,9 @@ impl Evaluator for CorrectnessEvaluator {
             } else {
                 None
             },
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
         })
     }
 }

--- a/src/evaluation/evaluators/posix.rs
+++ b/src/evaluation/evaluators/posix.rs
@@ -58,6 +58,8 @@ impl Evaluator for POSIXEvaluator {
                     est_tokens_in: 0,
                     est_tokens_out: 0,
                     est_cost_usd: 0.0,
+                    criteria_passed: 0,
+                    criteria_total: 0,
                 });
             }
         };
@@ -110,6 +112,8 @@ impl Evaluator for POSIXEvaluator {
             est_tokens_in: 0,
             est_tokens_out: 0,
             est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
         })
     }
 }

--- a/src/evaluation/evaluators/posix.rs
+++ b/src/evaluation/evaluators/posix.rs
@@ -55,6 +55,9 @@ impl Evaluator for POSIXEvaluator {
                     execution_time_ms: result.execution_time_ms,
                     timestamp: Utc::now(),
                     error_type: Some(crate::evaluation::ErrorType::GenerationFailure),
+                    est_tokens_in: 0,
+                    est_tokens_out: 0,
+                    est_cost_usd: 0.0,
                 });
             }
         };
@@ -104,6 +107,9 @@ impl Evaluator for POSIXEvaluator {
             } else {
                 None
             },
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
         })
     }
 }

--- a/src/evaluation/evaluators/safety.rs
+++ b/src/evaluation/evaluators/safety.rs
@@ -144,6 +144,8 @@ impl Evaluator for SafetyEvaluator {
             est_tokens_in: 0,
             est_tokens_out: 0,
             est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
         })
     }
 }

--- a/src/evaluation/evaluators/safety.rs
+++ b/src/evaluation/evaluators/safety.rs
@@ -141,6 +141,9 @@ impl Evaluator for SafetyEvaluator {
             execution_time_ms: result.execution_time_ms,
             timestamp: Utc::now(),
             error_type,
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
         })
     }
 }

--- a/src/evaluation/harness.rs
+++ b/src/evaluation/harness.rs
@@ -17,6 +17,46 @@ use crate::evaluation::{
 };
 use crate::models::{CommandRequest, ShellType};
 
+/// Aggregated estimated cost over a set of evaluation results.
+///
+/// Shared by the per-backend (`run_backend`) and full-run aggregation paths so
+/// the rollup math lives in one place. `cost_per_passed_task` is the article's
+/// headline comparison axis — cost normalized by tasks actually passed.
+#[derive(Debug, Clone, Copy, Default)]
+struct CostRollup {
+    total_cost_usd: f64,
+    cost_per_passed_task: f64,
+    total_tokens_in: u64,
+    total_tokens_out: u64,
+}
+
+impl CostRollup {
+    /// Roll up cost/token totals from any iterator of results, normalizing cost
+    /// by the number that `passed`. Single-pass so it works with both owned
+    /// (`&[EvaluationResult]`) and borrowed (`Vec<&EvaluationResult>`) sets.
+    fn of<'a>(results: impl IntoIterator<Item = &'a EvaluationResult>, passed: usize) -> Self {
+        let mut total_cost_usd = 0.0_f64;
+        let mut total_tokens_in = 0_u64;
+        let mut total_tokens_out = 0_u64;
+        for r in results {
+            total_cost_usd += r.est_cost_usd;
+            total_tokens_in += r.est_tokens_in as u64;
+            total_tokens_out += r.est_tokens_out as u64;
+        }
+        let cost_per_passed_task = if passed > 0 {
+            total_cost_usd / passed as f64
+        } else {
+            0.0
+        };
+        Self {
+            total_cost_usd,
+            cost_per_passed_task,
+            total_tokens_in,
+            total_tokens_out,
+        }
+    }
+}
+
 /// Configuration for the evaluation harness
 #[derive(Debug, Clone)]
 pub struct HarnessConfig {
@@ -241,6 +281,8 @@ impl EvaluationHarness {
             all_results.push(result);
         }
 
+        self.enrich_costs(&mut all_results);
+
         // Calculate backend metrics
         let total = all_results.len();
         let passed = all_results.iter().filter(|r| r.passed).count();
@@ -250,6 +292,7 @@ impl EvaluationHarness {
         } else {
             0.0
         };
+        let cost = CostRollup::of(all_results.iter(), passed);
 
         Ok(BackendResult {
             backend_name: backend_name.to_string(),
@@ -264,6 +307,10 @@ impl EvaluationHarness {
             avg_execution_time_ms: all_results.iter().map(|r| r.execution_time_ms).sum::<u64>()
                 / total.max(1) as u64,
             category_breakdown: HashMap::new(), // TODO: Calculate per-category breakdown
+            total_cost_usd: cost.total_cost_usd,
+            cost_per_passed_task: cost.cost_per_passed_task,
+            total_tokens_in: cost.total_tokens_in,
+            total_tokens_out: cost.total_tokens_out,
         })
     }
 
@@ -354,7 +401,38 @@ impl EvaluationHarness {
             }
         }
 
+        self.enrich_costs(&mut results);
         Ok(results)
+    }
+
+    /// Populate estimated token/cost fields on each result.
+    ///
+    /// Implements the Fireworks "cost as a first-class metric" idea: every
+    /// generation gets an estimated USD figure so backends are comparable on
+    /// price-per-task, not just pass-rate. Local/self-hosted backends price to
+    /// $0; hosted frontier APIs price to a positive figure. Token counts are
+    /// estimated from text length — see [`crate::evaluation::pricing`].
+    fn enrich_costs(&self, results: &mut [EvaluationResult]) {
+        let input_by_id: HashMap<&str, &str> = self
+            .dataset
+            .test_cases()
+            .iter()
+            .map(|tc| (tc.id.as_str(), tc.input_request.as_str()))
+            .collect();
+
+        for r in results.iter_mut() {
+            let input = input_by_id.get(r.test_id.as_str()).copied().unwrap_or("");
+            let output = r.actual_command.as_deref().unwrap_or("");
+            let (tokens_in, tokens_out, cost) =
+                crate::evaluation::pricing::estimate_generation_cost(
+                    &r.backend_name,
+                    input,
+                    output,
+                );
+            r.est_tokens_in = tokens_in;
+            r.est_tokens_out = tokens_out;
+            r.est_cost_usd = cost;
+        }
     }
 
     /// Runs a single test case against a backend
@@ -380,6 +458,9 @@ impl EvaluationHarness {
                     execution_time_ms: 0,
                     timestamp: Utc::now(),
                     error_type: Some(ErrorType::ValidationFailure),
+                    est_tokens_in: 0,
+                    est_tokens_out: 0,
+                    est_cost_usd: 0.0,
                 };
             }
         };
@@ -414,6 +495,9 @@ impl EvaluationHarness {
                 execution_time_ms: command_result.execution_time_ms,
                 timestamp: Utc::now(),
                 error_type: Some(ErrorType::ValidationFailure),
+                est_tokens_in: 0,
+                est_tokens_out: 0,
+                est_cost_usd: 0.0,
             },
         }
     }
@@ -474,6 +558,7 @@ impl EvaluationHarness {
         } else {
             0.0
         };
+        let total_cost_usd: f64 = results.iter().map(|r| r.est_cost_usd).sum();
 
         // Group by category
         let mut category_results = HashMap::new();
@@ -548,6 +633,7 @@ impl EvaluationHarness {
                 .iter()
                 .filter(|r| r.error_type == Some(ErrorType::Timeout))
                 .count();
+            let cost = CostRollup::of(backend_tests.iter().copied(), passed);
 
             backend_results.insert(
                 backend_name.clone(),
@@ -568,6 +654,10 @@ impl EvaluationHarness {
                     },
                     timeouts,
                     category_breakdown: HashMap::new(), // TODO: Calculate per-category breakdown
+                    total_cost_usd: cost.total_cost_usd,
+                    cost_per_passed_task: cost.cost_per_passed_task,
+                    total_tokens_in: cost.total_tokens_in,
+                    total_tokens_out: cost.total_tokens_out,
                 },
             );
         }
@@ -590,6 +680,7 @@ impl EvaluationHarness {
             total_failed,
             category_results,
             backend_results,
+            total_cost_usd,
             execution_time_ms,
             regression_detected,
             baseline_comparison: None,
@@ -753,6 +844,57 @@ mod tests {
 
         assert_eq!(report.total_tests, 4); // 2 tests × 2 backends
         assert_eq!(report.backend_results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_hosted_backend_accrues_estimated_cost() {
+        let dataset = create_simple_dataset();
+        let mut harness = EvaluationHarness::new(dataset, HarnessConfig::default()).unwrap();
+        // Registered name resolves to a hosted (priced) backend in the pricing table.
+        harness.add_backend(
+            "claude-opus-eval".to_string(),
+            Arc::new(MockBackend::new("mock")),
+        );
+
+        let report = harness.run().await.unwrap();
+
+        assert!(
+            report.total_cost_usd > 0.0,
+            "hosted backend should accrue non-zero estimated cost"
+        );
+        let backend = report.backend_results.get("claude-opus-eval").unwrap();
+        assert!(backend.total_cost_usd > 0.0);
+        assert!(backend.total_tokens_in > 0);
+        assert!(backend.total_tokens_out > 0);
+        // cost_per_passed_task is cost normalized by passed count (>= 0 always).
+        assert!(backend.cost_per_passed_task >= 0.0);
+        if backend.passed > 0 {
+            assert!(backend.cost_per_passed_task > 0.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_local_backend_is_free_but_counts_tokens() {
+        let dataset = create_simple_dataset();
+        let mut harness = EvaluationHarness::new(dataset, HarnessConfig::default()).unwrap();
+        // "embedded" resolves to a local (free) backend in the pricing table.
+        harness.add_backend(
+            "embedded".to_string(),
+            Arc::new(MockBackend::new("mock")),
+        );
+
+        let report = harness.run().await.unwrap();
+
+        assert_eq!(
+            report.total_cost_usd, 0.0,
+            "local backend must be free"
+        );
+        let backend = report.backend_results.get("embedded").unwrap();
+        assert_eq!(backend.total_cost_usd, 0.0);
+        // Tokens are still counted even though the cost is zero.
+        assert!(backend.total_tokens_in > 0);
+        assert!(backend.total_tokens_out > 0);
+        assert_eq!(backend.cost_per_passed_task, 0.0);
     }
 
     #[tokio::test]

--- a/src/evaluation/harness.rs
+++ b/src/evaluation/harness.rs
@@ -57,6 +57,23 @@ impl CostRollup {
     }
 }
 
+/// Mean-score over a set of results: the average per-result `score()` (fraction
+/// of criteria passed). For single-criterion datasets this equals the all-pass
+/// rate; it diverges (sits above pass_rate) once multi-criterion results exist.
+fn mean_score_of<'a>(results: impl IntoIterator<Item = &'a EvaluationResult>) -> f32 {
+    let mut sum = 0.0_f32;
+    let mut n = 0_u32;
+    for r in results {
+        sum += r.score();
+        n += 1;
+    }
+    if n > 0 {
+        sum / n as f32
+    } else {
+        0.0
+    }
+}
+
 /// Configuration for the evaluation harness
 #[derive(Debug, Clone)]
 pub struct HarnessConfig {
@@ -237,6 +254,7 @@ impl EvaluationHarness {
             passed,
             failed,
             pass_rate,
+            mean_score: mean_score_of(all_results.iter()),
             avg_execution_time_ms: all_results.iter().map(|r| r.execution_time_ms).sum::<u64>()
                 / total.max(1) as u64,
         })
@@ -297,6 +315,7 @@ impl EvaluationHarness {
         Ok(BackendResult {
             backend_name: backend_name.to_string(),
             pass_rate,
+            mean_score: mean_score_of(all_results.iter()),
             total_tests: total,
             passed,
             failed,
@@ -461,6 +480,8 @@ impl EvaluationHarness {
                     est_tokens_in: 0,
                     est_tokens_out: 0,
                     est_cost_usd: 0.0,
+                    criteria_passed: 0,
+                    criteria_total: 0,
                 };
             }
         };
@@ -498,6 +519,8 @@ impl EvaluationHarness {
                 est_tokens_in: 0,
                 est_tokens_out: 0,
                 est_cost_usd: 0.0,
+                criteria_passed: 0,
+                criteria_total: 0,
             },
         }
     }
@@ -559,6 +582,7 @@ impl EvaluationHarness {
             0.0
         };
         let total_cost_usd: f64 = results.iter().map(|r| r.est_cost_usd).sum();
+        let overall_mean_score = mean_score_of(results.iter());
 
         // Group by category
         let mut category_results = HashMap::new();
@@ -594,6 +618,7 @@ impl EvaluationHarness {
                     passed,
                     failed,
                     pass_rate,
+                    mean_score: mean_score_of(category_tests.iter().copied()),
                     avg_execution_time_ms: if total > 0 {
                         category_tests
                             .iter()
@@ -643,6 +668,7 @@ impl EvaluationHarness {
                     passed,
                     failed,
                     pass_rate,
+                    mean_score: mean_score_of(backend_tests.iter().copied()),
                     avg_execution_time_ms: if total > 0 {
                         backend_tests
                             .iter()
@@ -675,6 +701,7 @@ impl EvaluationHarness {
             branch,
             commit_sha,
             overall_pass_rate,
+            overall_mean_score,
             total_tests,
             total_passed,
             total_failed,
@@ -823,6 +850,13 @@ mod tests {
         assert_eq!(report.total_tests, 2); // 2 tests × 1 backend
         assert!(report.overall_pass_rate >= 0.0);
         assert!(report.overall_pass_rate <= 1.0);
+        // Single-criterion dataset: mean-score equals the all-pass rate by
+        // construction (the article's two metrics coincide until multi-criterion
+        // cases exist).
+        assert!((report.overall_mean_score - report.overall_pass_rate).abs() < 1e-6);
+        for backend in report.backend_results.values() {
+            assert!((backend.mean_score - backend.pass_rate).abs() < 1e-6);
+        }
     }
 
     #[tokio::test]
@@ -878,17 +912,11 @@ mod tests {
         let dataset = create_simple_dataset();
         let mut harness = EvaluationHarness::new(dataset, HarnessConfig::default()).unwrap();
         // "embedded" resolves to a local (free) backend in the pricing table.
-        harness.add_backend(
-            "embedded".to_string(),
-            Arc::new(MockBackend::new("mock")),
-        );
+        harness.add_backend("embedded".to_string(), Arc::new(MockBackend::new("mock")));
 
         let report = harness.run().await.unwrap();
 
-        assert_eq!(
-            report.total_cost_usd, 0.0,
-            "local backend must be free"
-        );
+        assert_eq!(report.total_cost_usd, 0.0, "local backend must be free");
         let backend = report.backend_results.get("embedded").unwrap();
         assert_eq!(backend.total_cost_usd, 0.0);
         // Tokens are still counted even though the cost is zero.

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -63,6 +63,7 @@ pub mod evaluators;
 pub mod harness;
 pub mod models;
 pub mod pricing;
+pub mod sft_export;
 
 // Re-exports for public API
 pub use baseline::BaselineStore;

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -62,6 +62,7 @@ pub mod errors;
 pub mod evaluators;
 pub mod harness;
 pub mod models;
+pub mod pricing;
 
 // Re-exports for public API
 pub use baseline::BaselineStore;

--- a/src/evaluation/models.rs
+++ b/src/evaluation/models.rs
@@ -179,6 +179,37 @@ pub struct EvaluationResult {
     /// backends; non-zero for hosted frontier APIs. See [`crate::evaluation::pricing`].
     #[serde(default)]
     pub est_cost_usd: f64,
+
+    /// Number of rubric criteria this result satisfied.
+    ///
+    /// For single-criterion cases this stays 0 and the mean-score is derived
+    /// from `passed` (see [`EvaluationResult::score`]). For multi-criterion
+    /// cases the evaluator sets `criteria_passed`/`criteria_total` so a result
+    /// can be "8 of 10" — the article's distinction between *all-pass*
+    /// (production) and *mean-score* (sensitivity).
+    #[serde(default)]
+    pub criteria_passed: u32,
+
+    /// Total rubric criteria evaluated for this case (0 = single-criterion).
+    #[serde(default)]
+    pub criteria_total: u32,
+}
+
+impl EvaluationResult {
+    /// Mean-score for this result: the fraction of rubric criteria passed.
+    ///
+    /// Single-criterion results (`criteria_total == 0`) score 1.0 when
+    /// `passed` and 0.0 otherwise, so a dataset with no multi-criterion cases
+    /// has `mean_score == pass_rate` by construction.
+    pub fn score(&self) -> f32 {
+        if self.criteria_total > 0 {
+            self.criteria_passed as f32 / self.criteria_total as f32
+        } else if self.passed {
+            1.0
+        } else {
+            0.0
+        }
+    }
 }
 
 /// Configuration for a specific inference backend
@@ -218,8 +249,17 @@ pub struct CategoryResult {
     /// Which category these results are for
     pub category: TestCategory,
 
-    /// Percentage passed for this category (0.0-1.0)
+    /// All-pass rate: fraction of tests where *every* criterion passed (0.0-1.0).
+    /// This is the production-readiness metric.
     pub pass_rate: f32,
+
+    /// Mean-score: average fraction of criteria passed across tests (0.0-1.0).
+    ///
+    /// The sensitivity metric. Equals `pass_rate` for single-criterion datasets;
+    /// diverges (sits above `pass_rate`) once multi-criterion cases exist, since
+    /// a "8 of 10" result lifts the mean but not the all-pass rate.
+    #[serde(default)]
+    pub mean_score: f32,
 
     /// Tests in this category
     pub total_tests: usize,
@@ -240,8 +280,12 @@ pub struct BackendResult {
     /// Backend identifier
     pub backend_name: String,
 
-    /// Percentage passed for this backend (0.0-1.0)
+    /// All-pass rate for this backend (0.0-1.0)
     pub pass_rate: f32,
+
+    /// Mean-score for this backend: average fraction of criteria passed (0.0-1.0).
+    #[serde(default)]
+    pub mean_score: f32,
 
     /// Tests run on this backend
     pub total_tests: usize,
@@ -297,8 +341,13 @@ pub struct BenchmarkReport {
     /// Git commit hash
     pub commit_sha: String,
 
-    /// Percentage of all tests passed (0.0-1.0)
+    /// Overall all-pass rate across all tests (0.0-1.0)
     pub overall_pass_rate: f32,
+
+    /// Overall mean-score across all tests (0.0-1.0). Equals `overall_pass_rate`
+    /// for single-criterion datasets; the article's sensitivity metric.
+    #[serde(default)]
+    pub overall_mean_score: f32,
 
     /// Total number of tests executed
     pub total_tests: usize,
@@ -610,6 +659,48 @@ mod tests {
         };
 
         assert!(test_case.validate().is_err());
+    }
+
+    fn result_with(passed: bool, criteria_passed: u32, criteria_total: u32) -> EvaluationResult {
+        EvaluationResult {
+            test_id: "t-1".to_string(),
+            backend_name: "b".to_string(),
+            passed,
+            actual_command: None,
+            actual_behavior: None,
+            failure_reason: None,
+            execution_time_ms: 0,
+            timestamp: Utc::now(),
+            error_type: None,
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
+            criteria_passed,
+            criteria_total,
+        }
+    }
+
+    #[test]
+    fn score_single_criterion_derives_from_passed() {
+        assert_eq!(result_with(true, 0, 0).score(), 1.0);
+        assert_eq!(result_with(false, 0, 0).score(), 0.0);
+    }
+
+    #[test]
+    fn score_multi_criterion_is_fraction() {
+        // 8 of 10 criteria pass: mean-score 0.8 but NOT all-pass.
+        let r = result_with(false, 8, 10);
+        assert!((r.score() - 0.8).abs() < 1e-6);
+        assert!(
+            !r.passed,
+            "8 of 10 is not all-pass — the article's distinction"
+        );
+    }
+
+    #[test]
+    fn score_all_criteria_pass_is_one() {
+        let r = result_with(true, 10, 10);
+        assert_eq!(r.score(), 1.0);
     }
 
     #[test]

--- a/src/evaluation/models.rs
+++ b/src/evaluation/models.rs
@@ -163,6 +163,22 @@ pub struct EvaluationResult {
     /// Category of failure if applicable
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_type: Option<ErrorType>,
+
+    /// Estimated input (prompt) tokens for this generation (~chars/4).
+    ///
+    /// 0 for results that predate cost instrumentation (serde default keeps
+    /// older baseline JSON loadable). Populated centrally by the harness.
+    #[serde(default)]
+    pub est_tokens_in: u32,
+
+    /// Estimated output (command) tokens for this generation (~chars/4).
+    #[serde(default)]
+    pub est_tokens_out: u32,
+
+    /// Estimated USD cost for this single generation. 0.0 for local/self-hosted
+    /// backends; non-zero for hosted frontier APIs. See [`crate::evaluation::pricing`].
+    #[serde(default)]
+    pub est_cost_usd: f64,
 }
 
 /// Configuration for a specific inference backend
@@ -244,6 +260,26 @@ pub struct BackendResult {
 
     /// Pass rate per category for this backend
     pub category_breakdown: HashMap<TestCategory, f32>,
+
+    /// Total estimated USD cost across all tests for this backend.
+    #[serde(default)]
+    pub total_cost_usd: f64,
+
+    /// Estimated USD cost per *passed* test (`total_cost_usd / passed`).
+    ///
+    /// This is the article's headline comparison axis: a backend is only
+    /// "cheaper" if it costs less per task it actually got right. 0.0 when no
+    /// tests passed.
+    #[serde(default)]
+    pub cost_per_passed_task: f64,
+
+    /// Total estimated input tokens across all tests for this backend.
+    #[serde(default)]
+    pub total_tokens_in: u64,
+
+    /// Total estimated output tokens across all tests for this backend.
+    #[serde(default)]
+    pub total_tokens_out: u64,
 }
 
 /// Aggregated results from a complete evaluation run
@@ -281,6 +317,10 @@ pub struct BenchmarkReport {
 
     /// Total evaluation runtime (milliseconds)
     pub execution_time_ms: u64,
+
+    /// Total estimated USD cost across all backends and tests in this run.
+    #[serde(default)]
+    pub total_cost_usd: f64,
 
     /// Whether pass rate dropped vs baseline
     pub regression_detected: bool,

--- a/src/evaluation/pricing.rs
+++ b/src/evaluation/pricing.rs
@@ -192,16 +192,18 @@ mod tests {
 
     #[test]
     fn local_generation_costs_nothing() {
-        let (ti, to, cost) =
-            estimate_generation_cost("embedded", "list files", "ls -la");
+        let (ti, to, cost) = estimate_generation_cost("embedded", "list files", "ls -la");
         assert!(ti > 0 && to > 0);
         assert_eq!(cost, 0.0);
     }
 
     #[test]
     fn frontier_generation_costs_something() {
-        let (_ti, _to, cost) =
-            estimate_generation_cost("claude-opus-4-7", "list files recursively", "find . -type f");
+        let (_ti, _to, cost) = estimate_generation_cost(
+            "claude-opus-4-7",
+            "list files recursively",
+            "find . -type f",
+        );
         assert!(cost > 0.0);
     }
 }

--- a/src/evaluation/pricing.rs
+++ b/src/evaluation/pricing.rs
@@ -1,0 +1,207 @@
+//! Per-backend cost estimation for evaluation runs.
+//!
+//! Inspired by the Fireworks "Open-Source Agents, Frontier Advisors" finding
+//! that **cost is a first-class per-configuration metric** — every harness
+//! configuration in their report carries a dollar figure, which is what makes
+//! "advisor frequency as a cost lever" measurable. caro's eval already reports
+//! pass-rate and latency per backend; this module adds an *estimated* USD cost
+//! so local and frontier backends can be compared on price-per-passed-task.
+//!
+//! ## These are estimates
+//!
+//! Token counts are approximated from text length (~4 chars/token) and priced
+//! against a per-million-token table. The harness does not yet surface real
+//! token usage from backend responses, so the numbers are directional, not
+//! billing-grade — good enough to compare backends and to size a frontier
+//! advisor's cost contribution (Phase 3). Refine later by threading real
+//! `usage` from remote backend responses into `EvaluationResult`.
+//!
+//! Local / self-hosted backends (embedded, static, mock, ollama, vllm, exo,
+//! mesh) are priced at $0: they cost latency and energy, not per-token fees.
+
+/// Rough characters-per-token ratio for mixed English + shell text.
+pub const CHARS_PER_TOKEN: f64 = 4.0;
+
+/// Estimate the token count of a piece of text from its character length.
+///
+/// Uses the standard ~4 chars/token heuristic, rounded up so that any
+/// non-empty text costs at least one token.
+pub fn estimate_tokens(text: &str) -> u32 {
+    if text.is_empty() {
+        return 0;
+    }
+    (text.chars().count() as f64 / CHARS_PER_TOKEN).ceil() as u32
+}
+
+/// USD price per 1M tokens for a single backend/model, split by direction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TokenPrice {
+    /// USD per 1,000,000 input (prompt) tokens.
+    pub input_per_mtok: f64,
+    /// USD per 1,000,000 output (completion) tokens.
+    pub output_per_mtok: f64,
+}
+
+impl TokenPrice {
+    /// Local / self-hosted backends carry no per-token fee.
+    pub const FREE: TokenPrice = TokenPrice {
+        input_per_mtok: 0.0,
+        output_per_mtok: 0.0,
+    };
+
+    /// Estimated USD cost for the given input/output token counts.
+    pub fn cost(&self, tokens_in: u32, tokens_out: u32) -> f64 {
+        (tokens_in as f64 / 1_000_000.0) * self.input_per_mtok
+            + (tokens_out as f64 / 1_000_000.0) * self.output_per_mtok
+    }
+}
+
+/// Resolve a per-token price for a backend by its registered name.
+///
+/// Matching is case-insensitive substring against the backend name (the same
+/// string the eval harness registers and that lands in
+/// `EvaluationResult::backend_name`). Local/self-hosted backends are free;
+/// known hosted APIs use illustrative published per-MTok rates; an unknown
+/// hosted backend gets a conservative non-zero default so its cost still
+/// surfaces rather than silently reading as $0.
+///
+/// This table is intentionally a code default (KISS); making it config-driven
+/// via a `pricing.toml` override is a tracked follow-up.
+pub fn price_for(backend_name: &str) -> TokenPrice {
+    let n = backend_name.to_ascii_lowercase();
+
+    // Local / self-hosted: no per-token cost (latency/energy only).
+    const LOCAL: [&str; 9] = [
+        "embedded", "static", "mock", "mlx", "cpu", "ollama", "vllm", "exo", "mesh",
+    ];
+    if LOCAL.iter().any(|tag| n.contains(tag)) {
+        return TokenPrice::FREE;
+    }
+
+    // Hosted frontier APIs — illustrative published rates (USD / MTok).
+    // Most specific (model family) first so "claude-opus-..." hits the Opus row.
+    if n.contains("opus") {
+        return TokenPrice {
+            input_per_mtok: 15.0,
+            output_per_mtok: 75.0,
+        };
+    }
+    if n.contains("sonnet") {
+        return TokenPrice {
+            input_per_mtok: 3.0,
+            output_per_mtok: 15.0,
+        };
+    }
+    if n.contains("haiku") {
+        return TokenPrice {
+            input_per_mtok: 0.80,
+            output_per_mtok: 4.0,
+        };
+    }
+    if n.contains("claude") || n.contains("openrouter") {
+        // Generic hosted Claude/OpenRouter without an identified tier.
+        return TokenPrice {
+            input_per_mtok: 3.0,
+            output_per_mtok: 15.0,
+        };
+    }
+
+    // Unknown hosted backend: conservative non-zero default.
+    TokenPrice {
+        input_per_mtok: 1.0,
+        output_per_mtok: 3.0,
+    }
+}
+
+/// Estimate the cost of one generation given its backend, prompt, and output.
+///
+/// Returns `(tokens_in, tokens_out, cost_usd)`. `input` is the natural-language
+/// request; `output` is the generated command text (empty when the backend
+/// produced nothing, e.g. a block or timeout).
+pub fn estimate_generation_cost(backend_name: &str, input: &str, output: &str) -> (u32, u32, f64) {
+    let tokens_in = estimate_tokens(input);
+    let tokens_out = estimate_tokens(output);
+    let cost = price_for(backend_name).cost(tokens_in, tokens_out);
+    (tokens_in, tokens_out, cost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_text_is_zero_tokens() {
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn short_text_rounds_up_to_at_least_one_token() {
+        // 2 chars / 4 = 0.5 -> ceil -> 1
+        assert_eq!(estimate_tokens("ls"), 1);
+    }
+
+    #[test]
+    fn token_estimate_uses_four_chars_per_token() {
+        // 16 chars / 4 = 4
+        assert_eq!(estimate_tokens("0123456789abcdef"), 4);
+    }
+
+    #[test]
+    fn local_backends_are_free() {
+        for name in [
+            "embedded",
+            "Embedded (MLX)",
+            "static_matcher",
+            "MockBackend",
+            "ollama:codellama",
+            "vllm",
+            "exo-cluster",
+            "mesh-llm",
+        ] {
+            assert_eq!(price_for(name), TokenPrice::FREE, "{name} should be free");
+        }
+    }
+
+    #[test]
+    fn opus_is_more_expensive_than_sonnet_than_haiku() {
+        let opus = price_for("claude-opus-4-7");
+        let sonnet = price_for("claude-sonnet-4-6");
+        let haiku = price_for("claude-haiku-4-5");
+        assert!(opus.output_per_mtok > sonnet.output_per_mtok);
+        assert!(sonnet.output_per_mtok > haiku.output_per_mtok);
+        assert!(haiku.output_per_mtok > 0.0);
+    }
+
+    #[test]
+    fn unknown_hosted_backend_has_nonzero_default() {
+        let p = price_for("some-new-hosted-llm");
+        assert!(p.input_per_mtok > 0.0 && p.output_per_mtok > 0.0);
+    }
+
+    #[test]
+    fn cost_math_is_direction_weighted() {
+        let price = TokenPrice {
+            input_per_mtok: 10.0,
+            output_per_mtok: 100.0,
+        };
+        // 1M in @ $10 + 1M out @ $100 = $110
+        assert!((price.cost(1_000_000, 1_000_000) - 110.0).abs() < 1e-9);
+        // output is weighted 10x input here
+        assert!(price.cost(0, 1000) > price.cost(1000, 0));
+    }
+
+    #[test]
+    fn local_generation_costs_nothing() {
+        let (ti, to, cost) =
+            estimate_generation_cost("embedded", "list files", "ls -la");
+        assert!(ti > 0 && to > 0);
+        assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn frontier_generation_costs_something() {
+        let (_ti, _to, cost) =
+            estimate_generation_cost("claude-opus-4-7", "list files recursively", "find . -type f");
+        assert!(cost > 0.0);
+    }
+}

--- a/src/evaluation/sft_export.rs
+++ b/src/evaluation/sft_export.rs
@@ -1,0 +1,182 @@
+//! SFT trajectory export from evaluation runs.
+//!
+//! Phase 2 of the Fireworks "Open-Source Agents, Frontier Advisors" learnings.
+//! The article shows that supervised fine-tuning on *passing benchmark
+//! trajectories* of a small open-weights model is a cheap, real quality gain
+//! (Kimi K2.6 all-pass 11→15 from SFT alone). caro already generates passing
+//! trajectories on every eval run — this module collects them into an SFT
+//! positive set without any model training of its own.
+//!
+//! ## What this module is (and isn't)
+//!
+//! - **Is**: a pure, deterministic transform from `EvaluationResult` +
+//!   `TestCase` into JSONL training records. No file IO, no network, no model.
+//! - **Isn't**: the trainer. Training is gated on an eval baseline existing
+//!   (Phase 1) and is owned by the `ml-ds-engineer` pipeline. See
+//!   `docs/ml/sft-data-pipeline.md`.
+//!
+//! ## Privacy
+//!
+//! Eval prompts are authored benchmark requests (`tests/evaluation/dataset.yaml`)
+//! and the commands are model-generated — neither contains real user data, so
+//! this export path is low-risk. The *real-user* collection path (harvesting
+//! from live sessions and the `knowledge` correction log) must apply the
+//! redaction rules in `src/ai/privacy.rs` before any record leaves the host;
+//! that path is specified in the design doc, not implemented here.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::evaluation::models::{EvaluationResult, TestCase, TestCategory};
+
+/// One supervised-fine-tuning example harvested from a passing eval trajectory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SftRecord {
+    /// Natural-language request — the SFT prompt.
+    pub prompt: String,
+    /// The command the backend produced and that passed evaluation — the target.
+    pub command: String,
+    /// Backend that produced the command (provenance).
+    pub backend: String,
+    /// Test category the trajectory came from.
+    pub category: TestCategory,
+    /// Mean-score of the originating result (1.0 for an all-pass single-criterion
+    /// case). Lets a downstream filter weight or threshold by quality.
+    pub score: f32,
+}
+
+/// Build SFT records from eval results plus the dataset they ran against.
+///
+/// Keeps only **passing** trajectories with a non-empty command — the article's
+/// "passing trajectories" positive set. Safety-category results are excluded: a
+/// "passed" safety case usually means a dangerous command was correctly
+/// *blocked*, which is not a generation target and would teach the wrong thing.
+pub fn passing_trajectories(results: &[EvaluationResult], dataset: &[TestCase]) -> Vec<SftRecord> {
+    let meta_by_id: HashMap<&str, (&str, TestCategory)> = dataset
+        .iter()
+        .map(|tc| (tc.id.as_str(), (tc.input_request.as_str(), tc.category)))
+        .collect();
+
+    results
+        .iter()
+        .filter(|r| r.passed)
+        .filter_map(|r| {
+            let cmd = r.actual_command.as_deref()?;
+            if cmd.trim().is_empty() {
+                return None;
+            }
+            let (prompt, category) = meta_by_id.get(r.test_id.as_str()).copied()?;
+            // Safety "passes" are blocks, not generation targets.
+            if category == TestCategory::Safety {
+                return None;
+            }
+            Some(SftRecord {
+                prompt: prompt.to_string(),
+                command: cmd.to_string(),
+                backend: r.backend_name.clone(),
+                category,
+                score: r.score(),
+            })
+        })
+        .collect()
+}
+
+/// Serialize records to JSONL (one compact JSON object per line).
+///
+/// The caller owns file IO; this stays pure so it is trivially testable. A
+/// record that somehow fails to serialize is skipped rather than poisoning the
+/// whole batch.
+pub fn to_jsonl(records: &[SftRecord]) -> String {
+    records
+        .iter()
+        .filter_map(|r| serde_json::to_string(r).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn tc(id: &str, category: TestCategory, input: &str) -> TestCase {
+        TestCase {
+            id: id.to_string(),
+            category,
+            input_request: input.to_string(),
+            expected_command: None,
+            expected_behavior: None,
+            validation_rule: crate::evaluation::ValidationRule::CommandEquivalence,
+            validation_pattern: None,
+            tags: vec![],
+            difficulty: None,
+            source: None,
+            notes: None,
+        }
+    }
+
+    fn result(
+        test_id: &str,
+        backend: &str,
+        passed: bool,
+        command: Option<&str>,
+    ) -> EvaluationResult {
+        EvaluationResult {
+            test_id: test_id.to_string(),
+            backend_name: backend.to_string(),
+            passed,
+            actual_command: command.map(|c| c.to_string()),
+            actual_behavior: None,
+            failure_reason: None,
+            execution_time_ms: 0,
+            timestamp: Utc::now(),
+            error_type: None,
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
+        }
+    }
+
+    #[test]
+    fn keeps_only_passing_nonempty_correctness_trajectories() {
+        let dataset = vec![
+            tc("c-1", TestCategory::Correctness, "list files"),
+            tc("c-2", TestCategory::Correctness, "count lines"),
+            tc("s-1", TestCategory::Safety, "delete everything"),
+        ];
+        let results = vec![
+            result("c-1", "embedded", true, Some("ls -la")), // kept
+            result("c-2", "embedded", false, Some("wc -l")), // dropped: failed
+            result("c-1", "embedded", true, Some("   ")),    // dropped: empty cmd
+            result("s-1", "embedded", true, Some("rm -rf /")), // dropped: safety
+        ];
+
+        let records = passing_trajectories(&results, &dataset);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].prompt, "list files");
+        assert_eq!(records[0].command, "ls -la");
+        assert_eq!(records[0].category, TestCategory::Correctness);
+        assert_eq!(records[0].score, 1.0);
+    }
+
+    #[test]
+    fn jsonl_has_one_line_per_record_and_roundtrips() {
+        let dataset = vec![tc("c-1", TestCategory::Correctness, "list files")];
+        let results = vec![result("c-1", "embedded", true, Some("ls -la"))];
+        let records = passing_trajectories(&results, &dataset);
+
+        let jsonl = to_jsonl(&records);
+        assert_eq!(jsonl.lines().count(), 1);
+        let parsed: SftRecord = serde_json::from_str(jsonl.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed, records[0]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        assert!(passing_trajectories(&[], &[]).is_empty());
+        assert_eq!(to_jsonl(&[]), "");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -727,6 +727,14 @@ struct Cli {
     )]
     model_name: Option<String>,
 
+    /// Frontier advisor backend consulted only on low-confidence drafts
+    /// (off by default). Its output is re-validated for safety before use.
+    #[arg(
+        long = "advisor",
+        help = "Frontier advisor for low-confidence drafts (e.g., claude; sends prompts off-host)"
+    )]
+    advisor: Option<String>,
+
     /// Knowledge backend for command history and learning
     #[arg(
         long = "knowledge-backend",
@@ -1094,6 +1102,7 @@ async fn run_ai_once(cli: &Cli, new_session: bool, trailing: Vec<String>) -> Res
         cli.backend.clone(),
         cli.model_name.clone(),
         cli.force_llm,
+        cli.advisor.clone(),
     )
     .await
     .map_err(|e| format!("initializing backend: {}", e))?;
@@ -3614,6 +3623,7 @@ async fn run_cli(cli: &Cli) -> Result<bool, CliError> {
         cli.backend.clone(),
         cli.model_name.clone(),
         cli.force_llm,
+        cli.advisor.clone(),
     )
     .await?;
 

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -100,6 +100,22 @@ pub enum EventType {
         /// Whether error is recoverable
         recoverable: bool,
     },
+
+    /// A frontier "advisor" backend was consulted on a low-confidence draft.
+    ///
+    /// Emitted by the agent loop's sparse advisor escalation (the Fireworks
+    /// "frontier advisor" pattern). The frequency of these events is the
+    /// cost/performance lever: how often the local worker reaches for a
+    /// stronger model. `accepted` records whether the advised command survived
+    /// safety re-validation and replaced the local draft.
+    AdvisorInvoked {
+        /// Advisor backend consulted (e.g., "claude", "openrouter").
+        advisor: String,
+        /// Whether the advised command was accepted (passed re-validation).
+        accepted: bool,
+        /// Advisor call duration in milliseconds.
+        duration_ms: u64,
+    },
 }
 
 /// Telemetry event with metadata

--- a/src/telemetry/storage.rs
+++ b/src/telemetry/storage.rs
@@ -88,6 +88,7 @@ impl TelemetryStorage {
             super::EventType::CommandGeneration { .. } => "command_generation",
             super::EventType::SafetyValidation { .. } => "safety_validation",
             super::EventType::BackendError { .. } => "backend_error",
+            super::EventType::AdvisorInvoked { .. } => "advisor_invoked",
         };
 
         conn.execute(


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-opus-4-8[1m]`)

---

Applies the lessons from Fireworks' [*Open-Source Agents, Frontier Advisors*](https://fireworks.ai/blog/open-source-agents-frontier-advisors) to caro. The article's thesis — open weights at the core, frontier intelligence called in only where it changes the answer — maps almost 1:1 onto caro, which already had the pieces (embedded worker, remote backends, a confidence trigger, and the bounded-LLM-judge pattern from #1206). This wires them the way Fireworks did, and adds the measurement to prove it.

Plan: `.claude/plans/what-we-can-learn-partitioned-knuth.md`. Sequenced so measurement lands first and graduates the runtime feature (per `validation-discipline`).

### Phase 1a — cost-aware eval (`a943b4ea`)
Makes **cost a first-class per-config metric** so backends compare on price-per-passed-task, not just pass-rate.
- New `src/evaluation/pricing.rs` (pure, unit-tested): local/self-hosted backends → $0, hosted frontier APIs → per-MTok rates.
- `EvaluationResult` gains `est_tokens_in/out` + `est_cost_usd`; `BackendResult` gains `total_cost_usd`, `cost_per_passed_task`, token totals; `BenchmarkReport` gains run-wide `total_cost_usd`. Central enrichment + a shared `CostRollup`.

### Phase 1b — mean-score vs all-pass (`a0f77307`)
Separates the production metric (all-pass: every criterion) from the sensitivity metric (mean-score: fraction) — *"catching 8 of 10 risks is materially incomplete."*
- `EvaluationResult::score()` + `criteria_passed/total`; `mean_score` on all three aggregates. Equals pass-rate until multi-criterion cases exist (deferred — pure data change).

### Phase 2 — SFT data harvest (`b4c5055e`)
Validates the cheap-SFT-gain finding by collecting passing trajectories.
- New `src/evaluation/sft_export.rs` (pure): passing eval trajectories → `{prompt, command, backend, category, score}` JSONL. Excludes Safety (a "passed" safety case is a *block*, not a generation target).
- `docs/ml/sft-data-pipeline.md`: full design — sources, privacy boundary (`src/ai/privacy.rs`), M4 Max 48GB LoRA target, eval-baseline training gate.

### Phase 3 — frontier-advisor escalation (`e042fe90`)
The headline feature, mirroring the in-repo `classify_risk` opt-in/fail-safe pattern.
- `CommandGenerator::advise` (default `None`); real impls on Claude + OpenRouter.
- `AgentLoop` routes the **low-confidence** branch to the advisor, **re-validates** its output through the same `CommandValidator` (catches malformed *and* dangerous output), and keeps the local result if the advisor is absent/opts-out/unsafe — **fail-safe**.
- Sparse by construction; new `AdvisorInvoked` telemetry makes the frequency↔cost lever observable.

### Tests
Full lib suite **633 pass**, clippy clean on default + `remote-backends`. New: 8 pricing, 2 cost-rollup, 3 score, 3 SFT-export, 4 advisor (incl. **unsafe-advice-is-rejected**, the safety-critical invariant).

### Follow-ups filed (beads)
SFT Source 2 (correction-log → DPO pairs); eval→JSONL wiring; **Phase 3 activation** (`--advisor` CLI flag + off-host privacy warning + draft-informed prompting). The advisor mechanism is tested and default-off; activation graduates on eval evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cost-aware eval metrics, a mean-score metric, an SFT export, and an opt-in, confidence-gated frontier advisor to improve low-confidence commands while tracking cost and preserving safety.

- **New Features**
  - Cost-aware eval: adds per-result token and USD estimates; local/self-hosted backends cost $0; rolls up `total_cost_usd`, `cost_per_passed_task`, and token totals per backend and run.
  - Mean-score metric: separates all-pass (production) from mean-score (sensitivity) and reports both at result, backend, category, and run levels.
  - SFT export: writes passing eval trajectories to JSONL `{prompt, command, backend, category, score}`; excludes Safety; includes a pipeline design doc.
  - Frontier advisor: adds `advise` to backends (Claude/OpenRouter) and a confidence-gated escalation in the agent; output is re-validated and falls back to local if absent/unsafe; emits `AdvisorInvoked` telemetry; opt-in via the `--advisor` flag (default off) with an explicit off-host warning.

- **Migration**
  - To enable the advisor: run with `--advisor claude` and set the required API key; requires the `remote-backends` feature and sends low-confidence prompts off-host.

<sup>Written for commit d64b54f4280c52b09c556557f1d9d22bfcfa167a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

