### PR TITLE
feat(i18n): evergreen model selection with retry-aware fallback

### DIFF
--- a/.github/scripts/translate-multi-backend.js
+++ b/.github/scripts/translate-multi-backend.js
@@ -8,7 +8,10 @@ const crypto = require('crypto');
 
 const targetLocale = process.env.TARGET_LOCALE;
 const forceRetranslate = process.env.FORCE_RETRANSLATE === 'true';
-const translationBackend = process.env.TRANSLATION_BACKEND || 'openai'; // openai, libretranslate, claude, skill
+// 'auto' (the default) resolves the model from translation-config.json's chain.
+// Any explicit value (openai, gemini, claude, libretranslate, skill) pins that
+// backend and bypasses model selection — kept for manual workflow_dispatch runs.
+const translationBackend = process.env.TRANSLATION_BACKEND || 'auto';
 
 // Language metadata with cultural context
 const languageMetadata = {
@@ -135,10 +138,11 @@ class TranslationBackend {
 // ============================================
 
 class OpenAIBackend extends TranslationBackend {
-  constructor() {
+  constructor(model) {
     super();
     const OpenAI = require('openai');
     this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    this.model = model || process.env.OPENAI_MODEL || 'gpt-4o';
   }
 
   async initialize() {
@@ -148,7 +152,7 @@ class OpenAIBackend extends TranslationBackend {
   }
 
   getName() {
-    return 'OpenAI GPT-4';
+    return `OpenAI (${this.model})`;
   }
 
   async translate(enContent, locale, fileName) {
@@ -177,7 +181,7 @@ class OpenAIBackend extends TranslationBackend {
       console.log(`[${locale}] [OpenAI] Translating ${fileName}...`);
 
       const response = await this.openai.chat.completions.create({
-        model: process.env.OPENAI_MODEL || 'gpt-4o',
+        model: this.model,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }
@@ -301,10 +305,10 @@ class LibreTranslateBackend extends TranslationBackend {
 // ============================================
 
 class ClaudeBackend extends TranslationBackend {
-  constructor() {
+  constructor(model) {
     super();
     this.apiKey = process.env.ANTHROPIC_API_KEY;
-    this.model = process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929';
+    this.model = model || process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929';
   }
 
   async initialize() {
@@ -394,6 +398,103 @@ ${metadata.rtl ? '8. For RTL: translate text naturally, keep technical terms LTR
 }
 
 // ============================================
+// Gemini Backend
+// ============================================
+
+// Raw fetch against the Generative Language API rather than @google/genai:
+// the translate workflow only runs `npm install openai`, so adding an SDK
+// would mean a workflow change too. ClaudeBackend already sets the precedent.
+class GeminiBackend extends TranslationBackend {
+  constructor(model) {
+    super();
+    this.apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+    this.model = model || process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+  }
+
+  async initialize() {
+    if (!this.apiKey) {
+      throw new Error('GEMINI_API_KEY (or GOOGLE_API_KEY) is required for Gemini backend');
+    }
+  }
+
+  getName() {
+    return `Gemini (${this.model})`;
+  }
+
+  async translate(enContent, locale, fileName) {
+    const metadata = languageMetadata[locale];
+
+    const systemPrompt = `You are a professional technical writer and translator specializing in ${metadata.name}.
+
+**Cultural Context:**
+- Target metro: ${metadata.metro}
+- Culture: ${metadata.culture}
+- Pop culture references: ${metadata.popCulture}
+
+**Critical Rules:**
+1. Translate ONLY string values, NEVER JSON keys
+2. PRESERVE placeholders: {count}, {name}, {var}, etc.
+3. PRESERVE brand names: "Caro", "Claude", "GitHub"
+4. PRESERVE technical terms: POSIX, shell, CLI, MLX, vLLM, Ollama, JSON, API, HTTP
+5. PRESERVE code blocks and commands
+6. PRESERVE emoji and special characters
+7. Return ONLY valid JSON, no explanations
+${metadata.rtl ? '8. For RTL: translate text naturally, keep technical terms LTR' : ''}
+
+**File:** ${fileName}`;
+
+    const userPrompt = `Translate this JSON to natural ${metadata.name} for developers in ${metadata.metro}:\n\n${JSON.stringify(enContent, null, 2)}`;
+
+    try {
+      console.log(`[${locale}] [Gemini] Translating ${fileName}...`);
+
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': this.apiKey
+        },
+        body: JSON.stringify({
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
+          generationConfig: {
+            temperature: 0.3,
+            maxOutputTokens: 8192,
+            responseMimeType: 'application/json'
+          }
+        })
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Gemini API error: ${response.status} ${response.statusText} — ${body.slice(0, 200)}`);
+      }
+
+      const result = await response.json();
+      const translatedText = result.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      if (!translatedText) {
+        throw new Error(`Gemini returned no text (finishReason: ${result.candidates?.[0]?.finishReason ?? 'unknown'})`);
+      }
+
+      let jsonText = translatedText;
+      if (translatedText.startsWith('```')) {
+        const match = translatedText.match(/```(?:json)?\n?([\s\S]*?)\n?```/);
+        if (match) jsonText = match[1];
+      }
+
+      const translated = JSON.parse(jsonText);
+      console.log(`[${locale}] [Gemini] ✓ Successfully translated ${fileName}`);
+      return translated;
+
+    } catch (error) {
+      console.error(`[${locale}] [Gemini] ✗ Error: ${error.message}`);
+      throw error;
+    }
+  }
+}
+
+// ============================================
 // Skill Backend (uses /translator skill with sub-agents)
 // ============================================
 
@@ -413,21 +514,218 @@ class SkillBackend extends TranslationBackend {
 // Backend Factory
 // ============================================
 
-function createBackend(backendName) {
+function createBackend(backendName, model) {
   switch (backendName.toLowerCase()) {
     case 'openai':
-      return new OpenAIBackend();
+      return new OpenAIBackend(model);
     case 'libretranslate':
     case 'libre':
       return new LibreTranslateBackend();
     case 'claude':
     case 'anthropic':
-      return new ClaudeBackend();
+      return new ClaudeBackend(model);
+    case 'gemini':
+    case 'google':
+      return new GeminiBackend(model);
     case 'skill':
       return new SkillBackend();
     default:
-      throw new Error(`Unknown backend: ${backendName}. Use: openai, libretranslate, claude, or skill`);
+      throw new Error(`Unknown backend: ${backendName}. Use: openai, gemini, libretranslate, claude, or skill`);
   }
+}
+
+// ============================================
+// Model Selection (evergreen — see translation-config.json)
+// ============================================
+
+const MODEL_CONFIG_PATH = path.join(__dirname, 'translation-config.json');
+
+function loadModelConfig(configPath = MODEL_CONFIG_PATH) {
+  const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+  if (!Array.isArray(raw.chain) || raw.chain.length === 0) {
+    throw new Error(`${configPath}: "chain" must be a non-empty array`);
+  }
+  for (const id of raw.chain) {
+    const entry = raw.models?.[id];
+    if (!entry) {
+      throw new Error(`${configPath}: chain references unknown model "${id}"`);
+    }
+    for (const field of ['backend', 'api_model', 'api_key_env', 'last_verified']) {
+      if (!entry[field]) {
+        throw new Error(`${configPath}: model "${id}" is missing required field "${field}"`);
+      }
+    }
+  }
+  return raw;
+}
+
+function daysSince(isoDate) {
+  const then = Date.parse(isoDate);
+  if (Number.isNaN(then)) return Infinity;
+  return Math.floor((Date.now() - then) / 86400000);
+}
+
+// Staleness is a WARNING, never a hard failure: a model that hasn't been
+// re-verified in 31 days is a maintenance smell, but blocking the pipeline on
+// a calendar date would replace one silent outage with a louder one.
+function warnIfStale(modelId, entry, staleAfterDays) {
+  const age = daysSince(entry.last_verified);
+  if (age > staleAfterDays) {
+    console.warn(
+      `⚠️  [model-config] "${modelId}" was last verified ${age} days ago ` +
+      `(threshold ${staleAfterDays}d). Confirm it is still live and bump ` +
+      `"last_verified" in translation-config.json.`
+    );
+  }
+  return age;
+}
+
+// Extract the HTTP status from an error, whichever backend raised it.
+// The OpenAI SDK sets `error.status`; the Claude and Gemini backends format
+// their own message as "<Provider> API error: <status> <text>". We anchor on
+// that "API error:" prefix rather than scanning for any 3-digit run, because
+// the Gemini message also carries a slice of the response body.
+function extractStatus(error) {
+  if (typeof error?.status === 'number') return error.status;
+  if (typeof error?.statusCode === 'number') return error.statusCode;
+  const match = /API error:\s*(\d{3})\b/.exec(error?.message ?? '');
+  return match ? Number(match[1]) : null;
+}
+
+const MODEL_GONE_PATTERN = /model[^.]*not\s*found|not\s*found[^.]*model|unsupported\s*model|invalid\s*model|does not exist|deprecated|decommissioned/i;
+
+// Classify a failure into the three cases the fallback policy cares about:
+//   'retry' — the model is fine, we're throttled or the server hiccuped.
+//             Backing off and retrying is cheaper (and better quality) than
+//             demoting to a weaker model for the whole run.
+//   'gone'  — the model is retired. Retrying cannot help; move down the chain
+//             immediately. This is the caro-z1rp failure mode.
+//   'other' — unknown (auth, malformed response, parse failure). Fall back
+//             rather than hang the pipeline, but don't waste retries on it.
+function classifyError(error) {
+  const status = extractStatus(error);
+
+  if (status === 429 || (status !== null && status >= 500 && status < 600)) {
+    return 'retry';
+  }
+  if (status === 404) return 'gone';
+  if (status === 400 && MODEL_GONE_PATTERN.test(error?.message ?? '')) return 'gone';
+
+  return 'other';
+}
+
+// Should this error advance to the next model in the chain *right now*?
+// Retryable errors say no — the caller backs off first, and only falls back
+// once retries are exhausted.
+function shouldFallback(error) {
+  return classifyError(error) !== 'retry';
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// Retry with exponential backoff, but ONLY for errors that a retry can fix.
+// A 404 rethrows immediately so the caller can fall back without burning
+// ~14s of backoff on a model that no longer exists.
+async function withRetry(fn, { label, maxRetries = 3, baseDelayMs = 2000 } = {}) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (classifyError(error) !== 'retry') throw error;
+      if (attempt > maxRetries) break;
+
+      const status = extractStatus(error);
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      console.warn(
+        `[retry] Retrying ${label} (attempt ${attempt}/${maxRetries}, got ${status ?? 'error'}) — waiting ${delay}ms`
+      );
+      await sleep(delay);
+    }
+  }
+
+  console.warn(`[retry] ${label}: retries exhausted after ${maxRetries} attempts`);
+  throw lastError;
+}
+
+// Probe the model with a real (tiny) translation. This exercises the exact path
+// a production call takes — auth, model name, JSON mode, fence stripping, parse
+// — instead of just proving the endpoint is reachable.
+async function probeModel(backend, probeCfg) {
+  const translated = await backend.translate(
+    probeCfg.payload,
+    probeCfg.locale,
+    'health-probe.json'
+  );
+  if (!translated || typeof translated !== 'object') {
+    throw new Error('probe returned a non-object response');
+  }
+  const keys = Object.keys(probeCfg.payload);
+  const missing = keys.filter(k => !(k in translated));
+  if (missing.length > 0) {
+    throw new Error(`probe response dropped key(s): ${missing.join(', ')}`);
+  }
+  return translated;
+}
+
+// Walk the chain and return the first model that has a key AND passes its probe.
+async function resolveBackend(config) {
+  const staleAfterDays = config.policy?.stale_after_days ?? 30;
+  const probeCfg = config.policy?.probe ?? { locale: 'es', payload: { greeting: 'Hello' } };
+  const retryCfg = config.policy?.retry ?? {};
+  const retryOpts = {
+    maxRetries: retryCfg.max_retries ?? 3,
+    baseDelayMs: retryCfg.base_delay_ms ?? 2000
+  };
+  const attempts = [];
+
+  for (const [index, modelId] of config.chain.entries()) {
+    const entry = config.models[modelId];
+    const nextModel = config.chain[index + 1] ?? 'none (chain exhausted)';
+
+    if (!process.env[entry.api_key_env]) {
+      console.log(`[model-config] ⊘ ${modelId}: ${entry.api_key_env} not set, skipping`);
+      attempts.push(`${modelId} (no ${entry.api_key_env})`);
+      continue;
+    }
+
+    warnIfStale(modelId, entry, staleAfterDays);
+
+    let backend;
+    try {
+      backend = createBackend(entry.backend, entry.api_model);
+      await backend.initialize();
+      console.log(`[model-config] … probing ${modelId} (${backend.getName()})`);
+      await withRetry(() => probeModel(backend, probeCfg), {
+        label: `probe ${modelId}`,
+        ...retryOpts
+      });
+    } catch (error) {
+      const status = extractStatus(error);
+      // Two distinct paths land here: a 'gone' error (immediate, no retries
+      // burned) or a retryable error whose retries withRetry already exhausted.
+      // Either way the next model is the right move — but say which happened.
+      const reason = shouldFallback(error)
+        ? `got ${status ?? 'error'}`
+        : `got ${status ?? 'error'}, retries exhausted`;
+      console.warn(
+        `[model-config] ✗ Falling back from ${modelId} to ${nextModel} (${reason}): ${error.message}`
+      );
+      attempts.push(`${modelId} (${reason})`);
+      continue;
+    }
+
+    console.log(`[model-config] ✓ Using ${modelId} via ${backend.getName()}`);
+    return { backend, modelId, entry };
+  }
+
+  throw new Error(
+    `[model-config] No usable translation model. Tried:\n  - ${attempts.join('\n  - ')}`
+  );
 }
 
 // ============================================
@@ -478,9 +776,28 @@ async function translateAllFiles() {
   const targetDir = path.join(process.cwd(), `website/src/i18n/locales/${targetLocale}`);
   const cacheDir = path.join(process.cwd(), 'website/src/i18n/locales');
 
-  // Create backend
-  const backend = createBackend(translationBackend);
-  await backend.initialize();
+  // Resolve the backend: either the configured chain (health-checked) or an
+  // explicitly pinned backend. `cacheTag` keys the cache so that switching
+  // models re-translates instead of serving another model's output.
+  let backend;
+  let cacheTag;
+  let retryOpts = { maxRetries: 3, baseDelayMs: 2000 };
+
+  if (translationBackend === 'auto') {
+    const config = loadModelConfig();
+    retryOpts = {
+      maxRetries: config.policy?.retry?.max_retries ?? retryOpts.maxRetries,
+      baseDelayMs: config.policy?.retry?.base_delay_ms ?? retryOpts.baseDelayMs
+    };
+    const resolved = await resolveBackend(config);
+    backend = resolved.backend;
+    cacheTag = resolved.modelId;
+  } else {
+    backend = createBackend(translationBackend);
+    await backend.initialize();
+    cacheTag = translationBackend;
+    console.log(`[model-config] Model selection bypassed: TRANSLATION_BACKEND=${translationBackend}`);
+  }
 
   console.log(`========================================`);
   console.log(`Translation Backend: ${backend.getName()}`);
@@ -520,27 +837,32 @@ async function translateAllFiles() {
     try {
       const sourceHash = computeFileHash(enFilePath);
 
-      if (!needsRetranslation(cache, targetLocale, file, sourceHash, forceRetranslate, translationBackend)) {
+      if (!needsRetranslation(cache, targetLocale, file, sourceHash, forceRetranslate, cacheTag)) {
         console.log(`[${targetLocale}] ⊘ Skipping ${file} (unchanged, cached)`);
         skippedCount++;
         continue;
       }
 
       const enContent = JSON.parse(fs.readFileSync(enFilePath, 'utf8'));
-      const translated = await backend.translate(enContent, targetLocale, file);
+      // Retry transient throttling here too — a 429 midway through a locale
+      // would otherwise drop that file and count it as a failure.
+      const translated = await withRetry(
+        () => backend.translate(enContent, targetLocale, file),
+        { label: `${targetLocale}/${file}`, ...retryOpts }
+      );
 
       fs.writeFileSync(targetFilePath, JSON.stringify(translated, null, 2) + '\n', 'utf8');
       console.log(`[${targetLocale}] ✓ Wrote ${file}`);
 
       // Update cache with backend-specific key
-      const cacheKey = `${translationBackend}-${targetLocale}`;
+      const cacheKey = `${cacheTag}-${targetLocale}`;
       if (!cache[cacheKey]) {
         cache[cacheKey] = {};
       }
       cache[cacheKey][file] = {
         sourceHash: sourceHash,
         timestamp: new Date().toISOString(),
-        backend: translationBackend
+        backend: cacheTag
       };
 
       translatedCount++;
@@ -580,18 +902,31 @@ async function translateAllFiles() {
 // Validation & Execution
 // ============================================
 
-if (!targetLocale) {
-  console.error('ERROR: TARGET_LOCALE environment variable is not set');
-  process.exit(1);
+// Only run as a CLI. Exported below so the selection/retry logic is testable.
+if (require.main === module) {
+  if (!targetLocale) {
+    console.error('ERROR: TARGET_LOCALE environment variable is not set');
+    process.exit(1);
+  }
+
+  if (!languageMetadata[targetLocale]) {
+    console.error(`ERROR: Unknown locale: ${targetLocale}`);
+    console.error(`Supported locales: ${Object.keys(languageMetadata).join(', ')}`);
+    process.exit(1);
+  }
+
+  translateAllFiles().catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
 }
 
-if (!languageMetadata[targetLocale]) {
-  console.error(`ERROR: Unknown locale: ${targetLocale}`);
-  console.error(`Supported locales: ${Object.keys(languageMetadata).join(', ')}`);
-  process.exit(1);
-}
-
-translateAllFiles().catch(error => {
-  console.error('Fatal error:', error);
-  process.exit(1);
-});
+module.exports = {
+  classifyError,
+  shouldFallback,
+  extractStatus,
+  withRetry,
+  loadModelConfig,
+  daysSince,
+  createBackend
+};

--- a/.github/scripts/translate-multi-backend.test.js
+++ b/.github/scripts/translate-multi-backend.test.js
@@ -1,0 +1,136 @@
+// Tests for the evergreen model-selection and retry policy.
+// Run: node --test .github/scripts/translate-multi-backend.test.js
+//
+// No network: every case drives the classifier or a stubbed thunk. The retry
+// tests use base_delay_ms=1 so exponential backoff doesn't slow the suite.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  classifyError,
+  shouldFallback,
+  extractStatus,
+  withRetry,
+  loadModelConfig,
+  daysSince
+} = require('./translate-multi-backend.js');
+
+// Error shapes as each backend actually raises them.
+const openaiError = status => Object.assign(new Error('Request failed'), { status });
+const claudeError = (status, text = 'Not Found') =>
+  new Error(`Claude API error: ${status} ${text}`);
+const geminiError = (status, text = 'Not Found', body = '{"error":{"code":404}}') =>
+  new Error(`Gemini API error: ${status} ${text} — ${body}`);
+
+test('extractStatus reads the OpenAI SDK status property', () => {
+  assert.strictEqual(extractStatus(openaiError(429)), 429);
+});
+
+test('extractStatus parses Claude and Gemini message formats', () => {
+  assert.strictEqual(extractStatus(claudeError(503, 'Service Unavailable')), 503);
+  assert.strictEqual(extractStatus(geminiError(404)), 404);
+});
+
+test('extractStatus is not confused by digits in the Gemini body slice', () => {
+  // The body contains "404" but the real status is 400 — anchoring on the
+  // "API error:" prefix is what keeps this correct.
+  assert.strictEqual(extractStatus(geminiError(400, 'Bad Request')), 400);
+});
+
+test('extractStatus returns null when there is no status at all', () => {
+  assert.strictEqual(extractStatus(new Error('socket hang up')), null);
+});
+
+test('429 and 5xx classify as retry, not fallback', () => {
+  for (const status of [429, 500, 502, 503, 529]) {
+    assert.strictEqual(classifyError(openaiError(status)), 'retry', `status ${status}`);
+    assert.strictEqual(shouldFallback(openaiError(status)), false, `status ${status}`);
+  }
+});
+
+test('404 classifies as gone and falls back immediately', () => {
+  assert.strictEqual(classifyError(geminiError(404)), 'gone');
+  assert.strictEqual(shouldFallback(geminiError(404)), true);
+});
+
+test('400 falls back only when the message names a missing model', () => {
+  const retired = claudeError(400, 'model gpt-4-turbo-preview does not exist');
+  assert.strictEqual(classifyError(retired), 'gone');
+
+  // A plain 400 (e.g. a bad API key) is 'other' — still a fallback, but it is
+  // not claimed to be a retired model.
+  assert.strictEqual(classifyError(claudeError(400, 'Bad Request')), 'other');
+  assert.strictEqual(shouldFallback(claudeError(400, 'Bad Request')), true);
+});
+
+test('unknown errors fall back rather than hanging the pipeline', () => {
+  const parseFail = new SyntaxError('Unexpected token < in JSON at position 0');
+  assert.strictEqual(classifyError(parseFail), 'other');
+  assert.strictEqual(shouldFallback(parseFail), true);
+});
+
+test('withRetry retries a 429 and succeeds on a later attempt', async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw openaiError(429);
+      return 'ok';
+    },
+    { label: 'test', maxRetries: 3, baseDelayMs: 1 }
+  );
+
+  assert.strictEqual(result, 'ok');
+  assert.strictEqual(calls, 3);
+});
+
+test('withRetry stops after max retries and rethrows', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(
+      async () => { calls++; throw openaiError(503); },
+      { label: 'test', maxRetries: 3, baseDelayMs: 1 }
+    ),
+    /503|Request failed/
+  );
+
+  // 1 initial attempt + 3 retries.
+  assert.strictEqual(calls, 4);
+});
+
+test('withRetry does NOT retry a 404 — no backoff burned on a dead model', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(
+      async () => { calls++; throw geminiError(404); },
+      { label: 'test', maxRetries: 3, baseDelayMs: 1 }
+    ),
+    /404/
+  );
+
+  assert.strictEqual(calls, 1);
+});
+
+test('shipped config is valid and every chain entry is fully specified', () => {
+  const config = loadModelConfig();
+
+  assert.ok(config.chain.length >= 2, 'chain needs a fallback');
+  assert.strictEqual(config.chain[0], 'gemini-2.5-flash');
+
+  const keyEnvs = new Set();
+  for (const id of config.chain) {
+    const entry = config.models[id];
+    assert.ok(entry.backend && entry.api_model && entry.api_key_env, `${id} underspecified`);
+    assert.ok(!Number.isNaN(Date.parse(entry.last_verified)), `${id} last_verified unparseable`);
+    keyEnvs.add(entry.api_key_env);
+  }
+
+  // A chain whose every model needs the same key is not a fallback chain.
+  assert.ok(keyEnvs.size > 1, 'chain must span more than one provider credential');
+});
+
+test('daysSince treats a missing/garbage date as maximally stale', () => {
+  assert.strictEqual(daysSince('not-a-date'), Infinity);
+  assert.ok(daysSince('2020-01-01') > 1000);
+});

--- a/.github/scripts/translation-config.json
+++ b/.github/scripts/translation-config.json
@@ -1,0 +1,61 @@
+{
+  "$schema_version": 1,
+  "$comment": [
+    "Evergreen model selection for the website translation pipeline.",
+    "Models are named here, never hardcoded in translate-multi-backend.js.",
+    "'chain' is tried in order; the first model whose API key is present AND",
+    "whose live probe succeeds wins. Bump 'last_verified' whenever you confirm",
+    "a model still answers — entries staler than policy.stale_after_days warn.",
+    "Costs are USD per million tokens, list price at last_verified."
+  ],
+
+  "chain": ["gemini-2.5-flash", "gpt-4o-mini", "claude-haiku-4-5"],
+
+  "models": {
+    "gemini-2.5-flash": {
+      "backend": "gemini",
+      "api_model": "gemini-2.5-flash",
+      "api_key_env": "GEMINI_API_KEY",
+      "cost_per_m_input_tokens_usd": 0.3,
+      "cost_per_m_output_tokens_usd": 2.5,
+      "languages": "100+",
+      "quality": { "comet": 0.871, "cost_per_m_words_usd": 1.05 },
+      "last_verified": "2026-07-18",
+      "notes": "Primary. Best cost-efficiency for translation per 2026-07 research."
+    },
+    "gpt-4o-mini": {
+      "backend": "openai",
+      "api_model": "gpt-4o-mini",
+      "api_key_env": "OPENAI_API_KEY",
+      "cost_per_m_input_tokens_usd": 0.15,
+      "cost_per_m_output_tokens_usd": 0.6,
+      "languages": "50+",
+      "quality": { "comet": null, "cost_per_m_words_usd": null },
+      "last_verified": "2026-07-18",
+      "notes": "First fallback. OPENAI_API_KEY is the secret already wired in CI."
+    },
+    "claude-haiku-4-5": {
+      "backend": "claude",
+      "api_model": "claude-haiku-4-5-20251001",
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "cost_per_m_input_tokens_usd": 1.0,
+      "cost_per_m_output_tokens_usd": 5.0,
+      "languages": "50+",
+      "quality": { "comet": null, "cost_per_m_words_usd": null },
+      "last_verified": "2026-07-18",
+      "notes": "Last resort. Strongest on RTL/low-resource locales, priciest."
+    }
+  },
+
+  "policy": {
+    "stale_after_days": 30,
+    "retry": {
+      "max_retries": 3,
+      "base_delay_ms": 2000
+    },
+    "probe": {
+      "locale": "es",
+      "payload": { "greeting": "Hello" }
+    }
+  }
+}

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -14,9 +14,11 @@ on:
         type: boolean
         default: false
       backend:
-        description: 'Translation backend to use'
+        description: 'Translation backend ("auto" = model chain in translation-config.json)'
         type: choice
         options:
+          - auto
+          - gemini
           - openai
           - libretranslate
           - claude
@@ -32,6 +34,7 @@ jobs:
     outputs:
       has-openai: ${{ steps.check.outputs.has-openai }}
       has-anthropic: ${{ steps.check.outputs.has-anthropic }}
+      has-gemini: ${{ steps.check.outputs.has-gemini }}
     steps:
       - name: Check available secrets
         id: check
@@ -47,12 +50,19 @@ jobs:
           else
             echo "has-anthropic=false" >> $GITHUB_OUTPUT
           fi
+          if [ -n "${{ secrets.GEMINI_API_KEY }}" ]; then
+            echo "has-gemini=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-gemini=false" >> $GITHUB_OUTPUT
+            echo "⚠️ GEMINI_API_KEY secret not configured (primary model)"
+          fi
 
   translate:
     needs: check-secrets
     if: |
       needs.check-secrets.outputs.has-openai == 'true' ||
       needs.check-secrets.outputs.has-anthropic == 'true' ||
+      needs.check-secrets.outputs.has-gemini == 'true' ||
       github.event.inputs.backend == 'libretranslate'
     runs-on: ubuntu-latest
     strategy:
@@ -74,8 +84,13 @@ jobs:
       - name: Determine backend
         id: backend
         run: |
-          REQUESTED="${{ github.event.inputs.backend || 'openai' }}"
-          if [ "$REQUESTED" = "openai" ] && [ "${{ needs.check-secrets.outputs.has-openai }}" = "true" ]; then
+          REQUESTED="${{ github.event.inputs.backend || 'auto' }}"
+          if [ "$REQUESTED" = "auto" ]; then
+            # Model chain + health check in translation-config.json decides.
+            echo "selected=auto" >> $GITHUB_OUTPUT
+          elif [ "$REQUESTED" = "gemini" ]; then
+            echo "selected=gemini" >> $GITHUB_OUTPUT
+          elif [ "$REQUESTED" = "openai" ] && [ "${{ needs.check-secrets.outputs.has-openai }}" = "true" ]; then
             echo "selected=openai" >> $GITHUB_OUTPUT
           elif [ "$REQUESTED" = "claude" ] && [ "${{ needs.check-secrets.outputs.has-anthropic }}" = "true" ]; then
             echo "selected=claude" >> $GITHUB_OUTPUT
@@ -93,6 +108,7 @@ jobs:
         run: node .github/scripts/translate-multi-backend.js
         env:
           TRANSLATION_BACKEND: ${{ steps.backend.outputs.selected }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           LIBRETRANSLATE_URL: ${{ secrets.LIBRETRANSLATE_URL || 'https://libretranslate.com' }}


### PR DESCRIPTION
## Summary

Replaces the hardcoded translation model with a config-driven chain that health-checks before every run and self-heals when a model is retired.

The caro-z1rp outage — 14 auto-translate PRs (#1229–#1242) producing zero locale files, the 30% coverage gap — had two causes: `gpt-4-turbo-preview` was retired, and nothing verified the model before the run. #1228 (this PR's base) fixed the model string and made a zero-translation run fail loud. This PR makes the model name stop being a hardcoded constant at all.

**Part of** the i18n coverage recovery; extends #1228.

## Focus Areas

1. **`classifyError()` / retry policy** (`translate-multi-backend.js`) — the operator-decided policy: 429/5xx retry with backoff, 404 and "model not found" 400s fall back immediately, unknown errors fall back. This is the heart of the PR.
2. **`extractStatus()` regex** — anchors on the `API error: <code>` prefix rather than scanning for any 3-digit run, because the Gemini error message embeds a 200-char body slice that can contain stray digits. Covered by a dedicated test.
3. **`TRANSLATION_BACKEND` default flip to `auto`** — the workflow *always* set this variable, so without the flip the config would never have been consulted. Explicit values still pin a backend.
4. **Cache key change** — `${backend}-${locale}` → `${modelId}-${locale}`. Without it, a Gemini→Haiku fallback would hit Gemini's cache entries and skip files as already translated.

## Open Questions

1. **`GEMINI_API_KEY` is not yet a repo secret.** Until it is added, `auto` will skip the primary and land on `gpt-4o-mini` — correct behavior, but the cost-efficiency win doesn't materialize. Needs an operator action outside this PR.
2. The Gemini pricing in the config is list price at time of writing; the `$1.05/M words` / `0.871 COMET` figures come from the research cited in the issue, not from a measurement of our own corpus.

## Changes by Area

| File | Change |
|---|---|
| `.github/scripts/translation-config.json` | **New.** Model chain, per-model metadata, retry + staleness policy. |
| `.github/scripts/translate-multi-backend.js` | Model selection, health probe, retry harness, Gemini backend, model-aware cache keys, CLI/module split. |
| `.github/scripts/translate-multi-backend.test.js` | **New.** 13 tests over the classifier, retry harness, and shipped config. |
| `.github/workflows/translate.yml` | `auto` default + `gemini` option, `GEMINI_API_KEY` secret check and env. |

### Design notes

- **Config lives in `.github/scripts/`**, not `website/scripts/` as originally sketched — the translate script lives there; `website/scripts/` contains no translation code.
- **Gemini backend uses raw `fetch`**, not `@google/genai`, mirroring the existing Claude backend. The workflow only runs `npm install openai`; an SDK would have forced a dependency-install change too.
- **Staleness warns, never blocks.** Failing a pipeline on a calendar date would replace one silent outage with a louder one.
- **The probe reuses `translate()`** with a one-key payload instead of pinging a `/models` endpoint. A connectivity ping proves the key works; it does not prove the model returns parseable JSON through the fence stripper — which is the layer that actually failed in caro-z1rp.

## Verification Evidence

```
$ node --test .github/scripts/translate-multi-backend.test.js
# tests 13
# pass 13
# fail 0
```

Chain exhaustion exits non-zero rather than silently translating nothing:
```
$ env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u GEMINI_API_KEY TARGET_LOCALE=es node .github/scripts/translate-multi-backend.js
[model-config] ⊘ gemini-2.5-flash: GEMINI_API_KEY not set, skipping
[model-config] ⊘ gpt-4o-mini: OPENAI_API_KEY not set, skipping
[model-config] ⊘ claude-haiku-4-5: ANTHROPIC_API_KEY not set, skipping
Fatal error: Error: [model-config] No usable translation model. Tried: ...
EXIT=1
```

Live non-retryable failure falls back immediately — elapsed 0s, confirming no backoff was burned on a dead model:
```
$ GEMINI_API_KEY=invalid-test-key TARGET_LOCALE=es node .github/scripts/translate-multi-backend.js
[model-config] ✗ Falling back from gemini-2.5-flash to gpt-4o-mini (got 400): Gemini API error: 400 Bad Request — {
elapsed=0s
```

Staleness warning, verified by temporarily backdating `last_verified` (reverted before commit):
```
⚠️  [model-config] "gemini-2.5-flash" was last verified 198 days ago (threshold 30d).
```

`node --check` clean; `translate.yml` parses as valid YAML.

**Not verified:** no successful end-to-end translation against a live Gemini or OpenAI key — no valid credentials were available in this session. The success path through `probeModel` → `translate()` is exercised only by unit tests with stubbed thunks.

## Self-Review Checklist

- [x] Tests added and passing (13/13)
- [x] No new npm dependencies
- [x] Backward compatible — explicit `TRANSLATION_BACKEND` values behave as before
- [x] Verification evidence included, including a negative result
- [ ] AI/agent feedback triaged — no AI review threads yet
- [ ] End-to-end run against live credentials — blocked on `GEMINI_API_KEY` secret

## AI Involvement

**Level: L4** (Human-specced, bot-coded). The fallback policy — the retry/gone/other distinction, 3 retries from 2s — was specified by the operator; the implementation, tests, and verification are agent-authored.

- Agent: Claude Code (`claude-opus-4-8[1m]`)

**Low-confidence areas for reviewer scrutiny:**
- `MODEL_GONE_PATTERN` is a heuristic over provider error prose. Providers change their wording; a 400 whose message doesn't match will classify as `other` (still a fallback, just not labeled as a retired model). Low blast radius, but it will drift.
- The Gemini request shape (`systemInstruction`, `responseMimeType: 'application/json'`) is written from the API contract, not validated against a live response.
- Retry now wraps per-file translation calls in addition to the probe. Worst case for a fully-throttled locale is ~14s of added backoff per file before that file is counted as failed.

## Related Issues / PR Sequencing

**Part of** the caro-z1rp i18n recovery.

### Full stack ancestry

```
main
 └─ #1228  use live OpenAI model + fail loud on zero translations  ← this PR's base
    └─ (this PR)  evergreen model selection + retry-aware fallback  ← you are here
```

The fail-loud gate at the end of `translateAllFiles()` comes from #1228 and appears in this branch's history, not its diff — don't review it here.

- Blocked by: #1228 (must merge first)
- Follow-up needed: add `GEMINI_API_KEY` to repo secrets

## Ignore / Not in Scope

- Re-running the 14 stalled auto-translate PRs — separate operation once this lands and the secret exists.
- `.github/scripts/translate.js` (the older single-backend script) is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes translation evergreen and resilient by selecting models from a config-driven chain that probes health on each run and auto-falls back when a model is gone. Adds retry-aware handling to prevent zero-translation outages.

- **New Features**
  - Added `translation-config.json` with a model chain (`gemini-2.5-flash` → `gpt-4o-mini` → `claude-haiku-4-5`), per-model metadata, and staleness warnings; each candidate is live-probed before use.
  - Implemented retry policy on both the probe and per-file translations: 429/5xx backoff with exponential delays; 404 and “model not found” 400s fall back immediately; improved status parsing anchored on “API error:” to avoid false matches.
  - Introduced a Gemini backend via raw `fetch` (no new npm deps).
  - Defaulted `TRANSLATION_BACKEND` to `auto`; workflow supports `auto` and `gemini` and passes `GEMINI_API_KEY` when set.
  - Switched cache keys to `${modelId}-${locale}` to avoid cross-model cache hits; added unit tests for classifier, retry, and config validation.

- **Migration**
  - Add `GEMINI_API_KEY` to repo secrets to use the primary model; otherwise the chain falls back to OpenAI.

<sup>Written for commit 9e30f0315939c97d03b5d7a063a6620a1d2e283b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

