### PR TITLE
Fix typo in default Claude model id and update retired ids in agent docs

### DIFF
--- a/.claude/skills/caro-shell-helper/SKILL.md
+++ b/.claude/skills/caro-shell-helper/SKILL.md
@@ -40,7 +40,7 @@ This skill helps users effectively leverage **Caro** (formerly Caro) - a Rust CL
 caro --backend claude "user's request here"
 ```
 
-The Claude backend uses **claude-haiku-4-5-20251101** for fast, cost-effective command generation. The API key is automatically provided by Claude Code.
+The Claude backend uses **claude-haiku-4-5-20251001** for fast, cost-effective command generation. The API key is automatically provided by Claude Code.
 
 ## When to Use This Skill
 
@@ -103,7 +103,7 @@ Generated command:
   find ~/Downloads -name "*.pdf" -size +10M -ls
 
 Safety Assessment: ✅ Safe (Green)
-Backend: Claude (claude-haiku-4-5-20251101)
+Backend: Claude (claude-haiku-4-5-20251001)
 Execute this command? (y/N)
 ```
 
@@ -225,7 +225,7 @@ Caro supports multiple inference backends. Help users choose:
 ### Claude Backend (Default for Claude Code)
 - **Best for**: Running directly within Claude Code or with Anthropic API access
 - **Advantages**: Fastest, most accurate, uses Claude Haiku 4.5 by default
-- **Model**: claude-haiku-4-5-20251101 (default)
+- **Model**: claude-haiku-4-5-20251001 (default)
 - **Setup**:
   ```toml
   # ~/.config/caro/config.toml
@@ -233,7 +233,7 @@ Caro supports multiple inference backends. Help users choose:
   primary = "claude"
 
   [backend.claude]
-  model_name = "claude-haiku-4-5-20251101"  # Fast and cost-effective
+  model_name = "claude-haiku-4-5-20251001"  # Fast and cost-effective
   # API key read from ANTHROPIC_API_KEY environment variable
   ```
 
@@ -288,7 +288,7 @@ Generated command:
   find . -name "*.py" -type f -mtime -7
 
 Safety Assessment: ✅ Safe (Green)
-Backend: Claude (claude-haiku-4-5-20251101)
+Backend: Claude (claude-haiku-4-5-20251001)
 - Read-only operation
 - POSIX-compliant syntax
 - Searches current directory and subdirectories
@@ -316,7 +316,7 @@ Generated command:
   find . -name "*.log" -type f -mtime +30 -delete
 
 Safety Assessment: 🟠 High (Orange)
-Backend: Claude (claude-haiku-4-5-20251101)
+Backend: Claude (claude-haiku-4-5-20251001)
 - Performs deletion (irreversible)
 - Recursive operation
 - Affects multiple files
@@ -348,7 +348,7 @@ Generated command:
   df -h
 
 Safety Assessment: ✅ Safe (Green)
-Backend: Claude (claude-haiku-4-5-20251101)
+Backend: Claude (claude-haiku-4-5-20251001)
 - Read-only operation
 - Standard system utility
 - No modifications
@@ -409,7 +409,7 @@ primary = "claude"  # claude (default in Claude Code), embedded, ollama, or vllm
 enable_fallback = true
 
 [backend.claude]
-model_name = "claude-haiku-4-5-20251101"  # Fast and cost-effective
+model_name = "claude-haiku-4-5-20251001"  # Fast and cost-effective
 # API key read from ANTHROPIC_API_KEY environment variable
 ```
 

--- a/docs/coding-agents/aider.md
+++ b/docs/coding-agents/aider.md
@@ -66,7 +66,7 @@ aider --api-key anthropic=sk-...
 Located at `~/.aider.conf.yml`:
 
 ```yaml
-model: claude-sonnet-4-20250514
+model: claude-sonnet-4-6
 auto-commits: true
 git-depth: 2
 show-diffs: true
@@ -82,7 +82,7 @@ shell:
 Create `.aider.conf.yml` in project root:
 
 ```yaml
-model: claude-sonnet-4-20250514
+model: claude-sonnet-4-6
 read:
   - README.md
   - CLAUDE.md
@@ -101,7 +101,7 @@ aider
 aider src/main.rs src/lib.rs
 
 # With specific model
-aider --model claude-sonnet-4-20250514
+aider --model claude-sonnet-4-6
 
 # In architect mode (planning first)
 aider --architect
@@ -229,7 +229,7 @@ pre-commit:
 
 ```bash
 # Start both tools for a session
-aider --model claude-sonnet-4-20250514 &
+aider --model claude-sonnet-4-6 &
 caro --watch  # Watch for command validation requests
 ```
 

--- a/docs/coding-agents/augie.md
+++ b/docs/coding-agents/augie.md
@@ -62,7 +62,7 @@ Example `config.toml`:
 ```toml
 [model]
 provider = "anthropic"
-name = "claude-sonnet-4-20250514"
+name = "claude-sonnet-4-6"
 
 [safety]
 validate_commands = true

--- a/docs/coding-agents/cline.md
+++ b/docs/coding-agents/cline.md
@@ -40,7 +40,7 @@ After installation:
 {
   "cline.apiProvider": "anthropic",
   "cline.apiKey": "...",
-  "cline.model": "claude-sonnet-4-20250514",
+  "cline.model": "claude-sonnet-4-6",
   "cline.customInstructions": "Always validate shell commands with caro",
   "cline.alwaysAllowWrite": false,
   "cline.alwaysAllowExecute": false

--- a/docs/coding-agents/continue.md
+++ b/docs/coding-agents/continue.md
@@ -49,7 +49,7 @@ Located at `~/.continue/config.json`:
     {
       "title": "Claude Sonnet",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-20250514",
+      "model": "claude-sonnet-4-6",
       "apiKey": "..."
     },
     {

--- a/docs/coding-agents/crush.md
+++ b/docs/coding-agents/crush.md
@@ -110,8 +110,8 @@ Located at `~/.config/crush/config.json`:
   "editor": "nvim",
   "shell": "zsh",
   "models": {
-    "default": "claude-sonnet-4-20250514",
-    "fast": "claude-3-5-haiku-20241022"
+    "default": "claude-sonnet-4-6",
+    "fast": "claude-haiku-4-5-20251001"
   }
 }
 ```
@@ -129,7 +129,7 @@ crush "explain this codebase"
 crush -C /path/to/project
 
 # Use a specific model
-crush --model claude-sonnet-4-20250514 "refactor this function"
+crush --model claude-sonnet-4-6 "refactor this function"
 ```
 
 ## Key Features

--- a/docs/coding-agents/cursor.md
+++ b/docs/coding-agents/cursor.md
@@ -63,7 +63,7 @@ Cursor inherits VS Code settings with AI-specific additions:
 // ~/Library/Application Support/Cursor/User/settings.json (macOS)
 {
   "cursor.cpp.enabled": true,
-  "cursor.chat.defaultModel": "claude-sonnet-4-20250514",
+  "cursor.chat.defaultModel": "claude-sonnet-4-6",
   "cursor.prediction.enabled": true,
   "cursor.aiContext.enabled": true,
   "terminal.integrated.defaultProfile.linux": "zsh"

--- a/docs/coding-agents/roo-code.md
+++ b/docs/coding-agents/roo-code.md
@@ -39,7 +39,7 @@ Or search "Roo Code" in VS Code Extensions.
 {
   "roo-cline.apiProvider": "anthropic",
   "roo-cline.apiKey": "...",
-  "roo-cline.model": "claude-sonnet-4-20250514",
+  "roo-cline.model": "claude-sonnet-4-6",
   "roo-cline.customInstructions": "Use caro for shell command safety",
   "roo-cline.autoApprove": false
 }

--- a/docs/coding-agents/shai.md
+++ b/docs/coding-agents/shai.md
@@ -67,7 +67,7 @@ Located at `~/.config/shai/config.yaml`:
 ```yaml
 api:
   provider: anthropic  # or openai, ovh
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 
 shell:
   default: zsh

--- a/docs/coding-agents/void.md
+++ b/docs/coding-agents/void.md
@@ -45,7 +45,7 @@ brew install --cask void
 // ~/.config/Void/User/settings.json
 {
   "void.ai.provider": "anthropic",
-  "void.ai.model": "claude-sonnet-4-20250514",
+  "void.ai.model": "claude-sonnet-4-6",
   "void.ai.apiKey": "...",
   "void.chat.systemPrompt": "Validate shell commands with caro"
 }

--- a/docs/coding-agents/zed-ai.md
+++ b/docs/coding-agents/zed-ai.md
@@ -55,7 +55,7 @@ Press `Cmd+,` to open settings:
     "enabled": true,
     "default_model": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-20250514"
+      "model": "claude-sonnet-4-6"
     }
   },
   "terminal": {

--- a/src/backends/remote/claude.rs
+++ b/src/backends/remote/claude.rs
@@ -11,7 +11,7 @@ use crate::backends::{BackendInfo, BackendType, CommandGenerator, GeneratorError
 use crate::models::{CommandRequest, GeneratedCommand, RiskLevel};
 
 /// Default Claude model - Haiku 4.5 for fast, efficient command generation
-pub const DEFAULT_CLAUDE_MODEL: &str = "claude-haiku-4-5-20251101";
+pub const DEFAULT_CLAUDE_MODEL: &str = "claude-haiku-4-5-20251001";
 
 /// Claude API base URL
 pub const CLAUDE_API_URL: &str = "https://api.anthropic.com";
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_default_model() {
-        assert_eq!(DEFAULT_CLAUDE_MODEL, "claude-haiku-4-5-20251101");
+        assert_eq!(DEFAULT_CLAUDE_MODEL, "claude-haiku-4-5-20251001");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two separate things, both about model ids the Anthropic API will not accept.

## The default Claude model has a one digit typo

`DEFAULT_CLAUDE_MODEL` in `src/backends/remote/claude.rs` is set to `claude-haiku-4-5-20251101`. The published id for Haiku 4.5 is `claude-haiku-4-5-20251001`, so November where it should be October. Every request from the Claude backend that does not override the model carries an id that does not exist.

The test at line 474 asserts the same string, which is why the mistake has stayed green. I moved the test with the constant so the suite still passes. That is the only test change in this PR and I would not have touched it otherwise.

The same string appears eight times in `.claude/skills/caro-shell-helper/SKILL.md`, twice as configuration and six times inside sample terminal output that echoes the default. Those follow the constant, so I updated them together.

## Retired ids in the coding agent setup docs

`docs/coding-agents/` tells readers which model to put in their editor config. Fifteen of those lines name models past their retirement date, listed on the [model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations). `claude-sonnet-4-20250514` is replaced with `claude-sonnet-4-6`, and one `claude-3-5-haiku-20241022` in the crush config with `claude-haiku-4-5-20251001`.

Files touched: `aider.md` (4 lines), `crush.md` (3), and one line each in `augie.md`, `cline.md`, `continue.md`, `cursor.md`, `roo-code.md`, `shai.md`, `void.md`, `zed-ai.md`.

## Left alone on purpose

`src/backends/remote/claude.rs` also has `claude-3-5-sonnet-20241022` at lines 437 and 441. That is `test_claude_with_custom_model` checking that a caller supplied string is stored, so the literal is a fixture and the id being retired does not matter to what the test proves.

`exports/session-logs/` contains six more across four files. Those are transcripts of sessions you ran, and rewriting a record of what happened would make it wrong.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model IDs, and the typo turned up while I was reading the surrounding file, so I am saying that up front rather than leaving you to wonder. I have not run the backend against the API to reproduce a failure, the claims rest on the published model ids and retirement dates. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect default Claude model ID to `claude-haiku-4-5-20251001` and update coding agent docs to use current, non-retired model IDs.

- **Bug Fixes**
  - Set `DEFAULT_CLAUDE_MODEL` to `claude-haiku-4-5-20251001` and updated the matching test; corrected the same ID in `.claude/skills/caro-shell-helper/SKILL.md`.
  - Replaced `claude-sonnet-4-20250514` with `claude-sonnet-4-6` across agent docs and updated Crush’s fast model from `claude-3-5-haiku-20241022` to `claude-haiku-4-5-20251001`.

<sup>Written for commit 5fdc201b5deb72aa45024a363c4e4dd8ddf8cf03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

