### PR TITLE
test(website): guard vercel adapter against astro major drift

### DIFF
--- a/website/src/__tests__/vercel-adapter-astro-alignment.test.ts
+++ b/website/src/__tests__/vercel-adapter-astro-alignment.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Vercel Adapter ↔ Astro Major Alignment — Regression Guard
+ *
+ * Prevents the deploy-breaking bug fixed in #1313 / issue #1309: the site
+ * ran astro 6 but pinned `@astrojs/vercel@^9`, whose astro peer is
+ * `^5.0.0`. The adapter's serverless polyfill imported `applyPolyfills`
+ * (astro-6 only) against a nested astro 5, and every Vercel deploy of
+ * `caro-foss-website` crashed with:
+ *
+ *   "applyPolyfills" is not exported by astro/dist/.../node.js
+ *
+ * The `@astrojs/vercel` major tracks the Astro major one-to-one:
+ *   astro 5 → @astrojs/vercel 9   (peer astro ^5)
+ *   astro 6 → @astrojs/vercel 10  (peer astro ^6)
+ *   astro 7 → @astrojs/vercel 11  (peer astro ^7)
+ *
+ * If someone bumps astro without bumping the adapter (or vice versa),
+ * this test fails in CI instead of only surfacing as a red Vercel deploy
+ * after merge. Verified fix landed with all six Vercel projects green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WEBSITE_ROOT = resolve(HERE, '..', '..'); // website/
+
+/** Extract the leading major integer from a semver range like "^10.0.8". */
+function majorOf(range: string): number {
+  const m = range.match(/(\d+)/);
+  expect(m, `could not parse a major from "${range}"`).not.toBeNull();
+  return Number(m![1]);
+}
+
+// astro major -> required @astrojs/vercel major (from the adapter's astro peer)
+const ADAPTER_FOR_ASTRO: Record<number, number> = {
+  5: 9,
+  6: 10,
+  7: 11,
+};
+
+describe('Vercel adapter ↔ Astro major alignment', () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(WEBSITE_ROOT, 'package.json'), 'utf-8'),
+  );
+  const astroRange: string =
+    pkg.dependencies?.astro ?? pkg.devDependencies?.astro;
+  const adapterRange: string =
+    pkg.dependencies?.['@astrojs/vercel'] ??
+    pkg.devDependencies?.['@astrojs/vercel'];
+
+  it('declares both astro and the vercel adapter', () => {
+    expect(astroRange, 'website must depend on astro').toBeTruthy();
+    expect(
+      adapterRange,
+      'website must depend on @astrojs/vercel',
+    ).toBeTruthy();
+  });
+
+  it('pins an adapter major compatible with the astro major', () => {
+    const astroMajor = majorOf(astroRange);
+    const adapterMajor = majorOf(adapterRange);
+    const expected = ADAPTER_FOR_ASTRO[astroMajor];
+    expect(
+      expected,
+      `no known @astrojs/vercel major mapped for astro ${astroMajor}; ` +
+        `update ADAPTER_FOR_ASTRO in this test when adopting a new astro major`,
+    ).toBeDefined();
+    expect(
+      adapterMajor,
+      `astro ${astroMajor} needs @astrojs/vercel ${expected}, but ` +
+        `package.json pins ${adapterMajor} (${adapterRange}). ` +
+        `Mismatch reintroduces the applyPolyfills deploy crash (issue #1309).`,
+    ).toBe(expected);
+  });
+
+  it('the installed adapter, if present, peers the declared astro major', () => {
+    const adapterPkgPath = resolve(
+      WEBSITE_ROOT,
+      'node_modules/@astrojs/vercel/package.json',
+    );
+    if (!existsSync(adapterPkgPath)) return; // no install — static map covers it
+    const adapterPkg = JSON.parse(readFileSync(adapterPkgPath, 'utf-8'));
+    const peer: string | undefined = adapterPkg.peerDependencies?.astro;
+    expect(peer, 'adapter must declare an astro peer').toBeTruthy();
+    expect(
+      majorOf(peer!),
+      `installed @astrojs/vercel@${adapterPkg.version} peers astro ${peer}, ` +
+        `but website declares astro ${astroRange}`,
+    ).toBe(majorOf(astroRange));
+  });
+});


### PR DESCRIPTION
## Description

Cherry-picks the evergreen regression guard `website/src/__tests__/vercel-adapter-astro-alignment.test.ts` out of [#1308](https://github.com/wildcard/caro/pull/1308) onto a fresh branch off `main`.

### Motivation

The guard was written inside #1308, a ~16k-line Flox PR that is 60 commits behind `main` and not cleanly rebaseable. The guard has no dependency on that branch — it is one self-contained test file, zero config changes — so there is no reason for it to wait on Flox review.

Without it, adapter/astro major drift only surfaces as a **red Vercel deploy after merge**, which is exactly how issue #1309 was discovered.

### Changes Made

| File | Change |
|---|---|
| `website/src/__tests__/vercel-adapter-astro-alignment.test.ts` | **New.** 94-line vitest guard, byte-identical to the version in #1308 (`8b5833b9`). |

No config changes needed: `website/package.json` already declares `"test": "vitest run"`, and vitest auto-discovers `src/__tests__/`.

The test asserts the `@astrojs/vercel` major tracks the `astro` major one-to-one (5→9, 6→10, 7→11) via the adapter's declared astro peer, and additionally cross-checks the *installed* adapter's peer range when `node_modules` is present.

## Type of Change

- [x] Test / CI (no runtime behavior change)

## Related Issues and Specs

Closes #1309.

Source commit: `8b5833b9` on #1308. This PR does **not** supersede #1308 — that PR still carries the Flox work; it just no longer needs to be the gate for this guard. When #1308 rebases, this file will already be on `main` and should drop out of its diff.

## Testing Evidence

### Test Output

Full website suite on this branch:

\`\`\`
 ✓ src/__tests__/vercel-adapter-astro-alignment.test.ts (3 tests) 1ms
 ✓ src/utils/humanity-events.test.ts (46 tests) 7ms

 Test Files  2 passed (2)
      Tests  49 passed (49)
\`\`\`

### Manual Testing — negative case

A guard that only passes proves nothing, so I verified it actually fires. Temporarily pinning `@astrojs/vercel` back to `^9.0.0` against the current `astro ^6.1.10` reproduces the #1309 condition:

\`\`\`
 × pins an adapter major compatible with the astro major
AssertionError: astro 6 needs @astrojs/vercel 10, but package.json pins 9 (^9.0.0).
Mismatch reintroduces the applyPolyfills deploy crash (issue #1309).
\`\`\`

`package.json` was restored immediately; it is unmodified in this diff.

Current `main` state is already aligned (`astro ^6.1.10` + `@astrojs/vercel ^10.0.8`), so the guard lands green.

## Additional Context

### Technical Decisions

The astro→adapter mapping is a static table (`ADAPTER_FOR_ASTRO`) rather than derived purely from installed `node_modules`. That is deliberate: the static map still catches drift in a clean checkout with no install, which is the CI case that matters. The installed-peer check is a third assertion that self-skips when `node_modules/@astrojs/vercel` is absent.

Adopting a new astro major requires adding a row to that table — the failure message says so explicitly.

### Questions for Reviewers

None blocking. One note: this branch was cut from `origin/main` at `3a641786`.

## AI Involvement

**Level:** L4 (human-specced, bot-executed). Human specified the exact source commit, file, and target; the agent executed the cherry-pick and verification.

**Agent:** Claude Code (\`claude-opus-4-8[1m]\`)

**Low-confidence areas:** none — the change is a byte-identical copy of an already-reviewed file, verified both positively and negatively against the real vitest runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `vitest` regression guard that ensures the `@astrojs/vercel` major matches the `astro` major (5→9, 6→10, 7→11) and, when installed, verifies the adapter’s astro peer. This makes version drift fail CI instead of causing a red Vercel deploy (see #1309).

<sup>Written for commit 4d7a855a9c6b38c2287338667f58d3c328501cea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

