### PR TITLE
fix(ci): restore green main across unit/lint/security/knowledge jobs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -32,4 +32,20 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+
+    # quick-xml - RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (high severity, DoS-class)
+    # - Quadratic run time checking duplicate attribute names + unbounded
+    #   namespace-declaration allocation.
+    # - Two locked instances, both transitive via the LanceDB knowledge
+    #   feature, both pinned by intermediate deps with no compatible
+    #   quick-xml >=0.41 release yet:
+    #     quick-xml 0.37.5 <- reqsign 0.16.5 (requires quick-xml ^0.37) <-
+    #       opendal 0.55.0 <- lance-io 1.0.1 <- lancedb 0.23.1
+    #     quick-xml 0.38.4 <- object_store 0.12.4 (requires quick-xml ^0.38.0)
+    #       <- lancedb 0.23.1
+    # - `cargo update -p quick-xml --precise 0.41.0` fails for both today.
+    # - Revert: when reqsign and object_store both depend on quick-xml
+    #   >=0.41, or lancedb bumps past both.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3497,9 +3497,9 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -7808,9 +7808,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/audit.toml
+++ b/audit.toml
@@ -64,6 +64,24 @@ ignore = [
     # TRANSITIVE — LanceDB / fastembed / knowledge optional feature
     # -------------------------------------------------------------------------
 
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml quadratic run time on
+    # duplicate-attribute checks + unbounded namespace-declaration allocation
+    # (both high severity, DoS-class). Two locked instances, both transitive
+    # via the LanceDB knowledge feature and both pinned by intermediate deps
+    # that haven't released a quick-xml >=0.41 compatible version yet:
+    #   quick-xml 0.37.5 <- reqsign 0.16.5 (requires quick-xml ^0.37) <-
+    #     opendal 0.55.0 <- lance-io 1.0.1 <- lancedb 0.23.1
+    #   quick-xml 0.38.4 <- object_store 0.12.4 (requires quick-xml ^0.38.0)
+    #     <- lancedb 0.23.1
+    # `cargo update -p quick-xml --precise 0.41.0` fails for both — no
+    # semver-compatible resolution exists today. Confirmed 2026-07-12 while
+    # investigating the red main-branch Security Audit CI job.
+    # Revert: When reqsign and object_store both release versions depending
+    # on quick-xml >=0.41, or when lancedb bumps past both.
+    # Tracked: https://github.com/wildcard/caro/issues/1050
+    { id = "RUSTSEC-2026-0194", reason = "transitive via reqsign/object_store pins in lancedb; no compatible upgrade path yet" },
+    { id = "RUSTSEC-2026-0195", reason = "transitive via reqsign/object_store pins in lancedb; no compatible upgrade path yet" },
+
     # RUSTSEC-2026-0105: core2 0.4.0 yanked and unmaintained.
     # Via fastembed -> image -> ravif -> rav1e -> bitstream-io.
     # No control without updating fastembed. Image codec path; not hot path.

--- a/tests/cli_flag_tests.rs
+++ b/tests/cli_flag_tests.rs
@@ -200,7 +200,10 @@ fn backend_info_lists_known_backends() {
         "--backend-info output should mention 'backend', got:\n{}",
         combined
     );
-    for name in ["static", "embedded", "ollama", "vllm"] {
+    // "static" is intentionally excluded from the roster (#1115): it was
+    // advertised but never actually routable via create_backend, which was
+    // the P0 bug that commit fixed. See backends::CLI_SERVABLE_BACKENDS.
+    for name in ["embedded", "ollama", "vllm"] {
         assert!(
             combined.to_lowercase().contains(name),
             "--backend-info output should list '{}', got:\n{}",

--- a/tests/safety_validator_contract.rs
+++ b/tests/safety_validator_contract.rs
@@ -293,14 +293,22 @@ async fn test_custom_pattern_addition() {
 
 #[tokio::test]
 async fn test_allowlist_functionality() {
-    // CONTRACT: Should support allowlists for trusted commands
+    // CONTRACT: Should support allowlists for trusted commands.
+    //
+    // Uses a High-risk (not Critical) dangerous pattern here on purpose:
+    // since PR #1110, allowlists can never bypass a Critical built-in match
+    // (`rm -rf /` and friends stay blocked no matter what's in
+    // patterns.toml — see tests/custom_patterns_toml.rs for that contract).
+    // `rm -rf /tmp/...` collides with the Critical root-deletion patterns'
+    // unanchored `/` alternative, so it can never demonstrate an allowlist
+    // override; a High-risk system-directory match does.
     let mut config = SafetyConfig::strict();
-    config.add_allowlist_pattern(r"rm -rf /tmp/myapp_\d+"); // Allow cleaning app temp dirs
+    config.add_allowlist_pattern(r"chown\s+\S+\s+/etc/myapp/config\.toml"); // Allow the app's own config
 
     let validator = SafetyValidator::new(config).unwrap();
 
-    let allowed_rm = "rm -rf /tmp/myapp_123";
-    let blocked_rm = "rm -rf /tmp/other_app";
+    let allowed_rm = "chown appuser:appuser /etc/myapp/config.toml";
+    let blocked_rm = "chown appuser:appuser /etc/passwd";
 
     let allowed_result = validator
         .validate_command(allowed_rm, ShellType::Bash)


### PR DESCRIPTION
## Summary

Fixes the 5+ day red-`main` streak (verified against CI run [29179066835](https://github.com/wildcard/caro/actions/runs/29179066835), HEAD `9311c9ec`; reconfirmed by PR #1298 inheriting the same failures on an otherwise-clean diff).

- **Unit Tests (`test_allowlist_functionality`)**: was using `rm -rf /tmp/...` as its allowlist example, which collides with the Critical root-deletion builtin patterns' unanchored `/` alternative. Since PR #1110, Critical built-in matches can never be bypassed by an allowlist — that's intentional (see `tests/custom_patterns_toml.rs::user_pattern_cannot_disable_critical_builtin`). Reworked the test to use a High-risk system-directory pattern instead, which correctly demonstrates allowlist override without touching any shared safety regex (zero blast radius on the many other tests asserting Critical `rm -rf /...` behavior).
- **Unit Tests (`backend_info_lists_known_backends`)**: still expected `static` in the `--backend-info` roster. Commit 2a76cf90 (#1115) intentionally dropped `static` since it was never actually routable via `create_backend` — updated the assertion to match the new intentional roster.
- **Lint & Format / Knowledge Integration / ChromaDB Integration**: all three failed on the exact same root cause — `ethnum 1.5.2` hits `E0512` (transmute size mismatch) under the current rustc. Bumped to `1.5.3` in `Cargo.lock`, fixing all three jobs at once.
- **Security Audit**: 4 real RUSTSEC advisories with fixes available. Bumped `quinn-proto` → `0.11.15` and `crossbeam-epoch` → `0.9.20` (both semver-compatible patch bumps). `quick-xml` (RUSTSEC-2026-0194/0195) can't be bumped past 0.37.x/0.38.x today — it's pinned by `reqsign`/`object_store` in the LanceDB dependency chain with no compatible upgrade released yet — documented with dependency trees and added to the ignore list with revert criteria.

  Side finding: `cargo-audit` only reads `.cargo/audit.toml`, not the more thoroughly documented root `audit.toml` — the root file has been dead config since it was introduced (confirmed by removing it and observing an identical audit result). Kept both in sync for now; filed a follow-up task to consolidate them.

## Test plan

- [x] `cargo test --test safety_validator_contract` — 21 passed, 1 ignored (pre-existing)
- [x] `cargo test --test backend_trait_contract` / `platform_detection_contract` / `config_contract` / `execution_contract` / `cli_flag_tests` — all green, matching the exact CI `unit-tests` job invocation
- [x] `cargo test --lib` — 574 passed
- [x] `cargo test --test custom_patterns_toml` / `cve_enforcement` — confirm the Critical-bypass-immunity contract still holds
- [x] `cargo build --features knowledge --lib` — confirms `ethnum` 1.5.3 compiles clean under this toolchain (reproduces the exact failure point from the Knowledge/ChromaDB/Lint jobs)
- [x] `cargo audit` — exit 0, down from 6 real vulnerabilities
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores green main by fixing failing unit tests and updating deps to unblock lint, knowledge, and security jobs. Also aligns `cargo-audit` config and documents temporary ignores for `quick-xml`.

- **Bug Fixes**
  - Reworked allowlist test to use a High-risk (non-Critical) pattern; avoids the unbypassable `rm -rf /` Critical match added in PR #1110.
  - Updated backend roster test to exclude `static`; only expects `embedded`, `ollama`, `vllm`.

- **Dependencies**
  - Bumped `ethnum` to `1.5.3` to fix E0512 and unblock lint/knowledge/ChromaDB jobs.
  - Patched `quinn-proto` to `0.11.15` and `crossbeam-epoch` to `0.9.20` to resolve advisories.
  - Ignored `quick-xml` RUSTSEC-2026-0194/0195 (transitive via `reqsign`/`object_store` in `lancedb`); added revert criteria.
  - Kept `.cargo/audit.toml` and root `audit.toml` in sync; `cargo-audit` reads only the former.

<sup>Written for commit c3f3bb26d0e16f85d23b67c77739ef399feee0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

