### PR TITLE
fix(website): correct .with-caro badge contrast to WCAG AA

### DIFF
--- a/website/src/components/landing/LPMoments.astro
+++ b/website/src/components/landing/LPMoments.astro
@@ -205,7 +205,9 @@
 
   .with-caro {
     background: var(--bg-inverse);
-    color: var(--accent);
+    /* fg-inverse flips with bg-inverse → WCAG AA 7.2:1 light / 12.5:1 dark.
+       Not --accent: signal red fails contrast on both flipped panels. */
+    color: var(--fg-inverse);
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;

--- a/website/src/components/landing/LPMoments.contrast.test.ts
+++ b/website/src/components/landing/LPMoments.contrast.test.ts
@@ -1,0 +1,90 @@
+/**
+ * WCAG AA contrast regression guard for the LPMoments `.with-caro` badge.
+ *
+ * The badge's background is the theme-FLIPPING token `var(--bg-inverse)`
+ * (grey-700 dark-panel in light mode, beige-100 light-paper in dark mode),
+ * so its text color MUST flip too. The old `var(--accent)` (signal red)
+ * failed AA on both flipped panels (2.0:1 light / 2.6:1 dark); the fix uses
+ * `var(--fg-inverse)`, the flipping partner (7.2:1 light / 12.5:1 dark).
+ *
+ * This test fails if:
+ *   1. `.with-caro` is reverted to a non-flipping / red color, OR
+ *   2. the underlying token values drift below the 4.5:1 AA floor.
+ *
+ * See caro-czkx for the sibling `.section-subtitle` / `.moment-description`
+ * grey-300 issue (out of scope here — needs a design token decision).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const tokensCss = readFileSync(new URL('../../ui/tokens.css', import.meta.url), 'utf8');
+const componentSrc = readFileSync(new URL('./LPMoments.astro', import.meta.url), 'utf8');
+
+// --- WCAG 2.x relative luminance + contrast ratio ---
+function srgbToLinear(channel: number): number {
+  const s = channel / 255;
+  return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+function luminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+function contrast(fg: string, bg: string): number {
+  const [hi, lo] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// --- Resolve tokens.css: primitive (--caro-*: #hex) and semantic (--x: var(--caro-*)) ---
+function primitiveHex(name: string): string {
+  const m = tokensCss.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{6})`));
+  if (!m) throw new Error(`primitive token --${name} not found in tokens.css`);
+  return m[1];
+}
+function blockOf(selectorRe: RegExp): string {
+  const m = selectorRe.exec(tokensCss);
+  if (!m) throw new Error(`selector ${selectorRe} not found in tokens.css`);
+  const start = tokensCss.indexOf('{', m.index);
+  let depth = 0;
+  for (let i = start; i < tokensCss.length; i++) {
+    if (tokensCss[i] === '{') depth++;
+    else if (tokensCss[i] === '}' && --depth === 0) return tokensCss.slice(start + 1, i);
+  }
+  throw new Error(`unbalanced braces for ${selectorRe}`);
+}
+/** Resolve a semantic token (value is `var(--caro-*)` or a direct #hex) within a theme block. */
+function resolveSemantic(block: string, name: string): string {
+  const viaVar = block.match(new RegExp(`--${name}:\\s*var\\(--([a-z0-9-]+)\\)`));
+  if (viaVar) return primitiveHex(viaVar[1]);
+  const direct = block.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{6})`));
+  if (direct) return direct[1];
+  throw new Error(`semantic token --${name} not resolvable in the given theme block`);
+}
+
+const lightRoot = blockOf(/:root\s*\{/);
+const darkRoot = blockOf(/\.dark\s*\{/);
+const pair = {
+  light: { fg: resolveSemantic(lightRoot, 'fg-inverse'), bg: resolveSemantic(lightRoot, 'bg-inverse') },
+  dark: { fg: resolveSemantic(darkRoot, 'fg-inverse'), bg: resolveSemantic(darkRoot, 'bg-inverse') },
+};
+
+describe('LPMoments .with-caro badge — WCAG AA contrast guard', () => {
+  const rule = componentSrc.match(/\.with-caro\s*\{([^}]*)\}/)?.[1] ?? '';
+
+  it('sits on the flipping --bg-inverse and uses the flipping --fg-inverse text token', () => {
+    expect(rule).toMatch(/background:\s*var\(--bg-inverse\)/);
+    expect(rule).toMatch(/color:\s*var\(--fg-inverse\)/);
+  });
+
+  it('does not regress to the old failing red (color: var(--accent))', () => {
+    expect(rule).not.toMatch(/color:\s*var\(--accent\)/);
+  });
+
+  it('resolves to >=4.5:1 (AA normal text) in light mode', () => {
+    expect(contrast(pair.light.fg, pair.light.bg)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('resolves to >=4.5:1 (AA normal text) in dark mode', () => {
+    expect(contrast(pair.dark.fg, pair.dark.bg)).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-opus-4-8`)

---

## What & why

The "WITH CARO" pill badge in `LPMoments.astro` sits on `var(--bg-inverse)`, a **theme-flipping** token — `grey-700` (#4f4f4f, dark panel) in light mode, `beige-100` (#f4f1df, light paper) in dark mode. Its text was `var(--accent)` (signal red), which **fails WCAG AA on both flipped panels**.

Because the background flips light↔dark, **no fixed color can pass AA on both** (provably: the text luminance would have to be simultaneously ≥0.527 and ≤0.155). The fix uses `var(--fg-inverse)` — the flipping partner of `--bg-inverse` — exactly matching the sibling `.section-title` / `.moment-pain` in the same file.

| theme | badge bg | before (`--accent`) | after (`--fg-inverse`) |
|---|---|---|---|
| light | grey-700 `#4f4f4f` | ❌ 2.02:1 | ✅ **7.21:1** |
| dark | beige-100 `#f4f1df` | ❌ 2.55:1 | ✅ **12.47:1** |

Tradeoff: the badge is no longer red. No signal red reaches 4.5:1 against this flipping surface; the section keeps its red identity via the divider gradient and `.nl-input`.

## Evidence

- Contrast ratios computed with a WCAG 2.x checker and independently **verified live in a running browser** via `getComputedStyle` (both themes) during the design audit — measuring the real composited colors, not source hex.
- Regression guard passes locally: `4 passed`.
- CI: pending on this push.

## Demo

```bash
cd website
npx vitest run src/components/landing/LPMoments.contrast.test.ts
# → Test Files 1 passed / Tests 4 passed
```

Visual: `npm run dev`, open `/`, scroll to "Moments That Hurt", toggle light/dark — the "WITH CARO" pill stays legible in both.

## Regression guard

`website/src/components/landing/LPMoments.contrast.test.ts` — `describe('LPMoments .with-caro badge — WCAG AA contrast guard')`. It fails if the badge reverts to a non-flipping / red color **or** if the `--fg-inverse` / `--bg-inverse` token pair drifts below the 4.5:1 AA floor.

## Visual audit (design-dialogue-protocol Rule 5)

A `claude-design-frontend-engineer` audit rendered the section in both themes and confirmed the fix with no regression. It also surfaced a **pre-existing** sibling bug (not introduced here): `.section-subtitle` / `.moment-description` use fixed `var(--caro-grey-300)` → **1.49:1 in dark mode**. Tracked as **caro-czkx** (P1), intentionally out of scope for this hotfix — it needs a design-token decision (a muted-but-flipping token), not a mechanical swap, and per Rule 2 should route through Claude Design.

## Reviewer checklist (feature-evidence.md)

- [x] Copy-pasteable demo included
- [x] Regression-guard test named
- [x] No existing contract/e2e test deleted or ignored
- [ ] Green CI run — pending on this push


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "WITH CARO" badge contrast in `LPMoments.astro` to meet WCAG AA in both themes by switching its text color to `var(--fg-inverse)` on `var(--bg-inverse)`. Adds a `vitest` contrast test to guard against regressions (≥4.5:1 in light and dark).

<sup>Written for commit 62fd7276a9e2af5a7e2ecda752726eab47f5e37f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

