### PR TITLE
docs(groom): warn runner has no timeout; avoid false daemon-wedged reports

### DIFF
--- a/.claude/commands/caro-backlog-groom.md
+++ b/.claude/commands/caro-backlog-groom.md
@@ -16,6 +16,18 @@ git fetch origin --prune --tags --quiet
 bd stats
 ```
 
+> **Runner constraint — do NOT wrap `bd` in `timeout`.** The scheduled runner
+> has no `timeout`/`gtimeout` on `PATH` (GNU coreutils is not installed). A
+> command like `timeout 25 bd stats` fails with `command not found`, and a
+> `|| echo STILL_STUCK`-style fallback then reads as a daemon hang — this
+> produced a **false P0 "daemon wedged" report** on #792 (2026-07-11 cycle)
+> when the daemon was healthy (`bd stats` returns in <1s, exit 0). Call `bd`
+> directly. If you must bound a call, use a Bash background-job + poll guard,
+> not `timeout`. Also: run orphan-branch `bd create`s **one per Bash call**
+> (or in the background) — a multi-branch create loop can exceed the 2-minute
+> tool wall on a single slow Dolt write and get killed mid-batch. Tracked:
+> `caro-xk0.104`.
+
 ## Phase A — Scan sources (parallel where possible)
 
 Produce four JSON streams:


### PR DESCRIPTION
## What

Adds a **Runner constraint** callout to `.claude/commands/caro-backlog-groom.md` telling future grooming runs **not to wrap `bd` in `timeout`**.

## Why

During the 2026-07-11 06:xx grooming cycle, the routine reported a false **P0 "daemon wedged"** on #792 and told a human to recover a healthy daemon. Root cause: the scheduled runner has no `timeout`/`gtimeout` on `PATH`, so every `timeout N bd …` diagnostic failed with `command not found` and tripped a `|| echo STILL_STUCK` fallback that was misread as a hang. Verified after: `bd stats` returns in <1s (exit 0); the daemon was never stuck. The only genuine issue was an orphan-branch `bd create` loop hitting the 2-min Bash-tool wall on a slow Dolt write.

## Change

Documentation only — one callout after Preflight. No routine logic changed (the routine never contained `timeout`; the wrapping was an execution-time choice). Guidance: call `bd` directly, use a background+poll guard if a bound is truly needed, and run orphan-branch creates one-per-call.

Follow-up bead: `caro-xk0.104`. Correction comment: #792 (comment 4950023582).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a runner constraint callout in `.claude/commands/caro-backlog-groom.md` to stop wrapping `bd` with `timeout` on scheduled runs. Prevents false “daemon wedged” alerts on runners without `timeout`/`gtimeout`, aligned with `caro-xk0.104`.

- **Migration**
  - Call `bd` directly.
  - If you need a bound, use a background job + poll guard (not `timeout`).
  - Run orphan-branch `bd create` one per call (or in background) to avoid the 2‑min tool wall.

<sup>Written for commit d94004257cd815c8165f60c9ee360f6965deba49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

