### PR TITLE
feat(website): adopt Codex Pet Web SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12053,6 +12053,27 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/codex-pet-companion": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/codex-pet-companion/-/codex-pet-companion-0.1.0.tgz",
+      "integrity": "sha512-KDSPRW/poTAZ0S9G07UEzYVk85JfDYEqmmh+UfD4yDFkYPfg2MemQRNW8HNIBaRDPZ534iRtjHX59La8ZBqSXg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "codex-pet-companion": "dist/cli.js",
+        "codex-pet-web": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -25119,7 +25140,8 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "astro": "^6.1.10",
-        "canvas-confetti": "^1.9.4"
+        "canvas-confetti": "^1.9.4",
+        "codex-pet-companion": "^0.1.0"
       },
       "devDependencies": {
         "@astrojs/sitemap": "^3.7.3",

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,8 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "astro": "^6.1.10",
-    "canvas-confetti": "^1.9.4"
+    "canvas-confetti": "^1.9.4",
+    "codex-pet-companion": "^0.1.0"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.3",

--- a/website/src/pages/docs/kavana.astro
+++ b/website/src/pages/docs/kavana.astro
@@ -74,6 +74,23 @@ cd kavana-codex-pet
     mobile-sync helpers, and public source frames.
   </p>
 
+  <h2>Put any Codex pet on the web</h2>
+
+  <p>
+    This caro.sh companion now runs on the open-source
+    <a href="https://github.com/wildcard/codex-pet-companion" target="_blank" rel="noreferrer">Codex Pet Web SDK</a>.
+    It accepts any compatible <code>pet.json</code> and spritesheet, ships as an npm package and browser script,
+    and includes Kavana as the zero-configuration default. Try the
+    <a href="https://pets.caro.sh/" target="_blank" rel="noreferrer">live SDK field guide</a> or install it with npm:
+  </p>
+
+  <pre><code>npm install codex-pet-companion</code></pre>
+
+  <p>For a plain HTML site, one script and one custom element are enough:</p>
+
+  <pre><code>&lt;script src="https://unpkg.com/codex-pet-companion@0.1.0/dist/codex-pet-companion.global.js"&gt;&lt;/script&gt;
+&lt;codex-pet-companion&gt;&lt;/codex-pet-companion&gt;</code></pre>
+
   <h2 id="hatch-your-own">Hatch your own Codex pet</h2>
 
   <p>

--- a/website/src/ui/KavanaCompanion/KavanaCompanion.module.css
+++ b/website/src/ui/KavanaCompanion/KavanaCompanion.module.css
@@ -21,8 +21,7 @@
 .recallSprite { position: relative; display: block; width: 32px; height: 35px; overflow: hidden; }
 .recallSprite img { position: absolute; inset: 0 auto auto 0; width: 256px; height: 381.333px; max-width: none; image-rendering: auto; }
 .petButton:focus-visible { outline: 3px solid #139979; outline-offset: 5px; border-radius: 18px; }
-.sprite { position: relative; display: block; width: 96px; height: 104px; overflow: hidden; }
-.sprite img { position: absolute; inset: 0 auto auto 0; width: 768px; height: 1144px; max-width: none; image-rendering: auto; transition: transform 0s; }
+.sprite { position: relative; display: block; width: 96px; height: 104px; overflow: hidden; background-color: transparent; background-repeat: no-repeat; image-rendering: auto; }
 .nameplate { margin-top: -5px; padding: 3px 9px; border: 2px solid var(--outline); border-radius: 999px; background: var(--nameplate); font: 800 11px/1 Figtree, sans-serif; letter-spacing: .08em; text-transform: uppercase; }
 .prompt { position: absolute; right: -88px; top: -18px; white-space: nowrap; padding: 8px 11px; border: 2px solid var(--outline); border-radius: 13px 13px 13px 3px; background: var(--cream); font-size: 12px; font-weight: 800; animation: bob 2.4s ease-in-out infinite; }
 .atRight .prompt { right: calc(100% + 8px); border-radius: 13px 13px 3px 13px; }
@@ -43,4 +42,4 @@
 @keyframes bob { 50% { transform: translateY(-4px) rotate(-1deg); } }
 @media (max-width: 600px) { .roaming .dialogue { left: calc(14px - var(--kavana-x)); right: auto; bottom: 132px; width: calc(100vw - 28px); max-height: calc(100vh - 165px); overflow: auto; border-radius: 22px; } .prompt { right: -8px; top: -28px; } }
 @media (hover: none), (pointer: coarse) { .petControls { opacity: 1; transform: translateX(0); pointer-events: auto; } }
-@media (prefers-reduced-motion: reduce) { .roaming, .sprite img, .prompt, .petControls { transition: none; animation: none; } }
+@media (prefers-reduced-motion: reduce) { .roaming, .prompt, .petControls { transition: none; animation: none; } }

--- a/website/src/ui/KavanaCompanion/KavanaCompanion.tsx
+++ b/website/src/ui/KavanaCompanion/KavanaCompanion.tsx
@@ -1,15 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { SpriteAnimator } from 'codex-pet-companion/animator';
 import styles from './KavanaCompanion.module.css';
 
 type Topic = 'welcome' | 'status' | 'adopt' | 'hatch';
 type AnimationName = 'idle' | 'runRight' | 'runLeft' | 'wave' | 'jump' | 'waiting' | 'resting' | 'sleeping' | 'working' | 'review' | 'lookAround';
 type MinimizedSide = 'left' | 'right';
-
-interface SpriteFrame {
-  row: number;
-  column: number;
-  duration: number;
-}
 
 interface RoamStep {
   id: string;
@@ -46,34 +41,20 @@ const topics: Record<Topic, { eyebrow: string; title: string; body: string }> = 
   hatch: { eyebrow: 'Make a companion', title: 'Or hatch your own pet.', body: 'Open a Codex task with your character idea or reference art and ask Codex to use the hatch-pet skill. It can assemble and validate the complete animated atlas.' },
 };
 
-const rowFrames = (row: number, durations: number[]): SpriteFrame[] => durations.map((duration, column) => ({ row, column, duration }));
+type SdkAnimationName = Parameters<SpriteAnimator['setState']>[0];
 
-const animations: Record<AnimationName, SpriteFrame[]> = {
-  idle: rowFrames(0, [280, 110, 110, 140, 140, 320]),
-  runRight: rowFrames(1, [120, 120, 120, 120, 120, 120, 120, 220]),
-  runLeft: rowFrames(2, [120, 120, 120, 120, 120, 120, 120, 220]),
-  wave: rowFrames(3, [140, 140, 140, 280]),
-  jump: rowFrames(4, [140, 140, 140, 140, 280]),
-  waiting: rowFrames(6, [150, 150, 150, 150, 150, 260]),
-  resting: [
-    { row: 6, column: 2, duration: 650 },
-    { row: 6, column: 3, duration: 220 },
-    { row: 6, column: 4, duration: 650 },
-    { row: 6, column: 3, duration: 220 },
-  ],
-  sleeping: [
-    { row: 5, column: 2, duration: 320 },
-    { row: 5, column: 3, duration: 420 },
-    { row: 5, column: 4, duration: 1400 },
-    { row: 5, column: 5, duration: 520 },
-    { row: 5, column: 4, duration: 1400 },
-  ],
-  working: rowFrames(7, [120, 120, 120, 120, 120, 220]),
-  review: rowFrames(8, [150, 150, 150, 150, 150, 280]),
-  lookAround: [
-    ...rowFrames(9, [190, 150, 150, 150, 190, 150, 150, 150]),
-    ...rowFrames(10, [190, 150, 150, 150, 190, 150, 150, 240]),
-  ],
+const sdkAnimations: Record<AnimationName, SdkAnimationName> = {
+  idle: 'idle',
+  runRight: 'running-right',
+  runLeft: 'running-left',
+  wave: 'waving',
+  jump: 'jumping',
+  waiting: 'waiting',
+  resting: 'resting',
+  sleeping: 'sleeping',
+  working: 'running',
+  review: 'review',
+  lookAround: 'look-around',
 };
 
 const entranceStart: RoamStep = {
@@ -111,7 +92,6 @@ export function KavanaCompanion({ embedded = false, initiallyOpen = false }: Kav
   const [open, setOpen] = useState(initiallyOpen);
   const [topic, setTopic] = useState<Topic>('welcome');
   const [routeIndex, setRouteIndex] = useState(-1);
-  const [frameIndex, setFrameIndex] = useState(0);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
   const [hintIndex, setHintIndex] = useState(0);
@@ -132,6 +112,8 @@ export function KavanaCompanion({ embedded = false, initiallyOpen = false }: Kav
   const suppressClick = useRef(false);
   const sleepTimeout = useRef<number>();
   const companionRef = useRef<HTMLElement>(null);
+  const spriteRef = useRef<HTMLSpanElement>(null);
+  const animatorRef = useRef<SpriteAnimator>();
   const recallButtonRef = useRef<HTMLButtonElement>(null);
   const focusRecallAfterMinimize = useRef(false);
 
@@ -267,24 +249,30 @@ export function KavanaCompanion({ embedded = false, initiallyOpen = false }: Kav
   const step = exitStep ?? dragStep ?? restingStep ?? routeStep;
   const sleeping = manualSleeping || autoSleeping;
   const animationName: AnimationName = exitingSide ? step.animation : dragging ? step.animation : open ? 'idle' : sleeping ? 'sleeping' : placedPosition ? 'resting' : reducedMotion ? 'resting' : hovered ? 'wave' : embedded ? 'waiting' : step.animation;
-  const animation = animations[animationName];
-
-  useEffect(() => setFrameIndex(0), [animationName]);
 
   useEffect(() => {
-    if (reducedMotion) {
-      setFrameIndex(animationName === 'sleeping' ? animation.length - 1 : 0);
-      return;
-    }
-    if (animationName === 'sleeping' && frameIndex >= animation.length - 1) return;
-    const frame = animation[frameIndex % animation.length];
-    const advance = window.setTimeout(() => setFrameIndex((value) => (
-      animationName === 'sleeping' ? Math.min(value + 1, animation.length - 1) : (value + 1) % animation.length
-    )), frame.duration);
-    return () => window.clearTimeout(advance);
-  }, [animation, animationName, frameIndex, reducedMotion]);
+    const sprite = spriteRef.current;
+    if (!sprite) return;
+    const animator = new SpriteAnimator(sprite, {
+      atlasUrl: '/pets/kavana/spritesheet.webp',
+      scale: 0.5,
+      reducedMotion,
+    });
+    animatorRef.current = animator;
+    return () => {
+      animator.destroy();
+      if (animatorRef.current === animator) animatorRef.current = undefined;
+    };
+  }, [minimizedSide, reducedMotion]);
 
-  const frame = animation[frameIndex % animation.length];
+  useEffect(() => {
+    const animator = animatorRef.current;
+    if (!animator) return;
+    const state = sdkAnimations[animationName];
+    if (state === 'sleeping') animator.play(state, { loop: false });
+    else animator.setState(state);
+  }, [animationName, minimizedSide]);
+
   const content = topics[topic];
   const atRight = !embedded && step.side === 'right';
   const motionStyle = useMemo(() => ({
@@ -491,7 +479,7 @@ export function KavanaCompanion({ embedded = false, initiallyOpen = false }: Kav
         onPointerCancel={endDrag}
       >
         {!open && !exitingSide && <span className={styles.prompt}>{sleeping ? 'Zzz…' : placedPosition ? 'Comfy here — drag me anytime' : reducedMotion ? 'Keeping quiet company' : roamingHints[hintIndex]}</span>}
-        <span className={styles.sprite} aria-hidden="true"><img src="/pets/kavana/spritesheet.webp" alt="" draggable={false} style={{ transform: `translate(${-frame.column * 96}px, ${-frame.row * 104}px)` }} /></span>
+        <span ref={spriteRef} className={styles.sprite} data-kavana-sdk-sprite aria-hidden="true" />
         <span className={styles.nameplate}>Kavana</span>
       </button>
     </aside>


### PR DESCRIPTION
## Summary
- drive the caro.sh Kavana companion with the published `codex-pet-companion/animator` runtime
- keep Caro's existing roaming, dialogue, drag, sleep, tuck, keyboard, touch, and reduced-motion UX
- document the reusable npm and CDN integration on the Kavana docs page
- install the public `codex-pet-companion@0.1.0` registry package

## Verification
- `npm test --workspace website` — 46 passed
- `ASTRO_DATABASE_FILE=/tmp/caro-sdk-test.db npm exec --workspace website -- astro build` — passed
- `CARO_SITE_URL=http://127.0.0.1:4321 pnpm test:adoption:caro` in the SDK repo — desktop and mobile passed
- npm, unpkg, and jsDelivr `0.1.0` distribution verified

## Cross-links
- SDK: https://github.com/wildcard/codex-pet-companion
- release: https://github.com/wildcard/codex-pet-companion/releases/tag/v0.1.0
- Kavana web SDK site: https://kavana.caro.sh/#web-sdk
- original Kavana contribution: #1324


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted the `codex-pet-companion` Web SDK to power the Kavana companion on the website. Replaces custom sprite logic with the SDK while keeping roaming, dialogue, drag, sleep, keyboard, touch, and reduced-motion behavior.

- **New Features**
  - Documented SDK integration on the Kavana docs page (npm and CDN snippet).
  - Companion can run any compatible `pet.json` + spritesheet via the SDK defaults.

- **Refactors**
  - Replaced manual frame logic with `SpriteAnimator` from `codex-pet-companion/animator` and mapped local states to SDK states.
  - Switched from `<img>` sprite transforms to an SDK-driven `<span>`; updated CSS.
  - Sleep animation plays once; reduced-motion handled by the SDK.

- **Dependencies**
  - Added `codex-pet-companion@0.1.0`.

<sup>Written for commit 4fba854c4d5f98bc5213aca29bf4a746fc5e284b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

