### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c0dd59ac-91aa-4626-ab89-1c66b536468c","pid":2407,"procStart":"Sat May 16 06:52:15 2026","acquiredAt":1778918367565}

--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ tests/evaluation/results/*.md
 .claude/.env
 .claude/cache/
 .claude/notifications.log
+.claude/scheduled_tasks.lock
 
 # Codex CLI
 .codex/sessions/


### PR DESCRIPTION
## What

`.claude/scheduled_tasks.lock` is a per-session runtime lock file
(`{"sessionId", "pid", "procStart", "acquiredAt"}`) that gets rewritten
whenever any Claude Code session's scheduler touches it. It was
accidentally committed by #1097 and has been tracked ever since, so
every session that schedules anything shows up with a spurious
"uncommitted changes" diff on this one file.

Found while babysitting CI on #1184: a Stop hook flagged the working
tree as dirty because `CronCreate` (subscribing to PR activity) had
rewritten this file's `sessionId`/`pid` fields.

## Changes

- Add `.claude/scheduled_tasks.lock` to `.gitignore` (alongside the
  existing `.claude/sessions/`, `.claude/logs/`, etc. runtime excludes).
- `git rm --cached` it — stays on disk for the runtime, stops
  round-tripping through git.

## Scope

Pure repo hygiene, no code behavior change. Not bundled into #1184 or
#1280 since it's unrelated to either.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYrhHsLyhEJBPxKxm9mZpz)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop tracking the per-session lock file `.claude/scheduled_tasks.lock` to prevent false "dirty working tree" diffs in CI and local sessions. Added it to `.gitignore` and removed it from the index; the file still exists locally for runtime use.

<sup>Written for commit 70b9d942bdc629c39fb19763c96d47ead87ac63b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

