### PR TITLE
chore(qa): scheduled rotation 2026-07-12 — Slot A + Slot B + Slot C

### DIFF
--- a/.claude/memory/qa-bugs-backlog.md
+++ b/.claude/memory/qa-bugs-backlog.md
@@ -8,6 +8,7 @@ Active bugs filed by caro-qa-agent requiring investigation and fixes.
 
 | Issue | Priority | Domain | Summary | Status | Filed |
 |-------|----------|--------|---------|--------|-------|
+| [#1319](https://github.com/wildcard/caro/issues/1319) | P2 | docs | CLAUDE.md version banner shows 1.4.0 (GA) after 1.5.0 release | open | 2026-07-12 |
 | [#1044](https://github.com/wildcard/caro/issues/1044) | P2 | docs | CLAUDE.md version banner shows 1.1.0 (GA) instead of 1.3.0 | open | 2026-05-07 |
 
 ---

--- a/.claude/memory/qa-coverage-matrix.md
+++ b/.claude/memory/qa-coverage-matrix.md
@@ -1,6 +1,6 @@
 # QA Coverage Matrix
 
-**Last updated**: 2026-05-07
+**Last updated**: 2026-07-12
 
 This file drives Slot C surface selection. Pick the row with the oldest 'Last tested' value (treat 'never' as oldest). Tie-break randomly.
 
@@ -12,6 +12,7 @@ One row per pass. Update 'Last tested' column after every Slot A run.
 
 | Date | Build | --version | --help | doctor | dry-run | Notes |
 |------|-------|-----------|--------|--------|---------|-------|
+| 2026-07-12 | PASS | PASS (1.5.0) | PASS | PASS | FLAKE/PARTIAL | Model download ~60s; 30s timeout killed process; 90s succeeded but wrong output (CPU stub #1269); second FLAKE-001 proximity observation |
 | 2026-05-07 | PASS | PASS (1.3.0) | PASS | PASS | FLAKE | Model download blocked in sandbox (see flakes); first bootstrap run |
 
 ---
@@ -22,8 +23,8 @@ Slot C selects from this table. Update 'Last tested', 'Result', and 'Linked issu
 
 | # | Surface | Domain | Last tested | Result | Linked issue(s) |
 |---|---------|--------|-------------|--------|-----------------|
-| 1 | CLI smoke (build, --version, --help, doctor) | cli | 2026-05-07 | PASS | — |
-| 2 | `caro -p "..." --dry-run` command generation | cli | 2026-05-07 | FLAKE | — |
+| 1 | CLI smoke (build, --version, --help, doctor) | cli | 2026-07-12 | PASS | — |
+| 2 | `caro -p "..." --dry-run` command generation | cli | 2026-07-12 | FLAKE/PARTIAL | #1269, #1281, #1289 |
 | 3 | Telemetry consent persistence across invocations | cli | 2026-05-07 | PASS | — |
 | 4 | `caro shell-init bash/zsh/fish` | shell-integration | 2026-05-07 | PASS | — |
 | 5 | `caro init` setup wizard (--minimal, --force) | cli | 2026-05-07 | PASS | — |
@@ -31,7 +32,7 @@ Slot C selects from this table. Update 'Last tested', 'Result', and 'Linked issu
 | 7 | Safety CVE patterns (ruleset load, shell filters) | safety | 2026-05-07 | PASS | — |
 | 8 | Full library test suite (cargo test --lib) | cli | 2026-05-07 | PASS | — |
 | 9 | CaroML: `caro new / check / list / jobs` | cli | 2026-05-07 | PASS | — |
-| 10 | `caro ai --once` scripted conversational mode | ai | never | — | — |
+| 10 | `caro ai --once` scripted conversational mode | ai | 2026-07-12 | FAIL | #1269, #1281, #1289 |
 | 11 | `caro ai --continue-session` shell widget | ai | never | — | — |
 | 12 | `caro assess` system assessment | cli | never | — | — |
 | 13 | `caro suggest` command suggestions | cli | never | — | — |
@@ -53,7 +54,7 @@ Slot C selects from this table. Update 'Last tested', 'Result', and 'Linked issu
 | 29 | `caro --safety strict/moderate/permissive` modes | safety | never | — | — |
 | 30 | `caro --verbose` timing output | cli | never | — | — |
 | 31 | i18n website locale smoke (curl /es/, /fr/, /ja/) | i18n | never | — | — |
-| 32 | `caro doctor` advisory content accuracy | cli | 2026-05-07 | PASS | — |
+| 32 | `caro doctor` advisory content accuracy | cli | 2026-07-12 | PASS | — |
 
 ---
 
@@ -63,6 +64,7 @@ When a filed issue reveals a new surface gap, add it here so Slot C tracks it in
 
 | Issue | Surface | Domain | Filed | Status |
 |-------|---------|--------|-------|--------|
+| [#1319](https://github.com/wildcard/caro/issues/1319) | CLAUDE.md version field alignment | docs | 2026-07-12 | open |
 | [#1044](https://github.com/wildcard/caro/issues/1044) | CLAUDE.md version field alignment | docs | 2026-05-07 | open |
 
 ---
@@ -72,3 +74,4 @@ When a filed issue reveals a new surface gap, add it here so Slot C tracks it in
 - Slot C tie-break: when multiple surfaces share 'never', pick lowest `#` number unless context suggests a riskier surface is more valuable to exercise.
 - Website surfaces (#25, #26) can be tested with `curl` + Python parsing alone — no caro build needed.
 - Surfaces requiring model download (#19, #20) should be tested from an environment with a pre-downloaded model; note in session log if sandbox blocks download.
+- Next Slot C candidates (tie on 'never', pick lowest #): surface #11 (`caro ai --continue-session`), surface #12 (`caro assess`).

--- a/.claude/memory/qa-known-flakes.md
+++ b/.claude/memory/qa-known-flakes.md
@@ -13,6 +13,7 @@ Document flaky behaviours observed during QA runs. A flake observed 3+ times in 
 **Context**: Remote CI/QA sandbox where `https://huggingface.co/` returns HTTP 200 but binary blob downloads time out or are blocked at a lower network layer.  
 **Impact**: Slot A `--dry-run` smoke check cannot be completed in this environment. Use `caro --version`, `--help`, and `doctor` as proxy for binary health; use `cargo test --lib` for functional coverage.  
 **Occurrence log**:
+- 2026-07-12: observed (second proximity) — model download slow ~60s+ in sandbox; 30s timeout killed process; 90s timeout succeeded but CPU stub bug (#1269) produced wrong output
 - 2026-05-07: observed once
 
 **Promotion threshold**: File regression issue if observed 3 times in 7 days OR if it reproduces on a known-good environment with a pre-downloaded model.  

--- a/.claude/memory/qa-session-log.md
+++ b/.claude/memory/qa-session-log.md
@@ -4,6 +4,59 @@ Reading order: most recent first.
 
 ---
 
+## 2026-07-12 — Scheduled run (Slot A + Slot B + Slot C)
+
+**Trigger**: scheduled cron 14:00 UTC.
+**Rotation**: A + B (103 PRs merged since 2026-05-07) + C (surface #10 — `caro ai --once`).
+**Binary**: caro 1.5.0 (a6519f6 2026-07-12), built in 3m 03s.
+
+### Slot A — Smoke
+
+- `cargo build --release --features embedded-cpu` → **PASS** (3m 03s, Finished release profile)
+- `caro --version` → **PASS**: `caro 1.5.0 (a6519f6 2026-07-12)`
+- `caro --help` → **PASS**: all 24 subcommands listed including CaroML verbs and `skill` command
+- `caro doctor` → **PASS** (initial: no model advisory; after first dry-run: model downloaded, "✓ Embedded (ready)")
+- `caro -p 'list files in current directory' --dry-run` (30s timeout) → **FLAKE**: telemetry consent + model download; process killed by 30s timeout before completing
+- `caro -p 'list files in current directory' --dry-run` (90s timeout) → **PARTIAL**: model downloaded; generated `echo 'Please clarify your request'` instead of `ls` — root cause is CPU stub bug (see #1269, #1281, #1289, all open)
+- Repeat dry-run (90s, model cached) → same wrong result; 7/8 common queries return `echo 'Please clarify your request'` (only static-matcher hits like `show disk usage` → `df -h` work correctly)
+
+### Slot B — Recent diff
+
+103 PRs merged since 2026-05-07. Key surfaces exercised:
+
+- **Static matcher fix #947** (`find and kill the runaway process eating CPU` → full `ps aux | sort … | xargs kill` pipeline): **PASS** ✓
+- **Backend roster #1298 / #1115** (`caro --backend-info` shows `not compiled` for remote backends; no stale entries): **PASS** ✓
+- **Safety allowlist regression #1246** (7/7 `allowlist_catastrophic_tests` pass; specific-subpath allowlist works, catastrophic targets always blocked): **PASS** ✓
+- **Custom safety patterns 1.5.0 feature**: `patterns.toml` loaded without errors using `[[pattern]]` section (correct per example file; CHANGELOG says `[[safety.custom_patterns]]` — minor doc inconsistency). End-to-end blocking test **inconclusive** — CPU stub generates wrong commands so safety validator never sees a real kubectl/terraform command to block. Flagged for re-test once #1269 is fixed.
+- **MSRV 1.85**: confirmed in `Cargo.toml`; CLAUDE.md still says 1.83 (pre-existing #1283/#1288).
+
+Surfaces flagged for future Slot C: custom safety patterns end-to-end blocking.
+
+### Slot C — `caro ai --once` (surface #10)
+
+- `caro ai --once 'list files sorted by size'` → stdout: `echo 'Please clarify your request'`, stderr: `# caro-ai: session 1 confidence=0.85 risk=Safe`; EXIT=0
+- `caro ai --once 'show git log for last 5 commits'` → same wrong output; EXIT=0
+- `caro ai --once --new-session 'show memory usage'` → same wrong output; EXIT=0
+- **stdout/stderr split**: correct — command on stdout only, metadata comment on stderr. Help text "Stdout is the generated command only" is accurately implemented.
+- **Session handling**: resumption (`session 1 (resumed)`) and `--new-session` both work as described.
+- **Root cause**: CPU stub bugs #1269/#1281/#1289 reproduce in 1.5.0 unchanged.
+
+Surface #10 verdict: **FAIL** — produces wrong output on Linux x86_64; pre-existing bugs unresolved in 1.5.0 release.
+
+### Findings
+
+- [#1319](https://github.com/wildcard/caro/issues/1319) — `docs: CLAUDE.md version banner shows 1.4.0 (GA) after 1.5.0 release` (P2) — **NEW**
+- Pre-existing open bugs confirmed in 1.5.0: #1269, #1281, #1289 (CPU stub / `caro ai --once`); #1283, #1288 (MSRV drift)
+
+### Followups
+
+- Custom safety patterns (1.5.0 headline feature) cannot be validated end-to-end until #1269 is fixed.
+- CLAUDE.md has two stale fields: version (1.4.0→1.5.0, filed #1319) and MSRV (1.83→1.85, existing #1283/#1288). Both fixed by adding CLAUDE.md to release-version-alignment checklist.
+- Model download timing: first dry-run timed out at 30s; second attempt (90s) succeeded. Model download slow (~60s+) in this sandbox. FLAKE-001 second proximity observation logged.
+- Next Slot C candidates: surface #11 (`caro ai --continue-session` shell widget), surface #12 (`caro assess`).
+
+---
+
 ## 2026-05-07 — Scheduled run (Slot A + Slot C) [BOOTSTRAP]
 
 **Trigger**: manual invocation; first-ever run of caro-qa-agent (bootstrap pass).


### PR DESCRIPTION
<!-- [agent] caro-qa-agent automated rotation -->

## QA Rotation — 2026-07-12

**Trigger**: scheduled cron 14:00 UTC  
**Binary**: caro 1.5.0 (a6519f6 2026-07-12)  
**Rotation**: Slot A (smoke) + Slot B (103 PRs since 2026-05-07) + Slot C (surface #10 — `caro ai --once`)

---

## Slot A — Smoke

| Check | Result |
|-------|--------|
| `cargo build --release --features embedded-cpu` | **PASS** |
| `caro --version` | **PASS** — `caro 1.5.0 (a6519f6 2026-07-12)` |
| `caro --help` | **PASS** — all 24 subcommands listed |
| `caro doctor` | **PASS** |
| `caro -p '...' --dry-run` (30s timeout) | **FLAKE** — model download slow; killed by timeout |
| `caro -p '...' --dry-run` (90s timeout) | **PARTIAL** — model downloaded; wrong output due to CPU stub bug #1269 |

FLAKE-001 second proximity observation logged in `qa-known-flakes.md`.

---

## Slot B — Recent diff (103 PRs since 2026-05-07)

| Surface | Result |
|---------|--------|
| Static matcher fix #947 (`find and kill the runaway process eating CPU`) | **PASS** ✓ |
| Backend roster #1298/#1115 (`caro --backend-info` shows `not compiled` for remote backends) | **PASS** ✓ |
| Safety allowlist regression #1246 (7/7 `allowlist_catastrophic_tests`) | **PASS** ✓ |
| Custom safety patterns 1.5.0 feature (`patterns.toml` loading, `[[pattern]]` section) | **INCONCLUSIVE** — CPU stub generates wrong commands before safety validator can exercise a real `kubectl`/`terraform` command |
| MSRV 1.85 in `Cargo.toml` | **PASS** — confirmed; `CLAUDE.md` still says 1.83 (pre-existing #1283/#1288) |

Custom safety patterns end-to-end blocking flagged for re-test once #1269 is fixed.

---

## Slot C — `caro ai --once` (surface #10)

| Check | Result |
|-------|--------|
| stdout/stderr split (command on stdout only, `# caro-ai:` metadata on stderr) | **PASS** ✓ |
| Session resumption (`session 1 (resumed)`) | **PASS** ✓ |
| `--new-session` flag | **PASS** ✓ |
| Command quality (`list files sorted by size`, `show git log`, `show memory usage`) | **FAIL** — all return `echo 'Please clarify your request'` |

**Root cause**: CPU stub bug (#1269/#1281/#1289) — `CpuBackend::infer()` checks `prompt.contains("rm")` against the full system prompt, which always contains `"rm -rf"` in rule 11. Reproduces in 1.5.0 unchanged.

Surface #10 verdict: **FAIL** (pre-existing bugs unresolved in 1.5.0 release).

---

## New Issues Filed

- [#1319](https://github.com/wildcard/caro/issues/1319) — `docs: CLAUDE.md version banner shows 1.4.0 (GA) after 1.5.0 release` (P2) — **NEW**

## Pre-existing Open Bugs Confirmed in 1.5.0

- #1269, #1281, #1289 — CPU stub / `caro ai --once` wrong output on Linux x86_64
- #1283, #1288 — MSRV drift (CLAUDE.md says 1.83, Cargo.toml is 1.85)

---

## Files Changed

- `.claude/memory/qa-session-log.md` — 2026-07-12 run prepended
- `.claude/memory/qa-coverage-matrix.md` — Slot A row added; surface #10 updated to FAIL/2026-07-12; #1319 added to bug-filings table; Last updated bumped
- `.claude/memory/qa-bugs-backlog.md` — #1319 added to watch list
- `.claude/memory/qa-known-flakes.md` — FLAKE-001 second proximity observation logged


---
_Generated by [Claude Code](https://claude.ai/code/session_017BM8DGmRUwEJGxJA2WCDAZ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs the 2026-07-12 QA rotation and updates `.claude/memory` matrices and session notes. Confirms 1.5.0 smoke passes, key recent-diff surfaces pass, marks `caro ai --once` as FAIL (CPU stub #1269/#1281/#1289), records FLAKE-001 again for slow model downloads, and adds docs issue #1319.

<sup>Written for commit bfa71b334b16b9820c66844e4bbe9c9e9379ea1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

