### PR TITLE
fix: support telemetry config keys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2226,6 +2226,11 @@ fn handle_config_command(command: ConfigCommands) -> Result<(), String> {
                     "disabled"
                 }
             );
+            println!(
+                "  {}: {}",
+                "telemetry.first_run".cyan(),
+                config.telemetry.first_run
+            );
             println!();
             println!(
                 "{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2099,9 +2099,23 @@ fn handle_config_command(command: ConfigCommands) -> Result<(), String> {
                     config.safety_level = level;
                     println!("{} Set safety level to '{:?}'", "✓".green(), level);
                 }
+                "telemetry.enabled" | "telemetry_enabled" => {
+                    let enabled: bool = value.parse().map_err(|_| {
+                        format!("Invalid boolean for telemetry.enabled '{}'", value)
+                    })?;
+                    config.telemetry.enabled = enabled;
+                    println!("{} Set telemetry.enabled to '{}'", "✓".green(), enabled);
+                }
+                "telemetry.first_run" | "telemetry_first_run" => {
+                    let first_run: bool = value.parse().map_err(|_| {
+                        format!("Invalid boolean for telemetry.first_run '{}'", value)
+                    })?;
+                    config.telemetry.first_run = first_run;
+                    println!("{} Set telemetry.first_run to '{}'", "✓".green(), first_run);
+                }
                 _ => {
                     return Err(format!(
-                        "Unknown config key '{}'. Valid keys: backend, model-name, shell, safety",
+                        "Unknown config key '{}'. Valid keys: backend, model-name, shell, safety, telemetry.enabled, telemetry.first_run",
                         key
                     ));
                 }
@@ -2144,9 +2158,23 @@ fn handle_config_command(command: ConfigCommands) -> Result<(), String> {
                 "safety" => {
                     println!("{}: {:?}", "safety".bold(), config.safety_level);
                 }
+                "telemetry.enabled" | "telemetry_enabled" => {
+                    println!(
+                        "{}: {}",
+                        "telemetry.enabled".bold(),
+                        config.telemetry.enabled
+                    );
+                }
+                "telemetry.first_run" | "telemetry_first_run" => {
+                    println!(
+                        "{}: {}",
+                        "telemetry.first_run".bold(),
+                        config.telemetry.first_run
+                    );
+                }
                 _ => {
                     return Err(format!(
-                        "Unknown config key '{}'. Valid keys: backend, model-name, shell, safety",
+                        "Unknown config key '{}'. Valid keys: backend, model-name, shell, safety, telemetry.enabled, telemetry.first_run",
                         key
                     ));
                 }

--- a/tests/config_telemetry_cli.rs
+++ b/tests/config_telemetry_cli.rs
@@ -1,0 +1,90 @@
+//! Black-box CLI tests for `caro config set/get telemetry.*`.
+//!
+//! Regression test for #1292: the consent flow advertises
+//! `caro config set telemetry.enabled false`, so the CLI needs to accept,
+//! persist, and display telemetry config keys consistently.
+
+use assert_cmd::Command;
+
+fn caro_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_caro"));
+    cmd.env("HOME", home).env_remove("XDG_CONFIG_HOME");
+    cmd
+}
+
+#[test]
+fn config_set_and_get_telemetry_enabled() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    caro_cmd(home.path())
+        .args(["config", "set", "telemetry.enabled", "false"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.enabled"));
+
+    caro_cmd(home.path())
+        .args(["config", "get", "telemetry.enabled"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.enabled: false"));
+}
+
+#[test]
+fn config_set_and_get_telemetry_first_run() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    caro_cmd(home.path())
+        .args(["config", "set", "telemetry.first_run", "false"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.first_run"));
+
+    caro_cmd(home.path())
+        .args(["config", "get", "telemetry.first_run"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.first_run: false"));
+}
+
+#[test]
+fn config_set_telemetry_underscore_alias() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    caro_cmd(home.path())
+        .args(["config", "set", "telemetry_enabled", "false"])
+        .assert()
+        .success();
+
+    caro_cmd(home.path())
+        .args(["config", "get", "telemetry_enabled"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.enabled: false"));
+}
+
+#[test]
+fn config_set_telemetry_rejects_invalid_boolean() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    caro_cmd(home.path())
+        .args(["config", "set", "telemetry.enabled", "not-a-bool"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Invalid boolean"));
+}
+
+#[test]
+fn config_show_includes_telemetry_first_run() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    caro_cmd(home.path())
+        .args(["config", "set", "telemetry.first_run", "false"])
+        .assert()
+        .success();
+
+    caro_cmd(home.path())
+        .args(["config", "show"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("telemetry.first_run"));
+}


### PR DESCRIPTION
## Description

Support the telemetry config keys that the consent screen already advertises.

### Motivation

`caro config set telemetry.enabled false` was documented to users but rejected as an unknown key. That made the post-consent opt-out path broken.

### Changes Made

- add `telemetry.enabled` handling to `config set` and `config get`
- add `telemetry.first_run` handling to `config set` and `config get`
- update the unknown-key error text to list the telemetry keys

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code restructuring without changing behavior)
- [ ] Documentation update (changes to docs, comments, or guides)
- [ ] Performance improvement (makes code faster or more efficient)
- [ ] Test coverage (adds or improves tests)
- [ ] CI/CD or tooling (changes to build, release, or development tools)

---

## Checklist

### Code Quality

- [x] I have run `cargo fmt --all` (code is properly formatted)
- [ ] I have run `cargo clippy -- -D warnings` (no clippy warnings)
- [ ] I have run `cargo test` (all tests pass)
- [ ] I have run `cargo audit` (no security vulnerabilities in dependencies)

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added contract tests for new public APIs (if applicable)
- [ ] I have added integration tests for cross-module workflows (if applicable)
- [ ] I have verified performance requirements are met (if applicable)

### Documentation

- [ ] I have added rustdoc comments for new public APIs
- [ ] I have updated relevant documentation (README, specs, guides)
- [ ] I have added examples to demonstrate new functionality (if applicable)
- [ ] I have updated the CHANGELOG.md with my changes

### TDD Workflow

- [ ] I followed the Red-Green-Refactor cycle (if implementing new features)
- [ ] I wrote failing tests before implementing the solution
- [ ] I verified tests with `cargo watch -x test` during development

---

## Breaking Changes

### API Changes

None.

### Migration Guide

N/A

### Deprecation Plan

N/A

---

## Related Issues and Specs

- Closes #1292
- Related to #<!-- issue number -->
- Implements spec: `specs/<!-- feature-id -->/spec.md`
- Addresses contract: `specs/<!-- feature-id -->/contracts/<!-- contract-name -->.md`

---

## Performance Impact

### Benchmarks

N/A

### Binary Size

N/A

### Memory Usage

N/A

---

## Screenshots / Examples

### Before

```bash
$ caro config set telemetry.enabled false
Error: Unknown config key 'telemetry.enabled'. Valid keys: backend, model-name, shell, safety
```

### After

```bash
$ caro config set telemetry.enabled false
✓ Set telemetry.enabled to 'false'
telemetry.enabled: false
```

---

## Testing Evidence

### Test Output

```bash
$ cargo fmt --check
$ cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 54s

$ cargo build --bin caro -q
$ ./target/debug/caro config set telemetry.enabled false
✓ Set telemetry.enabled to 'false'
$ ./target/debug/caro config get telemetry.enabled
telemetry.enabled: false
$ ./target/debug/caro config set telemetry.first_run false
✓ Set telemetry.first_run to 'false'
$ ./target/debug/caro config get telemetry.first_run
telemetry.first_run: false
```

### Manual Testing

- [x] Tested on macOS (Apple Silicon / Intel)
- [ ] Tested on Linux (Ubuntu / Fedora / Arch)
- [ ] Tested on Windows (10 / 11)
- [ ] Tested with different backends (MLX / vLLM / Ollama / Mock)
- [x] Tested edge cases and error conditions

---

## Additional Context

### Technical Decisions

I kept the fix narrowly scoped to the existing `config set` / `config get` dispatch so the advertised CLI path works without changing the broader config schema or telemetry prompt flow.

### Future Work

Adding focused tests around config key dispatch would help prevent future drift between documented keys and the CLI implementation.

### Questions for Reviewers

None.

---

## Reviewer Checklist

- [ ] Code follows Rust best practices and project conventions
- [ ] Tests are comprehensive and follow TDD principles
- [ ] Documentation is clear and complete
- [ ] Changes align with project specifications
- [ ] Performance impact is acceptable
- [ ] Breaking changes are justified and documented
- [ ] Security implications have been considered

---

**By submitting this PR, I confirm that:**

- [x] My code follows the style guidelines of this project (see [AGENTS.md](https://github.com/wildcard/caro/blob/main/AGENTS.md))
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](https://github.com/wildcard/caro/blob/main/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/wildcard/caro/blob/main/CODE_OF_CONDUCT.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables telemetry config keys in the `caro` CLI so users can opt out after consent. Aligns `config set/get/show` with the consent screen and fixes #1292.

- **Bug Fixes**
  - Support `telemetry.enabled` and `telemetry.first_run` in `config set` and `config get` (accept `telemetry_enabled` and `telemetry_first_run`).
  - Include `telemetry.first_run` in `config show`.
  - Update unknown-key errors to list telemetry keys.
  - Add CLI tests for aliases, invalid booleans, and `config show` output.

<sup>Written for commit 34f2e370c461d2600446d7adcc8b9020ab44880d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

