### PR TITLE
fix(safety): let allowlists override broad rm patterns, keep catastrophic core

### DIFF
--- a/src/safety/mod.rs
+++ b/src/safety/mod.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::models::{RiskJudgment, RiskLevel, SafetyLevel, ShellType, SuggestedRouting};
+use once_cell::sync::Lazy;
 
 pub use cve_patterns::{get_cve_compiled_patterns_for_shell, CVE_COMPILED};
 pub use patterns::{
@@ -46,6 +47,53 @@ pub use patterns::{
 /// User patterns longer than this are rejected by [`validate_user_pattern`].
 /// Built-in patterns are not subject to this cap.
 pub const MAX_USER_PATTERN_LENGTH: usize = 512;
+
+/// The **catastrophic core**: a deliberately narrow set of unrecoverable
+/// operations that an allowlist may NEVER re-enable.
+///
+/// A user-supplied allowlist entry is a statement of trust for a *specific,
+/// scoped* command (e.g. `rm -rf /tmp/myapp_\d+`). Honouring that trust is the
+/// whole point of the allowlist. But some commands are catastrophic regardless
+/// of intent — deleting `/`, wiping a raw disk, formatting a filesystem, a fork
+/// bomb — and no allowlist should be able to turn them back on.
+///
+/// This list is intentionally *narrower* than the full set of Critical
+/// built-in patterns. The Critical `rm -rf /` patterns in [`patterns`] are
+/// unanchored and also match benign scoped absolute paths like
+/// `rm -rf /tmp/myapp_123`; gating the allowlist on "matches any Critical
+/// pattern" therefore made every scoped `rm -rf /abs/path` un-allowlistable,
+/// breaking the allowlist contract (see `test_allowlist_functionality`).
+/// Matching against this focused list instead lets scoped operations be
+/// allowlisted while keeping the genuinely unrecoverable forms locked.
+static CATASTROPHIC_CORE_PATTERNS: Lazy<Vec<regex::Regex>> = Lazy::new(|| {
+    [
+        // Recursive deletion whose target IS root / home / a top-level glob
+        // (target is exactly `/`, `~`, `$HOME`, `/*`, `~/*`, or `*` — followed
+        // by a separator or end-of-command, NOT a subpath like `/tmp`).
+        r"rm\s+(-\S+\s+)*(/|~|\$HOME|/\*|~/\*|\*)(\s|;|&|\||$)",
+        // Explicit root-protection bypass — never legitimate.
+        r"rm\s+.*--no-preserve-root",
+        // Raw block-device overwrite (either argument order).
+        r"dd\s+.*of=/dev/(sd|hd|nvme|disk|da)",
+        r"dd\s+.*if=/dev/(zero|random|urandom).*of=/dev/(sd|hd|nvme|disk|da)",
+        // Formatting a real block device.
+        r"mkfs(\.\w+)?\s+.*/dev/(sd|hd|nvme|disk|da)",
+        // Classic fork bomb.
+        r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:",
+    ]
+    .iter()
+    .map(|p| regex::Regex::new(p).expect("catastrophic-core regex must compile"))
+    .collect()
+});
+
+/// Returns `true` when `command` matches the catastrophic core — the set of
+/// operations an allowlist must never re-enable. See
+/// [`CATASTROPHIC_CORE_PATTERNS`].
+fn matches_catastrophic_core(command: &str) -> bool {
+    CATASTROPHIC_CORE_PATTERNS
+        .iter()
+        .any(|re| re.is_match(command))
+}
 
 /// Maximum length of a user-supplied pattern description.
 pub const MAX_USER_PATTERN_DESCRIPTION_LENGTH: usize = 200;
@@ -480,22 +528,21 @@ impl SafetyValidator {
             });
         }
 
-        // First pass: detect whether the command matches a built-in or CVE
-        // pattern at Critical risk. Critical built-ins are NEVER bypassed by
-        // user-supplied allowlists — `rm -rf /` is dangerous regardless of
-        // what's in patterns.toml. Without this guard a permissive
-        // `allowlist_patterns = ["^rm"]` would silently re-enable disaster.
+        // First pass: an allowlist entry expresses trust for a specific, scoped
+        // command and may override even a Critical built-in match — EXCEPT for
+        // the catastrophic core (`rm -rf /`, raw-disk wipe, mkfs, fork bomb,
+        // `--no-preserve-root`), which no allowlist can re-enable.
+        //
+        // Gating on the catastrophic core rather than "any Critical match" is
+        // deliberate: the Critical `rm -rf /` patterns are unanchored and also
+        // match benign scoped paths like `rm -rf /tmp/myapp_123`, so the old
+        // "any Critical match blocks the allowlist" rule made every scoped
+        // `rm -rf /abs/path` un-allowlistable and broke the allowlist contract.
         let built_in_patterns = patterns::get_compiled_patterns_for_shell(shell);
         let cve_compiled = cve_patterns::get_cve_compiled_patterns_for_shell(shell);
-        let has_critical_builtin_or_cve_match = built_in_patterns
-            .iter()
-            .chain(cve_compiled.iter())
-            .any(|(regex, level, _desc, _)| {
-                *level == RiskLevel::Critical && Self::is_dangerous_in_context(command, regex)
-            });
 
-        // Check allowlist patterns only if no Critical built-in/CVE match.
-        if !has_critical_builtin_or_cve_match {
+        // Check allowlist patterns only if the command is not catastrophic-core.
+        if !matches_catastrophic_core(command) {
             for allow_pattern in &self.config.allowlist_patterns {
                 if let Ok(regex) = regex::Regex::new(allow_pattern) {
                     if regex.is_match(command) {

--- a/tests/safety_validator_contract.rs
+++ b/tests/safety_validator_contract.rs
@@ -322,6 +322,39 @@ async fn test_allowlist_functionality() {
 }
 
 #[tokio::test]
+async fn test_allowlist_cannot_bypass_catastrophic_core() {
+    // CONTRACT: An allowlist expresses trust for a scoped command, but it must
+    // NEVER be able to re-enable the catastrophic core (root deletion, raw-disk
+    // wipe, mkfs, fork bomb, --no-preserve-root). Even an explicit, matching
+    // allowlist entry must not allow these through.
+    let catastrophic = [
+        r"rm -rf /",
+        r"rm -rf /*",
+        r"rm -rf ~",
+        r"rm -rf --no-preserve-root /",
+        r"dd if=/dev/zero of=/dev/sda",
+        r"mkfs.ext4 /dev/sda",
+    ];
+
+    for cmd in catastrophic {
+        let mut config = SafetyConfig::strict();
+        // Deliberately allowlist the exact command — this must still not help.
+        config.add_allowlist_pattern(&regex::escape(cmd));
+        let validator = SafetyValidator::new(config).unwrap();
+
+        let result = validator
+            .validate_command(cmd, ShellType::Bash)
+            .await
+            .unwrap();
+
+        assert!(
+            !result.allowed,
+            "Catastrophic-core command must stay blocked even when allowlisted: {cmd:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_validation_performance() {
     // CONTRACT: Validation should be fast (<100ms for typical commands)
     let validator = SafetyValidator::new(SafetyConfig::moderate()).unwrap();


### PR DESCRIPTION
## Problem (caro-xk0.105 — main CI red)

`safety_validator_contract::test_allowlist_functionality` fails on `main` (and therefore on every PR). Repro:

```
cargo test --test safety_validator_contract test_allowlist_functionality
# panicked at tests/safety_validator_contract.rs:314: "Allowlisted pattern should be allowed"
```

## Root cause

PR #1110 (2026-05-16) added a guard so any command matching a **Critical** built-in pattern can never be overridden by an allowlist — to stop someone allowlisting `rm -rf /`. But the Critical `rm -rf /` regexes are **unanchored** (`rm\s+-rf\s+/` matches any `rm -rf /absolute/path`), so the guard also blocked benign scoped paths like `rm -rf /tmp/myapp_123`. Result: **no scoped `rm -rf /abs/path` could ever be allowlisted**, contradicting the allowlist contract.

## Fix

Replace the "any Critical match blocks the allowlist" rule with a narrow, explicit **catastrophic-core** list that an allowlist can never re-enable: root/home/glob deletion, `--no-preserve-root`, raw-disk `dd`, `mkfs` on a device, fork bomb. Scoped Critical matches remain allowlist-overridable.

| Command | Allowlisted? | Result |
|---|---|---|
| `rm -rf /tmp/myapp_123` | yes | ✅ allowed |
| `rm -rf /` | yes | 🚫 blocked |
| `rm -rf /other_app` | no | 🚫 blocked |

## Tests
- `test_allowlist_functionality` now passes.
- New `test_allowlist_cannot_bypass_catastrophic_core` locks the floor (root deletion, `/*`, `~`, `--no-preserve-root`, `dd`, `mkfs` stay blocked even when explicitly allowlisted).
- Full `cargo test safety` green (27 passed); `cargo fmt --check` clean; `cargo clippy --lib` exit 0.

Closes caro-xk0.105. Fixes the pre-existing `main` Unit Tests failure noted in the #792 grooming cycle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let allowlists override broad Critical `rm -rf /abs/path` matches again, while a small catastrophic-core (root/home/glob deletion, `--no-preserve-root`, raw-disk `dd`, `mkfs`, fork bomb) stays permanently blocked. Fixes the failing safety allowlist test and unblocks CI; resolves `caro-xk0.105`.

- **Bug Fixes**
  - Replaced the "any Critical match blocks allowlist" guard with a targeted `matches_catastrophic_core` check.
  - Added a focused regex set for catastrophic-core in `src/safety/mod.rs` using `once_cell::sync::Lazy`.
  - Scoped deletions like `rm -rf /tmp/myapp_*` can be allowlisted; true catastrophes remain blocked even if listed.
  - Added `test_allowlist_cannot_bypass_catastrophic_core`; safety test suite now passes.

<sup>Written for commit e6de860f4fa9e216ac38041f5056825a537fb063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

