### PR TITLE
feat(slash-router): read command whitelist from `.github/caro/config.yml` (part of #1339)

### DIFF
--- a/.github/SLASH_COMMANDS.md
+++ b/.github/SLASH_COMMANDS.md
@@ -7,6 +7,9 @@ workflow. Implemented by `.github/workflows/slash-router.yml`. Inspired by
 
 ## Available commands
 
+The command list is sourced from `.github/caro/config.yml::slash_router.commands`
+at runtime; this table is a mirror kept for readability.
+
 | Command | Description | Status |
 |---|---|---|
 | `/caro help` | Show the command list as a comment | ✅ available |
@@ -30,9 +33,16 @@ Unknown commands fall through to `help` with an "Unknown command" hint.
 
 ## Adding a new command
 
-1. **Whitelist** the command name in `slash-router.yml::parse::Parse command`
-   (the bash `case` statement). Without this it falls through to
-   `help-unknown`.
+1. **Flip the command to `available` in `.github/caro/config.yml`** under
+   `slash_router.commands`, e.g.:
+   ```yaml
+   slash_router:
+     commands:
+       spec: { status: available, handler: speckit-specify }
+   ```
+   The parse step in `slash-router.yml` reads this to decide whether the
+   command is real; a command with `status: planned` (or anything not
+   `available`) falls through to `help-unknown`.
 2. **Add a handler job** to `slash-router.yml`:
    ```yaml
    <name>:
@@ -43,8 +53,12 @@ Unknown commands fall through to `help` with an "Unknown command" hint.
      steps:
        - # … your handler …
    ```
-3. **Update this file's table** to document the command.
-4. **Reuse existing skills**: prefer mapping the slash command to an existing
+3. **Add a human-readable description** to the `descriptions` map in the
+   `help` job's `github-script` step — the help table pulls names + statuses
+   from `config.yml` but keeps descriptions local (they don't belong in a
+   structural config file).
+4. **Update this file's mirror table**.
+5. **Reuse existing skills**: prefer mapping the slash command to an existing
    `.claude/skills/<name>/SKILL.md` rather than implementing logic in the
    workflow. The handler should `gh workflow run`, `repository_dispatch`, or
    shell out to a runner script — keep YAML thin.

--- a/.github/workflows/slash-router.yml
+++ b/.github/workflows/slash-router.yml
@@ -2,10 +2,14 @@ name: Slash Command Router
 
 # Inspired by warpdotdev/oz-for-oss's `/oz-verify` pattern.
 # Listens on issue and PR comments for `/caro <command> [args]` and dispatches
-# to per-command handlers. Initially supports help/echo/version as a routing
-# scaffold; future PRs wire up handlers for /caro review, /caro qa,
-# /caro spec, /caro tune-prompt, /caro release-acceptance — each maps to an
-# existing skill in .claude/skills/ or agent in .claude/agents/.
+# to per-command handlers.
+#
+# The command whitelist AND the help table are sourced from
+# `.github/caro/config.yml::slash_router.commands` -- add a command there
+# once (with status: available|planned and an optional handler) and it
+# takes effect on both parsing and the help reply. Fallback to a small
+# hard-coded set if the config file is missing so the router degrades
+# gracefully.
 
 on:
   issue_comment:
@@ -30,6 +34,7 @@ jobs:
       command: ${{ steps.parse.outputs.command }}
       args: ${{ steps.parse.outputs.args }}
       is_pr: ${{ steps.parse.outputs.is_pr }}
+      commands_json: ${{ steps.commands.outputs.json }}
     steps:
       - name: Add 'eyes' reaction (acknowledgement)
         uses: actions/github-script@v9
@@ -42,13 +47,43 @@ jobs:
               content: 'eyes'
             });
 
+      - name: Checkout for config.yml access
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/caro/config.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Load command table from config.yml (with fallback)
+        id: commands
+        run: |
+          # Emit a compact JSON of the slash_router.commands table so
+          # downstream github-script steps can consume it without pulling
+          # in a YAML parser. Fall back to the minimum built-in set if
+          # config.yml is missing (fresh clone, deleted key, etc.).
+          if [ -f .github/caro/config.yml ] && command -v yq >/dev/null 2>&1; then
+            json=$(yq -o=json -I=0 '.slash_router.commands // {}' .github/caro/config.yml 2>/dev/null || echo '{}')
+          else
+            json='{}'
+          fi
+          if [ "$json" = '{}' ] || [ -z "$json" ]; then
+            # Fallback: the three commands that were part of the router
+            # scaffold before Pattern 5 landed.
+            json='{"help":{"status":"available"},"echo":{"status":"available"},"version":{"status":"available"}}'
+          fi
+          echo "json=$json" >> "$GITHUB_OUTPUT"
+          echo "Loaded command table:"
+          echo "$json" | python3 -m json.tool
+
       - name: Parse command and args
         id: parse
         env:
           BODY: ${{ github.event.comment.body }}
+          COMMANDS_JSON: ${{ steps.commands.outputs.json }}
         run: |
-          # Strip leading "/caro " (or just "/caro"); take first token as command,
-          # remainder as args. Defaults command to "help" when no token.
+          # Strip leading "/caro " (or just "/caro"); take first token as
+          # command, remainder as args. Defaults command to "help" when
+          # no token.
           line="${BODY#/caro}"
           line="${line# }"
           command="${line%% *}"
@@ -59,12 +94,24 @@ jobs:
             args="${line#"$command"}"
             args="${args# }"
           fi
-          # Whitelist allowed commands -- unknown commands fall through to help
-          # with an "unknown command" hint.
-          case "$command" in
-            help|echo|version) ;;
-            *) args="$command $args"; command="help-unknown" ;;
-          esac
+          # Check the config-loaded whitelist. A command is "available"
+          # when its slash_router.commands.<cmd>.status == "available".
+          # Anything else falls through to help-unknown (with the
+          # attempted command name preserved in args).
+          is_available=$(printf '%s' "$COMMANDS_JSON" | python3 -c "
+          import json, sys, os
+          cmd = os.environ.get('COMMAND', '')
+          try:
+              d = json.load(sys.stdin)
+              entry = d.get(cmd, {})
+              print('yes' if entry.get('status') == 'available' else 'no')
+          except Exception:
+              print('no')
+          " COMMAND="$command")
+          if [ "$is_available" != "yes" ]; then
+            args="$command $args"
+            command="help-unknown"
+          fi
           echo "command=$command" >> "$GITHUB_OUTPUT"
           # Multi-line-safe arg passing
           {
@@ -72,7 +119,8 @@ jobs:
             echo "$args"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          # Detect PR vs issue (issue_comment fires for both; PRs have pull_request key)
+          # Detect PR vs issue (issue_comment fires for both; PRs have
+          # pull_request key)
           if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
             echo "is_pr=true" >> "$GITHUB_OUTPUT"
           else
@@ -89,25 +137,52 @@ jobs:
         uses: actions/github-script@v9
         env:
           UNKNOWN_HINT: ${{ needs.parse.outputs.command == 'help-unknown' && needs.parse.outputs.args || '' }}
+          COMMANDS_JSON: ${{ needs.parse.outputs.commands_json }}
         with:
           script: |
             const unknown = process.env.UNKNOWN_HINT.trim();
+            let commands;
+            try {
+              commands = JSON.parse(process.env.COMMANDS_JSON || '{}');
+            } catch (e) {
+              commands = {};
+            }
+            // Descriptions live alongside the router because config.yml is
+            // structural, not user-facing. Order matches the sequence in
+            // config.yml; anything the config lists that we don't have a
+            // description for still renders with just its status.
+            const descriptions = {
+              help: 'Show this help text',
+              echo: 'Echo `<text>` back as a comment',
+              version: 'Show caro version from Cargo.toml',
+              review: 'Run a multi-agent code review',
+              qa: 'Run QA investigation against this PR',
+              spec: 'Generate a spec from the linked issue',
+              'tune-prompt': 'Run prompt-tuner against test failures',
+              'release-acceptance': 'Audit release readiness'
+            };
+            const statusEmoji = { available: '✅ available', planned: '🛠 planned' };
+            const argPlaceholder = {
+              echo: '<text>',
+              spec: '',
+              'tune-prompt': '',
+              'release-acceptance': ''
+            };
+            const rows = Object.entries(commands).map(([name, entry]) => {
+              const desc = descriptions[name] || '';
+              const args = argPlaceholder[name] === undefined ? '' : ` ${argPlaceholder[name]}`.trimEnd();
+              const status = statusEmoji[entry.status] || entry.status || '?';
+              return `| \`/caro ${name}${args}\` | ${desc} | ${status} |`;
+            });
             const prefix = unknown
               ? `Unknown command: \`/caro ${unknown.split(' ')[0]}\`. Available commands:\n\n`
               : `Available **/caro** commands:\n\n`;
             const body = prefix + [
               '| Command | Description | Status |',
               '|---|---|---|',
-              '| `/caro help` | Show this help text | ✅ available |',
-              '| `/caro echo <text>` | Echo `<text>` back as a comment | ✅ available |',
-              '| `/caro version` | Show caro version from Cargo.toml | ✅ available |',
-              '| `/caro review` | Run a multi-agent code review | 🛠 planned |',
-              '| `/caro qa` | Run QA investigation against this PR | 🛠 planned |',
-              '| `/caro spec` | Generate a spec from the linked issue | 🛠 planned |',
-              '| `/caro tune-prompt` | Run prompt-tuner against test failures | 🛠 planned |',
-              '| `/caro release-acceptance` | Audit release readiness | 🛠 planned |',
+              ...rows,
               '',
-              '_Inspired by [oz-for-oss](https://github.com/warpdotdev/oz-for-oss)._'
+              '_Inspired by [oz-for-oss](https://github.com/warpdotdev/oz-for-oss). Table sourced from `.github/caro/config.yml`._'
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

First slice of #1339. Wires the slash router (`.github/workflows/slash-router.yml`) to read its command whitelist and help table from `.github/caro/config.yml::slash_router.commands` at run time, instead of hard-coding both in the workflow.

**Effect**: adding a `/caro qa` handler now means flipping `qa: { status: available }` in `config.yml` + adding the handler job — instead of remembering to update the `case` statement, the help table, and `SLASH_COMMANDS.md` in parallel.

## Changes

### `.github/workflows/slash-router.yml`

- **`parse` job**: sparse-checkout of `.github/caro/config.yml`, `yq -o=json` extraction into a new `commands_json` output, then the whitelist check consults that JSON via a small python one-liner. **Fallback**: missing config file or empty section → built-in `help|echo|version` set so the router keeps working.
- **`help` job**: builds the reply table from `commands_json` + a local `descriptions` map. Descriptions stay in the workflow because `config.yml` is structural, not user-facing prose. Anything the config lists still renders even without a description.
- **`echo` and `version` jobs**: unchanged.

### `.github/SLASH_COMMANDS.md`

- "Adding a new command" recipe rewritten — step 1 is now flipping `status: planned` → `available` in `config.yml`, then adding a handler + description entry.
- Table now labelled "sourced from `.github/caro/config.yml` at runtime; this table is a mirror".

## Test plan

- [ ] After merge, comment `/caro help` on any PR — expect the same table as before (config.yml lists the same 8 commands with the same statuses).
- [ ] Comment `/caro echo hello` — expect `🔊 hello` reply (no behaviour change, but confirms parsing still works).
- [ ] Comment `/caro nonexistent` — expect the `help-unknown` reply with "Unknown command: `/caro nonexistent`".
- [ ] Comment `/caro review` — expect the `help-unknown` fallthrough because `review.status: planned` in `config.yml` (until #1337 lands a handler).
- [ ] Test the fallback: locally verify that if `.github/caro/config.yml` is deleted, the parse step still accepts `help|echo|version` and rejects everything else.

## Follow-ups (still in #1339)

- Wire `caro-backlog-groom` to read `triage.default_priority` and `triage.do_not_touch_labels`.
- Wire `caro-coder-loop` to read `coder_loop.max_reviewer_retries` and `coder_loop.fallback_specialist`/`documentation_specialist`.
- Wire `caro.release.*` skills to read `release.publish_token_secret` and `release.msrv`.

## References

- Meta-tracker: #1343 (oz-for-oss adoption follow-ups)
- Consumer wiring issue: #1339
- Original config.yml PR: #1078
- Original slash-router PR: #1041

https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY

---
_Generated by [Claude Code](https://claude.ai/code/session_011KzA1DQXpcUSuJ4e97uiJY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The slash router now reads its command whitelist and help table from `.github/caro/config.yml::slash_router.commands` at runtime instead of hard-coding them. This makes the config the single source of truth and adds a safe fallback to `help|echo|version` if the file or key is missing.

- **New Features**
  - `.github/workflows/slash-router.yml`: sparse-checkout of `.github/caro/config.yml`, extract commands with `yq` to JSON, and accept commands only when `status: available`; unknowns fall through to `help-unknown`.
  - Help reply is generated from the config JSON plus a local `descriptions` map; items without descriptions still render.
  - `.github/SLASH_COMMANDS.md`: updated flow; table marked as a mirror of the runtime config.

- **Migration**
  - Set `status: available` under `slash_router.commands` in `.github/caro/config.yml`.
  - Add a handler job in the workflow.
  - Add a description entry in the help job’s `descriptions` map (and update the mirror table).

<sup>Written for commit 8a3682b753db6fd7e5861e3ed27bcfbc9b89a523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

