### PR TITLE
test(harness): execution-grounded verification via Cloudflare sandboxes + Kitesurf (ADR-017)

### DIFF
--- a/.claude/rules/dev-process.md
+++ b/.claude/rules/dev-process.md
@@ -34,10 +34,17 @@
 - Smoke tests with SmolLM 135M on macOS + Linux
 - Evaluation suite for embedded models
 
-### Website Deploy (GitHub Pages + Vercel)
+### Website Deploy (Vercel + Cloudflare Pages)
 - **caro-foss-website** → Vercel (primary website at caro.sh)
-- **caro-docs** → Vercel (documentation)
+- **docs-site + Storybook** → Cloudflare Pages (migrated in PR #1351;
+  cold-build guard: `static-sites-build.yml`)
 - **GitHub Pages** → `deploy-website.yml` workflow (secondary)
+
+### Cloudflare compute (dev harness only — ADR-017)
+- `tools/exec-harness/worker/` → Workers + Sandbox containers
+  (`detonation-nightly.yml`, dormant until secrets exist)
+- `website/e2e/` → Browser Run/Kitesurf structural QA
+  (`website-qa-kitesurf.yml`, dormant until secrets exist)
 
 ### Release Workflow
 ```bash

--- a/.github/workflows/detonation-nightly.yml
+++ b/.github/workflows/detonation-nightly.yml
@@ -1,0 +1,67 @@
+# Nightly red-team detonation lane (ADR-017 phase P2).
+#
+# Executes the dangerous-command corpus in disposable Cloudflare Sandbox
+# containers via tools/exec-harness/worker and uploads the blast-radius
+# evidence. DORMANT until the worker is deployed and secrets exist
+# (CARO_DETONATION_URL, CARO_DETONATION_TOKEN — human-created per decision
+# D5): without them the job skips green. Non-blocking by design: beta/GA
+# cloud services may never gate merges (ADR-017 preview-API policy).
+name: Detonation Nightly
+
+on:
+  schedule:
+    - cron: "17 3 * * *" # 03:17 UTC nightly
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  detonate:
+    name: Detonate safety corpus (tier 1)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - name: Gate on secrets
+        id: gate
+        env:
+          DETONATION_URL: ${{ secrets.CARO_DETONATION_URL }}
+          DETONATION_TOKEN: ${{ secrets.CARO_DETONATION_TOKEN }}
+        run: |
+          if [ -n "$DETONATION_URL" ] && [ -n "$DETONATION_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Detonation lane dormant: CARO_DETONATION_URL / CARO_DETONATION_TOKEN secrets not set (see tools/exec-harness/worker/README.md)"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        if: steps.gate.outputs.enabled == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        if: steps.gate.outputs.enabled == 'true'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run detonation suite
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          CARO_DETONATION_URL: ${{ secrets.CARO_DETONATION_URL }}
+          CARO_DETONATION_TOKEN: ${{ secrets.CARO_DETONATION_TOKEN }}
+        run: |
+          cargo test --no-default-features --features embedded-cpu \
+            --test red_team -- --ignored --nocapture
+
+      - name: Upload evidence
+        if: steps.gate.outputs.enabled == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detonation-evidence-${{ github.run_id }}
+          path: tests/red_team/evidence/*.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -8,6 +8,37 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 jobs:
+  # Execution-grounded eval, tier 0 (ADR-017): generated commands actually
+  # RUN in just-bash (pure-JS bash, in-memory FS — no cloud, no secrets) and
+  # are graded on observed effects. Non-blocking while the honest baseline is
+  # established; see tests/evaluation/datasets/posix/README.md.
+  execution-tier0:
+    name: Execution-grounded eval (tier 0)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install exec-harness (just-bash tier)
+        working-directory: tools/exec-harness
+        run: npm ci && npm test
+
+      - name: Run execution-grounded eval
+        run: |
+          cargo test --no-default-features --features embedded-cpu \
+            --test evaluation -- \
+            --dataset tests/evaluation/datasets/posix/exec_grounded.json \
+            --execution-tier tier0 || true
+
   evaluate:
     strategy:
       fail-fast: false  # Continue testing other backends even if one fails

--- a/.github/workflows/website-qa-kitesurf.yml
+++ b/.github/workflows/website-qa-kitesurf.yml
@@ -1,0 +1,81 @@
+# Nightly structural QA of caro.sh via Cloudflare Browser Run (Kitesurf).
+#
+# DORMANT until CARO_CF_ACCOUNT_ID / CARO_CF_API_TOKEN repo secrets exist
+# (human-created per decision D5) — without them the job skips green.
+# Non-blocking while Kitesurf is beta (ADR-017: beta services never gate
+# merges). BROWSER_MODE=chromium on manual dispatch uses the same endpoint
+# with real Chromium (paid) as the fallback engine.
+name: Website QA (Kitesurf)
+
+on:
+  schedule:
+    - cron: "43 4 * * *" # 04:43 UTC nightly, after the site's daily deploys
+  workflow_dispatch:
+    inputs:
+      browser_mode:
+        description: "Browser engine (kitesurf = free beta, chromium = paid fallback)"
+        type: choice
+        default: kitesurf
+        options: [kitesurf, chromium]
+      base_url:
+        description: "Base URL to test"
+        default: "https://caro.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  structural-qa:
+    name: Structural QA via Browser Run
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 30
+    steps:
+      - name: Gate on secrets
+        id: gate
+        env:
+          CF_ACCOUNT: ${{ secrets.CARO_CF_ACCOUNT_ID }}
+          CF_TOKEN: ${{ secrets.CARO_CF_API_TOKEN }}
+        run: |
+          if [ -n "$CF_ACCOUNT" ] && [ -n "$CF_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Kitesurf QA dormant: CARO_CF_ACCOUNT_ID / CARO_CF_API_TOKEN secrets not set (see website/e2e/README.md)"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install e2e deps
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: website/e2e
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" # remote CDP browser — nothing local needed
+        run: npm ci
+
+      - name: Run structural QA
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: website/e2e
+        env:
+          CARO_CF_ACCOUNT_ID: ${{ secrets.CARO_CF_ACCOUNT_ID }}
+          CARO_CF_API_TOKEN: ${{ secrets.CARO_CF_API_TOKEN }}
+          BROWSER_MODE: ${{ inputs.browser_mode || 'kitesurf' }}
+          CARO_QA_BASE_URL: ${{ inputs.base_url || 'https://caro.sh' }}
+        run: npm test
+
+      - name: Upload results
+        if: steps.gate.outputs.enabled == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-qa-${{ github.run_id }}
+          path: website/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/COMPANY.md
+++ b/COMPANY.md
@@ -115,6 +115,21 @@ decision-maker inherits the reasoning):
   feature PR. Full record with alternatives:
   [`docs/decisions/2026-07-12-autonomous-mode-release-scope.md`](./docs/decisions/2026-07-12-autonomous-mode-release-scope.md).
 
+- **2026-09-06 — Cloudflare as assistive verification infrastructure,
+  not a runtime dependency.** Adopted Cloudflare compute (Sandbox
+  containers, Browser Run/Kitesurf, `@cloudflare/computer` preview) for
+  the *dev harness only*: execution-grounded eval, safety-corpus
+  detonation, and structural website QA — internal tooling, exempt from
+  validation gates. The product keeps zero runtime dependency on any
+  cloud vendor; every user-facing cloud-execution idea was parked as an
+  unvalidated hypothesis (`sandbox-preview-ux`, `live-playground`,
+  `agentic-loop` — 0/20 each), consistent with the local-first and
+  multi-vendor-resilience commitments above. Vendor account and API
+  tokens are human-created (per the 2026-07-12 D5 human-required
+  limits). Architecture, tier policy (GA-only for anything that could
+  gate CI), and vendor seam:
+  [`docs/adr/ADR-017-cloud-assisted-verification.md`](./docs/adr/ADR-017-cloud-assisted-verification.md).
+
 ## How to contribute to "the company part"
 
 - **Marketing / DevRel work** lives in the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,9 @@ futures = "0.3"
 serde_yaml = "0.9"
 env_logger = "0.11"
 wiremock = "0.5"
+# Same version+features as the base dependency (minus "stream"): resolves to the
+# already-present crate, adds no transitives. Used by tests/red_team/ only.
+reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 
 [[bench]]
 name = "cache"

--- a/docs/SECURITY-CHECKLIST.md
+++ b/docs/SECURITY-CHECKLIST.md
@@ -20,7 +20,7 @@ green, not by trust but by grep.
 | 3 | **Secret scanning** — no API keys / tokens / credentials in source | GitHub secret scanning + pre-commit hook | `grep -E '(api[_-]?key\|token\|secret)\s*[:=]\s*["'\''][a-zA-Z0-9]{20,}' -r src/ website/src/ docs/` finds nothing real |
 | 4 | **No bundled credentials in binaries** — release artifacts contain no defaults that grant network access | `cargo dist` build + spot-check | `strings target/release/caro \| grep -iE '(sk-\|ghp_\|api[_-]key)'` returns nothing |
 | 5 | **Safety pattern coverage** — 52+ dangerous-command patterns, zero false positives in regression suite | `cargo test --features safety` | `cargo test --features safety` green |
-| 6 | **Sandbox boundary on execution** — bubblewrap on Linux (ADR-010), explicit user confirmation otherwise | `tests/integration/safety/` | Integration tests under `tests/safety/` green |
+| 6 | **Sandbox boundary on execution** — local bwrap sandbox is ADR-010 (Proposed, unimplemented); until it lands, the boundary is explicit user confirmation + the detonation-verified pattern corpus | `tests/red_team/` (nightly, ADR-017) | Latest `detonation-nightly` run green with no risk-label contradictions in the evidence artifact |
 | 7 | **Telemetry redaction** — no command content / paths / env vars / PII leak | Privacy audit + redaction-pattern tests | `cargo test redaction` green; `docs/TELEMETRY.md` audit current |
 | 8 | **Supply-chain signing** — release binaries reproducibly buildable, SHA256s published | `.github/workflows/release.yml` | `gh release view vX.Y.Z` shows checksums |
 | 9 | **Constitution review** — release PR touches every file in `.claude/rules/release-version-alignment.md` | Manual PR review | All 6 release files modified |
@@ -84,8 +84,9 @@ strings target/release/caro | grep -iE '(sk-|ghp_|api[_-]key)=[a-zA-Z0-9]' \
   | (! grep . > /dev/null) && echo "✓ Gate 4"
 # 5. Safety suite
 cargo test --features safety && echo "✓ Gate 5"
-# 6. Sandbox tests
-cargo test --test 'safety_*' && echo "✓ Gate 6"
+# 6. Detonation lane (requires deployed worker + secrets; see tools/exec-harness/worker/README.md)
+CARO_DETONATION_URL=... CARO_DETONATION_TOKEN=... \
+  cargo test --test red_team -- --ignored && echo "✓ Gate 6"
 # 7. Redaction tests
 cargo test redaction && echo "✓ Gate 7"
 # 8. Release checksums (post-tag)

--- a/docs/adr/ADR-017-cloud-assisted-verification.md
+++ b/docs/adr/ADR-017-cloud-assisted-verification.md
@@ -1,0 +1,184 @@
+# ADR-017: Cloud-Assisted Verification (execution-grounded eval, detonation, browser QA)
+
+**Status**: Proposed
+**Date**: 2026-09-06
+**Deciders**: Autonomous session (per D5 protocol in
+[`docs/decisions/2026-07-12-autonomous-mode-release-scope.md`](../decisions/2026-07-12-autonomous-mode-release-scope.md));
+recorded in `COMPANY.md` decision log
+**Target audience**: Community Edition (dev infrastructure); no user-facing change
+
+## Context
+
+Caro's two central claims were, until this ADR, never verified by execution:
+
+1. **"The generated command actually works."** Every eval layer stops at
+   string comparison (`src/evaluation/evaluators/correctness.rs`); the
+   POSIX/BSD checks are regex heuristics; `tests/quickstart_scenarios.rs`
+   admits "full execution testing requires execution module (future work)".
+2. **"The 52+ safety patterns block real danger."** Safety is tested as
+   *classification* only; `tests/red_team/` was promised (`HELP_WANTED.md`)
+   and `docs/SECURITY-CHECKLIST.md` Gate 6 pointed at a directory that did
+   not exist. Nothing was ever detonated to confirm a pattern's risk label
+   corresponds to real destructive effect.
+
+Separately, caro.sh (58 pages × 15 locales) had zero browser-level QA: the
+documented L1 regression class (raw i18n keys rendered on production) could
+only be caught by a human looking.
+
+Two 2026 Cloudflare releases change the cost of closing these gaps:
+[`@cloudflare/sandbox`](https://developers.cloudflare.com/sandbox/) (GA
+Apr 2026: disposable real-Linux containers with an exec/file API) and
+[Kitesurf](https://blog.cloudflare.com/kitesurf/) (Aug 2026 free beta: an
+agent-first browser engine on Workers, CDP-compatible, 3–7× cheaper than
+Chromium). The preview-stage
+[`@cloudflare/computer`](https://github.com/cloudflare/computer) unifies
+isolate/container execution behind one workspace API, and its isolate-shell
+backend is [`just-bash`](https://github.com/vercel-labs/just-bash) — a
+pure-TypeScript bash with an in-memory filesystem that also runs in plain
+Node with **no cloud account at all**.
+
+Governance context that shapes the decision: dev-harness/internal tooling is
+explicitly exempt from `validation-discipline.md`; every user-facing
+cloud-execution idea is hard-blocked at Gate 1 (0/20 transcripts);
+[ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) (Proposed) is the
+standing *local* sandbox position; `COMPANY.md` commits to local-first
+privacy and multi-vendor resilience; and the 2026-05-15 strategy memo
+already scored Cloudflare sandboxes "Adjacent — complementary layers" with
+Opportunity 4 ("Trusted Execution Target Manifest") as the blessed
+product-side direction.
+
+## Decision
+
+Adopt cloud execution **as assistive verification infrastructure for the dev
+harness**, behind a provider-neutral protocol, in three tiers. Build no
+user-facing cloud execution.
+
+### One protocol, three tiers
+
+All execution flows through the JSONL contract in
+[`tools/exec-harness/PROTOCOL.md`](../../tools/exec-harness/PROTOCOL.md)
+(request: command + fixture files + timeout; response: exit code, output,
+fs_diff, `unsupported` flag). The protocol — not any vendor SDK — is the
+integration surface.
+
+| Tier | Engine | Cost / secrets | Allowed role |
+|------|--------|----------------|--------------|
+| 0 | just-bash in plain Node (`tools/exec-harness/`) | $0, none | CI-blocking-eligible smoke; runs today |
+| 1 | `@cloudflare/sandbox` **GA** containers (`tools/exec-harness/worker/`) | ~$5/mo Workers Paid + pay-per-use | non-blocking nightly; may graduate to blocking only after a quarter of nightly stability |
+| 2 | `@cloudflare/computer` **preview** + Kitesurf **beta** | free (beta) | experimental / non-blocking lanes only, pinned versions, never load-bearing |
+
+Consumers landed with this ADR:
+
+- **Execution-grounded eval**: `TestCategory::Execution` +
+  `ExecutionEvaluator` (`src/evaluation/evaluators/execution.rs`) grade
+  *observed behavior* (exit code, stdout, filesystem effects) instead of
+  command strings, via `--execution-tier tier0` on the eval CLI, against
+  `tests/evaluation/datasets/posix/exec_grounded.json`. Grading philosophy:
+  an engine gap is a SKIP, never a FAIL — pass-rates measure command
+  quality, not harness availability.
+- **Detonation lane**: `tests/red_team/` executes the dangerous-command
+  corpus in egress-restricted throwaway containers (`/detonate` route) and
+  fails on risk-label contradictions (a "critical" command that completes
+  exit-0 with zero observable effects). Evidence artifacts per run.
+  This makes SECURITY-CHECKLIST Gate 6 real.
+- **Website structural QA**: `website/e2e/` drives Kitesurf over CDP for
+  raw-i18n-key leak scans, link integrity, DOM structure, and
+  renders-at-all screenshots. **Explicitly not visual/brand fidelity** —
+  Kitesurf is not pixel-perfect; the claude-design Chromium flow
+  (`.claude/rules/design-dialogue-protocol.md`) keeps brand audits. The
+  Remotion demo re-render also stays on real Chromium. Kitesurf's REST
+  screenshot endpoint MAY replace the human-local-Chrome loop for
+  *structural* audits of public pages only.
+
+### Relation to ADR-010 (bubblewrap)
+
+Complementary, not competing. ADR-010 remains the plan for the *local*
+execution boundary on a user's machine. This ADR's remote tiers answer
+ADR-010's own stated trade-offs — "Linux-first" (a remote Linux container
+serves macOS/Windows developers) and the rejected local-Docker-daemon
+requirement (a remote API needs no daemon) — for *harness* use. When
+ADR-010's `SandboxBackend` trait lands, `RemoteSandbox` (a thin reqwest
+client speaking PROTOCOL.md) becomes one more implementation beside
+`bubblewrap.rs`.
+
+### Forward design (specced, not built): CaroML runbook verification
+
+The one product-adjacent wedge, gated behind feature flag `sandbox-verify`
+(never default): CaroML (shipped v1.4.0) compiles `.caro` tasks to
+per-platform runbooks it cannot verify on platforms the user isn't on.
+A `RemoteSandbox` implementation of ADR-010's trait shape lets
+`regen_evaluator` record `verified_on: [linux]` in the lock and rank
+`--explore` challenger variants by actual execution success. Egress
+hygiene, in order: CaroML `validators/secrets.rs` (refuse on findings) →
+`ContextSanitizer` (`src/backends/hybrid/sanitizer.rs`, the shipped ADR-015
+pattern) → send → `restore()`. Opt-in flag + config only; macOS/Windows
+runbooks surface as `unverified`, never silently trusted. This extends the
+validated core loop (exempt per the v2.0 audit's extension principle); it
+ships as a `feat:` PR with the full feature-evidence trio when built.
+
+### Product-side posture
+
+- **Parked as unvalidated hypotheses** (0/20, see
+  [`hypothesis-ledger.md`](../discovery/hypothesis-ledger.md)):
+  `sandbox-preview-ux` (verified preview instead of y/N via
+  `SuggestedRouting`), `live-playground` (execution-backed try-caro; the
+  current scripted mock stays a marketing surface), `agentic-loop`
+  (execute→observe→retry). Standard Gate 1 evidence graduates them.
+- **Blessed export direction** (strategy-memo Opportunity 4, future work):
+  `caro-profile.json` — caro exports safety policy INTO sandbox runtimes
+  (Cloudflare's included) with zero runtime dependency. Tracked separately;
+  not part of this ADR's build.
+
+### Non-negotiables (the "must-nots")
+
+1. No Rust vendor SDK — the product's only HTTP surface stays `reqwest`
+   (<50 MB binary, MSRV 1.85 untouched).
+2. No default-on features; everything cloud-touching is opt-in.
+3. No command/runbook content leaves a machine without secrets-validator +
+   sanitizer + explicit opt-in.
+4. Nothing CI-blocking may depend on preview (`computer`) or beta
+   (Kitesurf) APIs. Only GA `@cloudflare/sandbox` may ever back a required
+   check, and only after a quarter of nightly stability.
+5. Vendor accounts and API tokens are created by humans (D5). All
+   workflows skip green when secrets are absent.
+6. Multi-vendor seam: PROTOCOL.md is the boundary. E2B, local Docker, or
+   bwrap slot in as alternative protocol servers / `SandboxBackend` impls
+   without touching evaluators or tests.
+
+## Consequences
+
+**Positive**: caro's core claims become measurable (execution-grounded pass
+rates; detonation-verified risk labels); the missing `tests/red_team/`
+exists; the L1 website regression class is caught nightly for free; tier 0
+gives contributors a zero-setup local execution harness; the seam keeps
+vendor lock-in at one directory.
+
+**Negative / accepted costs**: ~$5/mo + sub-$10/mo container usage once
+activated; tier-0 dialect gaps require honest `tier0` labels in datasets;
+two dormant workflows until secrets exist; just-bash (Apache-2.0) and
+`@cloudflare/sandbox` (worker-side) enter the dev-dependency surface
+(license-compatible with AGPL-3.0; nothing links into the shipped binary).
+
+**Risks**: Kitesurf/beta churn (mitigated: non-blocking + `BROWSER_MODE=chromium`
+fallback via the same endpoint); `computer` API instability (mitigated:
+experimental lane only); sandbox blind spots hiding real blast radius
+(mitigated: the detonation suite fails on label contradictions so blind
+spots surface as findings, and the canary tree + system-intact probe cover
+the common classes).
+
+## Activation
+
+Human steps (D5): create the Cloudflare account, Workers Paid, API token;
+add repo secrets `CARO_CF_ACCOUNT_ID`, `CARO_CF_API_TOKEN`, and after
+worker deploy `CARO_DETONATION_URL`, `CARO_DETONATION_TOKEN`. Full
+checklist: [`tools/exec-harness/worker/README.md`](../../tools/exec-harness/worker/README.md).
+Until then: tier 0 and its eval lane run everywhere with zero secrets.
+
+## See also
+
+- [`tools/exec-harness/PROTOCOL.md`](../../tools/exec-harness/PROTOCOL.md) — the contract
+- [ADR-010](./ADR-010-bubblewrap-sandbox-execution.md) — local sandbox (complementary)
+- [ADR-015](./ADR-015-distributed-llm-backends-hybrid-privacy.md) — the sanitizer pattern P5 reuses
+- [`market-scans/2026-05-15-ai-agent-strategy-memo.md`](../../market-scans/2026-05-15-ai-agent-strategy-memo.md) — Opportunity 4
+- [`.claude/rules/validation-discipline.md`](../../.claude/rules/validation-discipline.md) — why product-side work is parked
+- [`docs/discovery/hypothesis-ledger.md`](../discovery/hypothesis-ledger.md) — the parked hypotheses

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ Example: `ADR-001-enterprise-community-architecture.md`
 | [ADR-014](./ADR-014-serde-env-evaluation.md) | Environment Variable Deserialization with serde-env | Proposed | 2026-01-01 |
 | [ADR-015](./ADR-015-distributed-llm-backends-hybrid-privacy.md) | Distributed-LLM Backends (Mesh-LLM, AI-Horde) via a Hybrid Privacy Gateway | Accepted | 2026-06-07 |
 | [ADR-016](./ADR-016-ponytail-pragmatic-reviewer.md) | Ponytail Pragmatic-Skeptic Reviewer (Additive Adoption) | Accepted | 2026-06-14 |
+| [ADR-017](./ADR-017-cloud-assisted-verification.md) | Cloud-Assisted Verification (execution-grounded eval, detonation, browser QA) | Proposed | 2026-09-06 |
 
 ## Contributing to ADRs
 

--- a/docs/discovery/hypothesis-ledger.md
+++ b/docs/discovery/hypothesis-ledger.md
@@ -38,10 +38,22 @@ A hypothesis graduates from `unvalidated` only when:
 | `self-healing` | Users want commands to retry/recover automatically on certain failure classes | 0 | 0 | `unvalidated` | 2026-05-25 | none |
 | `local-context-indexing` | Users want Caro to know about their repo / shell history / open files when generating commands | 0 | 0 | `unvalidated` | 2026-05-25 | none |
 | `enterprise-dashboard` | CISOs want a centralized policy + audit-trail surface for Caro deployments | 0 | 0 | `unvalidated` (**next priority** — calibrated script at [`interview-enterprise-dashboard.md`](./interview-enterprise-dashboard.md)) | 2026-06-13 | none |
+| `sandbox-preview-ux` | Users want a "verified preview" (run the command in a disposable sandbox, show the effects) instead of a bare y/N confirmation for risky commands | 0 | 0 | `unvalidated` | 2026-09-06 | none |
+| `live-playground` | Prospects want to try real Caro in the browser (execution-backed try-caro, replacing the scripted mock) before installing | 0 | 0 | `unvalidated` | 2026-09-06 | none |
+| `agentic-loop` | Users want Caro to execute→observe→retry multi-step tasks autonomously in a sandboxed environment | 0 | 0 | `unvalidated` | 2026-09-06 | none |
 
 The `caro-core` row is grandfathered because the rule applies forward
 from May 25, 2026. The full retroactive audit for each v2.0 hypothesis
 is in [`v2.0-validation-audit.md`](./v2.0-validation-audit.md).
+
+The three `sandbox-*`/`live-playground`/`agentic-loop` rows were coined
+by [ADR-017](../adr/ADR-017-cloud-assisted-verification.md)
+(cloud-assisted verification). Note what is deliberately NOT under
+them: the dev-harness execution tiers (internal tooling, exempt) and
+CaroML cross-platform runbook verification (extends the shipped CaroML
+loop — an *extension of the validated core* per the
+[audit's exemption principle](./v2.0-validation-audit.md), same class
+as ROADMAP's Handy.Computer #662).
 
 ## Synthesis entries
 
@@ -80,6 +92,22 @@ First synthesis entry will appear here after 5 interviews; per
 this is the next-highest-priority discovery target because the
 pricing-enterprise waitlist CTA gives it a defined outreach
 surface.*
+
+### `sandbox-preview-ux` synthesis
+
+*No transcripts logged yet. Candidate probe questions: what do users do
+today before running a command they don't fully trust? Has anyone been
+burned by a confirmed-then-regretted command?*
+
+### `live-playground` synthesis
+
+*No transcripts logged yet. The existing scripted mock at
+`/try-caro` provides a measurement surface (visits, chip clicks →
+waitlist conversions) before any interview.*
+
+### `agentic-loop` synthesis
+
+*No transcripts logged yet.*
 
 ## Pain pattern slugs
 

--- a/src/evaluation/evaluators/consistency.rs
+++ b/src/evaluation/evaluators/consistency.rs
@@ -309,6 +309,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![
@@ -344,6 +345,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![
@@ -381,6 +383,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![
@@ -413,6 +416,7 @@ mod tests {
             difficulty: Some(Difficulty::Medium),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![
@@ -454,6 +458,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![CommandResult::success(
@@ -488,6 +493,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::success("ls -al".to_string(), 100, "backend-1".to_string());
@@ -514,6 +520,7 @@ mod tests {
             difficulty: Some(Difficulty::Hard),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let results = vec![

--- a/src/evaluation/evaluators/correctness.rs
+++ b/src/evaluation/evaluators/correctness.rs
@@ -192,6 +192,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::success("ls -la".to_string(), 100, "test".to_string());
@@ -216,6 +217,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::success("ls -l".to_string(), 100, "test".to_string());
@@ -240,6 +242,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Test equivalent command (different flag order)
@@ -264,6 +267,7 @@ mod tests {
             difficulty: Some(Difficulty::Medium),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result =
@@ -288,6 +292,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::failed("Backend timeout".to_string(), 100, "test".to_string());

--- a/src/evaluation/evaluators/execution.rs
+++ b/src/evaluation/evaluators/execution.rs
@@ -1,0 +1,624 @@
+//! Execution-grounded evaluator
+//!
+//! Every other evaluator in this module judges the generated command *string*.
+//! This one actually runs the command in a disposable sandbox and scores what
+//! happened: exit code, stdout, and filesystem effects. The sandbox is reached
+//! over the provider-neutral JSONL protocol in `tools/exec-harness/PROTOCOL.md`;
+//! tier 0 is `just-bash` in a local Node child process (in-memory filesystem,
+//! nothing ever touches the host).
+//!
+//! Grading philosophy: an engine gap is never a command failure. When the tier
+//! cannot run at all (disabled, node missing, `npm ci` not run) or the engine
+//! reports the command `unsupported`, the case is SKIPPED (passes with an
+//! explanatory `actual_behavior`), so pass-rates measure command quality, not
+//! harness availability. See `docs/adr/ADR-017-cloud-assisted-verification.md`.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use crate::evaluation::errors::Result;
+use crate::evaluation::evaluators::{CommandResult, Evaluator};
+use crate::evaluation::{ErrorType, EvaluationResult, TestCase, TestCategory, Tier0Support};
+
+/// Per-command execution budget sent to the runner. Kept well under the
+/// Evaluator trait's 5-second contract (the runner adds snapshot overhead).
+const EXEC_TIMEOUT_MS: u64 = 3_000;
+
+/// Which execution tier backs `TestCategory::Execution` cases.
+///
+/// `Off` is the default everywhere: execution grounding is strictly opt-in
+/// (`--execution-tier tier0` on the eval CLI) and its absence never fails a
+/// run. Remote tiers (Cloudflare containers) are future variants — see
+/// ADR-017 for the policy on which tiers may back CI-blocking jobs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExecutionTier {
+    /// Execution cases are skipped (default)
+    #[default]
+    Off,
+    /// just-bash in a local Node child process (no network, no secrets)
+    Tier0,
+}
+
+/// Response shape of the exec-harness protocol (PROTOCOL.md).
+#[derive(Debug, Clone, Deserialize)]
+struct ExecResponse {
+    #[serde(default)]
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    exit_code: i64,
+    #[serde(default)]
+    stdout: String,
+    #[serde(default)]
+    unsupported: bool,
+    #[serde(default)]
+    timed_out: bool,
+    #[serde(default)]
+    fs_diff: FsDiff,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct FsDiff {
+    #[serde(default)]
+    created: Vec<String>,
+    #[serde(default)]
+    removed: Vec<String>,
+    #[serde(default)]
+    modified: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecRequest<'a> {
+    id: &'a str,
+    command: &'a str,
+    fixture_files: &'a HashMap<String, String>,
+    timeout_ms: u64,
+}
+
+/// A running tier-0 server child process.
+struct Tier0Runner {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl Tier0Runner {
+    /// Locates `tools/exec-harness` — env override first, then the repo the
+    /// binary was compiled from, then the current directory. Internal tooling:
+    /// eval runs happen from a checkout.
+    fn harness_dir() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("CARO_EXEC_HARNESS_DIR") {
+            return Some(PathBuf::from(dir));
+        }
+        [
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tools/exec-harness"),
+            PathBuf::from("tools/exec-harness"),
+        ]
+        .into_iter()
+        .find(|candidate| candidate.join("src/serve.mjs").exists())
+    }
+
+    fn start() -> std::result::Result<Self, String> {
+        let dir = Self::harness_dir().ok_or_else(|| {
+            "tools/exec-harness not found (set CARO_EXEC_HARNESS_DIR to override)".to_string()
+        })?;
+        let node = std::env::var("CARO_NODE_BIN").unwrap_or_else(|_| "node".to_string());
+
+        let mut child = Command::new(&node)
+            .arg(dir.join("src/serve.mjs"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("failed to spawn `{node}`: {e}"))?;
+
+        let stdin = child.stdin.take().expect("stdin piped");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout piped"));
+        let mut runner = Self {
+            child,
+            stdin,
+            stdout,
+        };
+
+        // Handshake proves the engine loaded (a missing `npm ci` fails here).
+        let pong = runner
+            .round_trip(&serde_json::json!({"op": "ping"}).to_string())
+            .map_err(|e| format!("handshake failed: {e} (run `npm ci` in tools/exec-harness)"))?;
+        if !pong.contains("\"pong\"") {
+            return Err(format!("unexpected handshake response: {pong}"));
+        }
+        Ok(runner)
+    }
+
+    fn round_trip(&mut self, line: &str) -> std::result::Result<String, String> {
+        writeln!(self.stdin, "{line}").map_err(|e| format!("write failed: {e}"))?;
+        self.stdin
+            .flush()
+            .map_err(|e| format!("flush failed: {e}"))?;
+        let mut response = String::new();
+        let read = self
+            .stdout
+            .read_line(&mut response)
+            .map_err(|e| format!("read failed: {e}"))?;
+        if read == 0 {
+            return Err("runner exited (EOF)".to_string());
+        }
+        Ok(response)
+    }
+}
+
+impl Drop for Tier0Runner {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+enum RunnerState {
+    NotStarted,
+    Ready(Box<Tier0Runner>),
+    /// Start failed once; remembered so every subsequent case skips with the
+    /// same reason instead of re-spawning node per case.
+    Unavailable(String),
+}
+
+/// Evaluator for `TestCategory::Execution`: delegates to the configured
+/// execution tier and grades observed behavior against
+/// `TestCase::execution.expected`.
+pub struct ExecutionEvaluator {
+    tier: ExecutionTier,
+    runner: Arc<Mutex<RunnerState>>,
+}
+
+impl ExecutionEvaluator {
+    pub fn new(tier: ExecutionTier) -> Self {
+        Self {
+            tier,
+            runner: Arc::new(Mutex::new(RunnerState::NotStarted)),
+        }
+    }
+
+    /// Runs one command through the tier-0 runner. `Err(reason)` means the
+    /// harness itself is unavailable/broken — callers turn that into a SKIP.
+    fn run_tier0(
+        runner: &Mutex<RunnerState>,
+        test_case: &TestCase,
+        command: &str,
+    ) -> std::result::Result<ExecResponse, String> {
+        let empty = HashMap::new();
+        let fixture_files = test_case
+            .execution
+            .as_ref()
+            .map(|e| &e.fixture_files)
+            .unwrap_or(&empty);
+        let request = serde_json::to_string(&ExecRequest {
+            id: &test_case.id,
+            command,
+            fixture_files,
+            timeout_ms: EXEC_TIMEOUT_MS,
+        })
+        .map_err(|e| format!("request encode failed: {e}"))?;
+
+        let mut state = runner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if matches!(*state, RunnerState::NotStarted) {
+            *state = match Tier0Runner::start() {
+                Ok(r) => RunnerState::Ready(Box::new(r)),
+                Err(reason) => RunnerState::Unavailable(reason),
+            };
+        }
+        let active = match &mut *state {
+            RunnerState::Ready(r) => r,
+            RunnerState::Unavailable(reason) => return Err(reason.clone()),
+            RunnerState::NotStarted => unreachable!("initialized above"),
+        };
+
+        match active.round_trip(&request) {
+            Ok(line) => serde_json::from_str::<ExecResponse>(&line)
+                .map_err(|e| format!("bad runner response: {e}")),
+            Err(reason) => {
+                // A dead runner poisons the tier for the rest of the run.
+                *state = RunnerState::Unavailable(reason.clone());
+                Err(reason)
+            }
+        }
+    }
+
+    fn skip(&self, test_case: &TestCase, result: &CommandResult, reason: &str) -> EvaluationResult {
+        EvaluationResult {
+            test_id: test_case.id.clone(),
+            backend_name: result.backend_name.clone(),
+            passed: true,
+            actual_command: result.command.clone(),
+            actual_behavior: Some(format!("skipped: {reason}")),
+            failure_reason: None,
+            execution_time_ms: result.execution_time_ms,
+            timestamp: Utc::now(),
+            error_type: None,
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
+        }
+    }
+
+    fn fail(
+        &self,
+        test_case: &TestCase,
+        result: &CommandResult,
+        error_type: ErrorType,
+        reason: String,
+    ) -> EvaluationResult {
+        EvaluationResult {
+            test_id: test_case.id.clone(),
+            backend_name: result.backend_name.clone(),
+            passed: false,
+            actual_command: result.command.clone(),
+            actual_behavior: None,
+            failure_reason: Some(reason),
+            execution_time_ms: result.execution_time_ms,
+            timestamp: Utc::now(),
+            error_type: Some(error_type),
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
+            criteria_passed: 0,
+            criteria_total: 0,
+        }
+    }
+}
+
+/// Pure grading of a runner response against a case's expected effects.
+/// Returns (passed, criteria_passed, criteria_total, failure_reason, behavior).
+fn grade(
+    test_case: &TestCase,
+    response: &ExecResponse,
+) -> (bool, u32, u32, Option<String>, String) {
+    let expected = test_case
+        .execution
+        .as_ref()
+        .map(|e| e.expected.clone())
+        .unwrap_or_default();
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut passed_count: u32 = 0;
+    let mut total: u32 = 0;
+
+    // Exit code is always one criterion; omitted expectation means 0.
+    total += 1;
+    let want_exit = i64::from(expected.exit_code.unwrap_or(0));
+    if response.exit_code == want_exit {
+        passed_count += 1;
+    } else {
+        failures.push(format!(
+            "exit code {} (expected {})",
+            response.exit_code, want_exit
+        ));
+    }
+
+    if let Some(pattern) = &expected.stdout_pattern {
+        total += 1;
+        match regex::Regex::new(pattern) {
+            Ok(re) if re.is_match(&response.stdout) => passed_count += 1,
+            Ok(_) => failures.push(format!("stdout did not match /{pattern}/")),
+            Err(e) => failures.push(format!("bad stdout_pattern /{pattern}/: {e}")),
+        }
+    }
+
+    for (label, wanted, observed) in [
+        (
+            "created",
+            &expected.files_created,
+            &response.fs_diff.created,
+        ),
+        (
+            "removed",
+            &expected.files_removed,
+            &response.fs_diff.removed,
+        ),
+        (
+            "modified",
+            &expected.files_modified,
+            &response.fs_diff.modified,
+        ),
+    ] {
+        for path in wanted {
+            total += 1;
+            // Dataset paths are workspace-relative; the runner reports absolute.
+            let matched = observed
+                .iter()
+                .any(|p| p == path || p.strip_prefix("/work/") == Some(path.as_str()));
+            if matched {
+                passed_count += 1;
+            } else {
+                failures.push(format!("expected {path} to be {label}, it was not"));
+            }
+        }
+    }
+
+    let behavior = format!(
+        "exit {}; created {:?}; removed {:?}; modified {:?}",
+        response.exit_code,
+        response.fs_diff.created,
+        response.fs_diff.removed,
+        response.fs_diff.modified
+    );
+    let passed = failures.is_empty();
+    let failure_reason = if passed {
+        None
+    } else {
+        Some(failures.join("; "))
+    };
+    (passed, passed_count, total, failure_reason, behavior)
+}
+
+#[async_trait]
+impl Evaluator for ExecutionEvaluator {
+    fn category(&self) -> TestCategory {
+        TestCategory::Execution
+    }
+
+    async fn evaluate(
+        &self,
+        test_case: &TestCase,
+        result: &CommandResult,
+    ) -> Result<EvaluationResult> {
+        if self.tier == ExecutionTier::Off {
+            return Ok(self.skip(
+                test_case,
+                result,
+                "execution tier disabled (--execution-tier off)",
+            ));
+        }
+
+        // Execution cases assert runtime behavior, so the command must exist.
+        if result.blocked {
+            return Ok(self.fail(
+                test_case,
+                result,
+                ErrorType::ValidationFailure,
+                "command was blocked by safety validation; execution case expects it to run"
+                    .to_string(),
+            ));
+        }
+        let command = match &result.command {
+            Some(c) => c.clone(),
+            None => {
+                return Ok(self.fail(
+                    test_case,
+                    result,
+                    ErrorType::GenerationFailure,
+                    format!(
+                        "backend produced no command: {}",
+                        result.error.as_deref().unwrap_or("unknown error")
+                    ),
+                ));
+            }
+        };
+
+        // Cases labeled unsupported for this tier are dialect gaps, not bugs.
+        if test_case.execution.as_ref().and_then(|e| e.tier0) == Some(Tier0Support::Unsupported) {
+            return Ok(self.skip(test_case, result, "case labeled tier0=unsupported"));
+        }
+
+        let runner = Arc::clone(&self.runner);
+        let case = test_case.clone();
+        let outcome =
+            tokio::task::spawn_blocking(move || Self::run_tier0(&runner, &case, &command))
+                .await
+                .map_err(|e| {
+                    crate::evaluation::errors::EvaluationError::Other(format!(
+                        "execution task panicked: {e}"
+                    ))
+                })?;
+
+        let response = match outcome {
+            Ok(r) => r,
+            Err(reason) => {
+                return Ok(self.skip(
+                    test_case,
+                    result,
+                    &format!("tier0 exec harness unavailable: {reason}"),
+                ))
+            }
+        };
+
+        if !response.ok {
+            return Ok(self.skip(
+                test_case,
+                result,
+                &format!(
+                    "harness error: {}",
+                    response.error.as_deref().unwrap_or("unknown")
+                ),
+            ));
+        }
+        if response.unsupported {
+            return Ok(self.skip(
+                test_case,
+                result,
+                "command not implemented by tier0 engine (exit 127)",
+            ));
+        }
+        if response.timed_out {
+            return Ok(self.fail(
+                test_case,
+                result,
+                ErrorType::Timeout,
+                format!("execution exceeded {EXEC_TIMEOUT_MS}ms budget"),
+            ));
+        }
+
+        let (passed, criteria_passed, criteria_total, failure_reason, behavior) =
+            grade(test_case, &response);
+
+        Ok(EvaluationResult {
+            test_id: test_case.id.clone(),
+            backend_name: result.backend_name.clone(),
+            passed,
+            actual_command: result.command.clone(),
+            actual_behavior: Some(behavior),
+            failure_reason,
+            execution_time_ms: result.execution_time_ms,
+            timestamp: Utc::now(),
+            error_type: if passed {
+                None
+            } else {
+                Some(ErrorType::IncorrectOutput)
+            },
+            est_tokens_in: 0,
+            est_tokens_out: 0,
+            est_cost_usd: 0.0,
+            criteria_passed,
+            criteria_total,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evaluation::{ExecutionSpec, ExpectedEffects, ValidationRule};
+
+    fn exec_case(expected: ExpectedEffects) -> TestCase {
+        TestCase {
+            id: "exec-test".to_string(),
+            category: TestCategory::Execution,
+            input_request: "sort data".to_string(),
+            expected_command: None,
+            expected_behavior: None,
+            validation_rule: ValidationRule::MustExecute,
+            validation_pattern: None,
+            tags: vec![],
+            difficulty: None,
+            source: None,
+            notes: None,
+            execution: Some(ExecutionSpec {
+                fixture_files: HashMap::new(),
+                expected,
+                tier0: None,
+            }),
+        }
+    }
+
+    fn generated(command: &str) -> CommandResult {
+        CommandResult::success(command.to_string(), 5, "static_matcher".to_string())
+    }
+
+    fn response(exit_code: i64, stdout: &str, created: &[&str]) -> ExecResponse {
+        ExecResponse {
+            ok: true,
+            error: None,
+            exit_code,
+            stdout: stdout.to_string(),
+            unsupported: false,
+            timed_out: false,
+            fs_diff: FsDiff {
+                created: created.iter().map(|s| s.to_string()).collect(),
+                removed: vec![],
+                modified: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn grade_passes_on_default_exit_zero() {
+        let case = exec_case(ExpectedEffects::default());
+        let (passed, ok, total, reason, _) = grade(&case, &response(0, "", &[]));
+        assert!(passed);
+        assert_eq!((ok, total), (1, 1));
+        assert!(reason.is_none());
+    }
+
+    #[test]
+    fn grade_fails_on_unexpected_exit_code() {
+        let case = exec_case(ExpectedEffects::default());
+        let (passed, ok, total, reason, _) = grade(&case, &response(2, "", &[]));
+        assert!(!passed);
+        assert_eq!((ok, total), (0, 1));
+        assert!(reason.unwrap().contains("exit code 2"));
+    }
+
+    #[test]
+    fn grade_matches_workspace_relative_created_files() {
+        let case = exec_case(ExpectedEffects {
+            files_created: vec!["out/sorted.txt".to_string()],
+            ..Default::default()
+        });
+        let (passed, ok, total, _, _) = grade(&case, &response(0, "", &["/work/out/sorted.txt"]));
+        assert!(passed);
+        assert_eq!((ok, total), (2, 2));
+    }
+
+    #[test]
+    fn grade_scores_stdout_pattern() {
+        let case = exec_case(ExpectedEffects {
+            stdout_pattern: Some(r"^\s*2\b".to_string()),
+            ..Default::default()
+        });
+        let (passed, ..) = grade(&case, &response(0, "2 matches\n", &[]));
+        assert!(passed);
+        let (failed, _, _, reason, _) = grade(&case, &response(0, "nope\n", &[]));
+        assert!(!failed);
+        assert!(reason.unwrap().contains("stdout"));
+    }
+
+    #[tokio::test]
+    async fn off_tier_skips_and_passes() {
+        let evaluator = ExecutionEvaluator::new(ExecutionTier::Off);
+        let case = exec_case(ExpectedEffects::default());
+        let result = evaluator.evaluate(&case, &generated("true")).await.unwrap();
+        assert!(result.passed);
+        assert!(result.actual_behavior.unwrap().starts_with("skipped:"));
+    }
+
+    #[tokio::test]
+    async fn unavailable_runner_skips_and_passes() {
+        std::env::set_var("CARO_EXEC_HARNESS_DIR", "/nonexistent/exec-harness");
+        let evaluator = ExecutionEvaluator::new(ExecutionTier::Tier0);
+        let case = exec_case(ExpectedEffects::default());
+        let result = evaluator.evaluate(&case, &generated("true")).await.unwrap();
+        std::env::remove_var("CARO_EXEC_HARNESS_DIR");
+        assert!(result.passed);
+        assert!(result.actual_behavior.unwrap().contains("unavailable"));
+    }
+
+    #[tokio::test]
+    async fn blocked_command_fails_execution_case() {
+        let evaluator = ExecutionEvaluator::new(ExecutionTier::Tier0);
+        let case = exec_case(ExpectedEffects::default());
+        let blocked = CommandResult::blocked(5, "static_matcher".to_string());
+        let result = evaluator.evaluate(&case, &blocked).await.unwrap();
+        assert!(!result.passed);
+        assert_eq!(result.error_type, Some(ErrorType::ValidationFailure));
+    }
+
+    /// Full round-trip through the real Node runner. Requires `npm ci` in
+    /// tools/exec-harness (matches the repo convention for env-gated tests).
+    #[tokio::test]
+    #[ignore = "requires node + npm ci in tools/exec-harness"]
+    async fn live_tier0_round_trip() {
+        let evaluator = ExecutionEvaluator::new(ExecutionTier::Tier0);
+        let mut case = exec_case(ExpectedEffects {
+            files_created: vec!["sorted.txt".to_string()],
+            ..Default::default()
+        });
+        case.execution.as_mut().unwrap().fixture_files =
+            HashMap::from([("data.txt".to_string(), "b\na\nb\n".to_string())]);
+        let result = evaluator
+            .evaluate(&case, &generated("sort -u data.txt > sorted.txt"))
+            .await
+            .unwrap();
+        assert!(result.passed, "failure: {:?}", result.failure_reason);
+        assert_eq!(result.criteria_total, 2);
+    }
+}

--- a/src/evaluation/evaluators/mod.rs
+++ b/src/evaluation/evaluators/mod.rs
@@ -96,6 +96,7 @@ pub trait Evaluator: Send + Sync {
 // Sub-modules for specific evaluator implementations
 pub mod consistency;
 pub mod correctness;
+pub mod execution;
 pub mod posix;
 pub mod safety;
 pub mod utils;
@@ -103,5 +104,6 @@ pub mod utils;
 // Re-exports for public API
 pub use consistency::ConsistencyEvaluator;
 pub use correctness::CorrectnessEvaluator;
+pub use execution::{ExecutionEvaluator, ExecutionTier};
 pub use posix::POSIXEvaluator;
 pub use safety::SafetyEvaluator;

--- a/src/evaluation/evaluators/posix.rs
+++ b/src/evaluation/evaluators/posix.rs
@@ -138,6 +138,7 @@ mod tests {
             difficulty: Some(Difficulty::Medium),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::success("find . -mtime 0".to_string(), 100, "test".to_string());
@@ -162,6 +163,7 @@ mod tests {
             difficulty: Some(Difficulty::Medium),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Command uses GNU extension (-mtime -1)
@@ -195,6 +197,7 @@ mod tests {
             difficulty: Some(Difficulty::Medium),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Command uses bash-specific [[ operator
@@ -228,6 +231,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Command uses GNU long options
@@ -252,6 +256,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::failed("Timeout".to_string(), 100, "test".to_string());

--- a/src/evaluation/evaluators/safety.rs
+++ b/src/evaluation/evaluators/safety.rs
@@ -170,6 +170,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: Some("manual".to_string()),
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::blocked(100, "test".to_string());
@@ -194,6 +195,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Dangerous command that was NOT blocked (test should fail)
@@ -222,6 +224,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         let result = CommandResult::success("ls ~/".to_string(), 100, "test".to_string());
@@ -246,6 +249,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: None,
             notes: None,
+            execution: None,
         };
 
         // Safe command that was incorrectly blocked

--- a/src/evaluation/harness.rs
+++ b/src/evaluation/harness.rs
@@ -88,6 +88,10 @@ pub struct HarnessConfig {
 
     /// Maximum number of concurrent backend operations
     pub max_concurrency: usize,
+
+    /// Which sandbox tier backs `TestCategory::Execution` cases (default Off:
+    /// execution cases are skipped, never failed, when no tier is enabled)
+    pub execution_tier: crate::evaluation::ExecutionTier,
 }
 
 impl Default for HarnessConfig {
@@ -97,6 +101,7 @@ impl Default for HarnessConfig {
             skip_unavailable: true,
             regression_threshold: 0.95, // 95% pass rate
             max_concurrency: 10,
+            execution_tier: crate::evaluation::ExecutionTier::Off,
         }
     }
 }
@@ -155,6 +160,11 @@ impl EvaluationHarness {
         evaluators.insert(
             TestCategory::MultiBackend,
             Arc::new(ConsistencyEvaluator::new()),
+        );
+
+        evaluators.insert(
+            TestCategory::Execution,
+            Arc::new(ExecutionEvaluator::new(config.execution_tier)),
         );
 
         Ok(Self {
@@ -591,6 +601,7 @@ impl EvaluationHarness {
             TestCategory::Safety,
             TestCategory::POSIX,
             TestCategory::MultiBackend,
+            TestCategory::Execution,
         ] {
             let category_tests: Vec<_> = results
                 .iter()
@@ -817,6 +828,7 @@ mod tests {
                 difficulty: Some(Difficulty::Easy),
                 source: None,
                 notes: None,
+                execution: None,
             },
             TestCase {
                 id: "test-002".to_string(),
@@ -830,6 +842,7 @@ mod tests {
                 difficulty: Some(Difficulty::Easy),
                 source: None,
                 notes: None,
+                execution: None,
             },
         ])
     }

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -69,6 +69,6 @@ pub mod sft_export;
 pub use baseline::BaselineStore;
 pub use dataset::*;
 pub use errors::*;
-pub use evaluators::{CommandResult, Evaluator};
+pub use evaluators::{CommandResult, Evaluator, ExecutionEvaluator, ExecutionTier};
 pub use harness::{EvaluationHarness, HarnessConfig};
 pub use models::*;

--- a/src/evaluation/models.rs
+++ b/src/evaluation/models.rs
@@ -23,6 +23,9 @@ pub enum TestCategory {
     POSIX,
     /// Validates consistency across different inference backends
     MultiBackend,
+    /// Validates observed runtime behavior by executing the generated command
+    /// in a disposable sandbox (see `tools/exec-harness/PROTOCOL.md`)
+    Execution,
 }
 
 /// Validation rule for test case evaluation
@@ -86,6 +89,66 @@ pub enum ErrorType {
     BackendInconsistency,
 }
 
+/// How faithfully the tier-0 engine (just-bash) can execute a case's command.
+///
+/// just-bash is neither GNU nor BSD userland. This label keeps dialect gaps
+/// honest — a `partial`/`unsupported` case measures engine coverage, never
+/// command correctness. See `tools/exec-harness/PROTOCOL.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tier0Support {
+    /// Command runs faithfully on tier 0
+    Supported,
+    /// Command runs, but some flags/behavior differ from real userland
+    Partial,
+    /// Command (or a flag it needs) is not implemented by tier 0
+    Unsupported,
+}
+
+/// Observable effects an execution-grounded case expects from running the
+/// generated command in a sandbox. Every populated field is one scored
+/// criterion; an omitted `exit_code` defaults to expecting 0.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ExpectedEffects {
+    /// Expected exit code (None = expect 0)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+
+    /// Regex the captured stdout must match
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout_pattern: Option<String>,
+
+    /// Sandbox paths the command must create
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files_created: Vec<String>,
+
+    /// Sandbox paths the command must remove
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files_removed: Vec<String>,
+
+    /// Sandbox paths whose content the command must change
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files_modified: Vec<String>,
+}
+
+/// Execution-grounding data for `TestCategory::Execution` cases: the sandbox
+/// fixture to seed, the effects to assert, and the tier-0 fidelity label.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionSpec {
+    /// Files seeded into the sandbox workspace before execution
+    /// (relative path → content)
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub fixture_files: HashMap<String, String>,
+
+    /// Effects the command must produce
+    #[serde(default)]
+    pub expected: ExpectedEffects,
+
+    /// Tier-0 engine compatibility (None is treated as `supported`)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier0: Option<Tier0Support>,
+}
+
 /// Single labeled evaluation test case
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestCase {
@@ -128,6 +191,10 @@ pub struct TestCase {
     /// Additional context or documentation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
+
+    /// Execution-grounding data (Execution category only)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ExecutionSpec>,
 }
 
 /// Outcome of running one test case on one backend
@@ -506,6 +573,7 @@ mod tests {
             (TestCategory::Safety, "\"safety\""),
             (TestCategory::POSIX, "\"posix\""),
             (TestCategory::MultiBackend, "\"multi_backend\""),
+            (TestCategory::Execution, "\"execution\""),
         ];
 
         for (category, expected_json) in categories {
@@ -608,6 +676,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: Some("manual".to_string()),
             notes: None,
+            execution: None,
         };
 
         // Serialize to JSON
@@ -637,6 +706,7 @@ mod tests {
             difficulty: Some(Difficulty::Easy),
             source: Some("manual".to_string()),
             notes: None,
+            execution: None,
         };
 
         assert!(test_case.validate().is_ok());
@@ -656,6 +726,7 @@ mod tests {
             difficulty: None,
             source: None,
             notes: None,
+            execution: None,
         };
 
         assert!(test_case.validate().is_err());

--- a/src/evaluation/sft_export.rs
+++ b/src/evaluation/sft_export.rs
@@ -113,6 +113,7 @@ mod tests {
             difficulty: None,
             source: None,
             notes: None,
+            execution: None,
         }
     }
 

--- a/tests/evaluation/datasets/posix/README.md
+++ b/tests/evaluation/datasets/posix/README.md
@@ -1,0 +1,62 @@
+# Execution-grounded POSIX dataset
+
+`exec_grounded.json` holds `TestCategory::Execution` cases: instead of
+comparing the generated command *string* against an expected string, the eval
+harness **executes** the generated command in a disposable sandbox and grades
+what actually happened. That makes grading generation-agnostic — any correct
+command that produces the expected effects passes, however it is phrased.
+
+Run it:
+
+```bash
+cd tools/exec-harness && npm ci && cd ../..   # once
+cargo test --test evaluation -- \
+  --dataset tests/evaluation/datasets/posix/exec_grounded.json \
+  --execution-tier tier0
+```
+
+## Case shape
+
+On top of the standard `TestCase` fields, each case carries an `execution`
+block:
+
+```json
+{
+  "execution": {
+    "fixture_files": { "data.txt": "b\na\nb\n" },
+    "expected": {
+      "exit_code": 0,
+      "stdout_pattern": "…regex…",
+      "files_created": ["sorted.txt"],
+      "files_removed": [],
+      "files_modified": []
+    },
+    "tier0": "supported"
+  }
+}
+```
+
+Every populated expectation is one scored criterion; `exit_code` defaults to
+expecting 0. File paths are workspace-relative (the sandbox cwd is `/work`).
+
+## Honesty rules (read before adding cases)
+
+1. **Tier 0 is a smoke tier, not ground truth.** The engine is
+   [`just-bash`](https://github.com/vercel-labs/just-bash) — neither GNU nor
+   BSD userland. It proves a command parses, runs, exits as expected, and
+   touches the right files. GNU/BSD flag fidelity is tier 1's job (real Linux
+   containers, `tools/exec-harness/worker/`).
+2. **Label every case's `tier0` compatibility** — `supported`, `partial`
+   (runs, behavior differs; assert only what holds), or `unsupported`
+   (skipped on tier 0). Measure the label by piping the command through
+   `node tools/exec-harness/src/serve.mjs`; don't guess.
+3. **An engine gap is never a command failure.** Commands the engine can't
+   interpret (exit 127 "command not found") are auto-skipped; `unsupported`
+   labels skip up front. Pass-rates must measure command quality only.
+4. **Assert only invariant effects.** Grading runs against whatever command
+   the backend generated, so expectations must hold for *any* correct answer
+   to the request (e.g. "count lines" → assert `\b5\b` in stdout, not the
+   exact `wc -l` byte output).
+5. **Known snapshot blind spots**: fs_diff hashes regular-file content only —
+   directory creation and permission changes are invisible (see exec-024/025);
+   such cases grade exit-code only.

--- a/tests/evaluation/datasets/posix/exec_grounded.json
+++ b/tests/evaluation/datasets/posix/exec_grounded.json
@@ -1,0 +1,422 @@
+[
+  {
+    "id": "exec-001",
+    "category": "execution",
+    "input_request": "create an empty file called report.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "expected": { "files_created": ["report.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-002",
+    "category": "execution",
+    "input_request": "copy notes.txt to notes.bak",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "notes.txt": "meeting at noon\n" },
+      "expected": { "files_created": ["notes.bak"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-003",
+    "category": "execution",
+    "input_request": "rename draft.txt to final.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "draft.txt": "v1 content\n" },
+      "expected": { "files_created": ["final.txt"], "files_removed": ["draft.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-004",
+    "category": "execution",
+    "input_request": "delete the file old.log",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "old.log": "stale\n" },
+      "expected": { "files_removed": ["old.log"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-005",
+    "category": "execution",
+    "input_request": "count the number of lines in access.log",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "access.log": "GET /\nGET /a\nPOST /b\nGET /c\nGET /d\n" },
+      "expected": { "stdout_pattern": "\\b5\\b" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-006",
+    "category": "execution",
+    "input_request": "show the first three lines of poem.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "poem.txt": "line-one\nline-two\nline-three\nline-four\n" },
+      "expected": { "stdout_pattern": "(?s)\\Aline-one\\s+line-two\\s+line-three\\s*\\z" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-007",
+    "category": "execution",
+    "input_request": "show the last two lines of poem.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "poem.txt": "line-one\nline-two\nline-three\nline-four\n" },
+      "expected": { "stdout_pattern": "(?s)\\Aline-three\\s+line-four\\s*\\z" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-008",
+    "category": "execution",
+    "input_request": "find all lines containing ERROR in app.log",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "search"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "app.log": "ok\nERROR alpha\nok\nERROR beta\n" },
+      "expected": { "stdout_pattern": "(?s)ERROR alpha.*ERROR beta" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-009",
+    "category": "execution",
+    "input_request": "count how many lines in app.log contain ERROR",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "search"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "app.log": "ok\nERROR alpha\nok\nERROR beta\n" },
+      "expected": { "stdout_pattern": "\\b2\\b" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-010",
+    "category": "execution",
+    "input_request": "search app.log for lines containing FATAL",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "search", "exit-code"],
+    "difficulty": "medium",
+    "source": "manual",
+    "notes": "No matches exist: a faithful grep exits 1 with empty output. Grades exit-code semantics, not just happy paths.",
+    "execution": {
+      "fixture_files": { "app.log": "ok\nERROR alpha\n" },
+      "expected": { "exit_code": 1 },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-011",
+    "category": "execution",
+    "input_request": "sort names.txt alphabetically and save the result to sorted.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text", "redirect"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "names.txt": "carol\nalice\nbob\n" },
+      "expected": { "files_created": ["sorted.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-012",
+    "category": "execution",
+    "input_request": "remove duplicate lines from data.txt and save the result to unique.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text", "redirect"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "data.txt": "b\na\nb\nc\na\n" },
+      "expected": { "files_created": ["unique.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-013",
+    "category": "execution",
+    "input_request": "replace every occurrence of foo with bar in config.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text", "in-place"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "config.txt": "foo=1\nname=foo\n" },
+      "expected": { "files_modified": ["config.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-014",
+    "category": "execution",
+    "input_request": "append the word DONE to status.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops", "redirect"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "status.txt": "started\n" },
+      "expected": { "files_modified": ["status.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-015",
+    "category": "execution",
+    "input_request": "create a tar.gz archive named backup.tar.gz containing data.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "archive"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "data.txt": "payload\n" },
+      "expected": { "files_created": ["backup.tar.gz"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-016",
+    "category": "execution",
+    "input_request": "compress big.log with gzip",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "archive"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "big.log": "many entries\n" },
+      "expected": { "files_created": ["big.log.gz"], "files_removed": ["big.log"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-017",
+    "category": "execution",
+    "input_request": "find all .log files under the current directory",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "search"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "a.log": "1\n", "sub/c.log": "2\n", "d.txt": "3\n" },
+      "expected": { "stdout_pattern": "(?s)a\\.log.*c\\.log" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-018",
+    "category": "execution",
+    "input_request": "delete all .tmp files in the current directory",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops", "glob"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "x.tmp": "1\n", "y.tmp": "2\n", "keep.txt": "3\n" },
+      "expected": { "files_removed": ["x.tmp", "y.tmp"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-019",
+    "category": "execution",
+    "input_request": "extract the second comma-separated column from users.csv",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text", "csv"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "users.csv": "1,alice\n2,bob\n" },
+      "expected": { "stdout_pattern": "(?s)alice.*bob" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-020",
+    "category": "execution",
+    "input_request": "count the words in essay.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "essay.txt": "one two three\nfour five\n" },
+      "expected": { "stdout_pattern": "\\b5\\b" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-021",
+    "category": "execution",
+    "input_request": "combine part1.txt and part2.txt into combined.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops", "redirect"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "part1.txt": "first\n", "part2.txt": "second\n" },
+      "expected": { "files_created": ["combined.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-022",
+    "category": "execution",
+    "input_request": "show the most frequent line in visits.txt with its count",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "pipeline"],
+    "difficulty": "hard",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "visits.txt": "home\nabout\nhome\ncontact\nhome\n" },
+      "expected": { "stdout_pattern": "3\\s+home" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-023",
+    "category": "execution",
+    "input_request": "extract the name field from package.json",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "json"],
+    "difficulty": "medium",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "package.json": "{\"name\":\"caro\",\"version\":\"1.5.0\"}\n" },
+      "expected": { "stdout_pattern": "caro" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-024",
+    "category": "execution",
+    "input_request": "make script.sh executable",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "permissions"],
+    "difficulty": "easy",
+    "source": "manual",
+    "notes": "Snapshots hash content only, so a mode change is invisible to fs_diff; the case still proves the command parses and exits 0.",
+    "execution": {
+      "fixture_files": { "script.sh": "#!/bin/sh\necho hi\n" },
+      "expected": {},
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-025",
+    "category": "execution",
+    "input_request": "create a directory named build",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops"],
+    "difficulty": "easy",
+    "source": "manual",
+    "notes": "fs_diff tracks regular files only (find -type f), so an empty directory is invisible; exit-0 grading still catches a broken command.",
+    "execution": {
+      "expected": {},
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-026",
+    "category": "execution",
+    "input_request": "write the text hello world into greeting.txt",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "file-ops", "redirect"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "expected": { "files_created": ["greeting.txt"] },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-027",
+    "category": "execution",
+    "input_request": "print code.txt with line numbers",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "text"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "fixture_files": { "code.txt": "alpha\nbeta\n" },
+      "expected": { "stdout_pattern": "(?s)1\\s+alpha.*2\\s+beta" },
+      "tier0": "supported"
+    }
+  },
+  {
+    "id": "exec-028",
+    "category": "execution",
+    "input_request": "show the disk usage of the current directory",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "system"],
+    "difficulty": "easy",
+    "source": "manual",
+    "notes": "just-bash du reports virtual sizes that differ from real userland; only exit 0 is asserted.",
+    "execution": {
+      "fixture_files": { "f.txt": "x\n" },
+      "expected": {},
+      "tier0": "partial"
+    }
+  },
+  {
+    "id": "exec-029",
+    "category": "execution",
+    "input_request": "list all running processes",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "system"],
+    "difficulty": "easy",
+    "source": "manual",
+    "notes": "No process model in tier 0 (ps is not implemented) — documents the tier boundary; tier 1 real containers cover it.",
+    "execution": {
+      "expected": {},
+      "tier0": "unsupported"
+    }
+  },
+  {
+    "id": "exec-030",
+    "category": "execution",
+    "input_request": "print today's date in YYYY-MM-DD format",
+    "validation_rule": "must_execute",
+    "tags": ["exec-grounded", "system"],
+    "difficulty": "easy",
+    "source": "manual",
+    "execution": {
+      "expected": { "stdout_pattern": "\\d{4}-\\d{2}-\\d{2}" },
+      "tier0": "supported"
+    }
+  }
+]

--- a/tests/evaluation/main.rs
+++ b/tests/evaluation/main.rs
@@ -23,7 +23,9 @@
 //! cargo test --test evaluation -- --threshold 0.10
 //! ```
 
-use caro::evaluation::{BaselineStore, Dataset, EvaluationHarness, HarnessConfig, TestCategory};
+use caro::evaluation::{
+    BaselineStore, Dataset, EvaluationHarness, ExecutionTier, HarnessConfig, TestCategory,
+};
 use clap::Parser;
 use std::path::PathBuf;
 use std::process;
@@ -34,9 +36,19 @@ use std::sync::Arc;
 #[command(name = "evaluation")]
 #[command(about = "Run LLM evaluation harness", long_about = None)]
 struct Args {
-    /// Test category to run (correctness, safety, posix, multi_backend)
+    /// Test category to run (correctness, safety, posix, multi_backend, execution)
     #[arg(long)]
     category: Option<String>,
+
+    /// Dataset file to load (YAML or JSON test-case array)
+    #[arg(long, default_value = "tests/evaluation/dataset.yaml")]
+    dataset: PathBuf,
+
+    /// Sandbox tier for execution-category cases (off, tier0).
+    /// tier0 = just-bash via tools/exec-harness (needs `npm ci` there);
+    /// when unavailable, execution cases are skipped, never failed.
+    #[arg(long, default_value = "off")]
+    execution_tier: String,
 
     /// Backend to test (static_matcher, mlx, ollama, vllm)
     #[arg(long)]
@@ -91,13 +103,24 @@ fn validate_args(args: &Args) -> Result<(), String> {
     // Validate category if provided
     if let Some(ref category) = args.category {
         match category.as_str() {
-            "correctness" | "safety" | "posix" | "multi_backend" => {}
+            "correctness" | "safety" | "posix" | "multi_backend" | "execution" => {}
             _ => {
                 return Err(format!(
-                "Invalid category: {}. Must be one of: correctness, safety, posix, multi_backend",
+                "Invalid category: {}. Must be one of: correctness, safety, posix, multi_backend, execution",
                 category
             ))
             }
+        }
+    }
+
+    // Validate execution tier
+    match args.execution_tier.as_str() {
+        "off" | "tier0" => {}
+        _ => {
+            return Err(format!(
+                "Invalid execution tier: {}. Must be 'off' or 'tier0'",
+                args.execution_tier
+            ))
         }
     }
 
@@ -146,8 +169,7 @@ fn validate_args(args: &Args) -> Result<(), String> {
 /// Run evaluation with given arguments
 async fn run_evaluation(args: Args) -> Result<i32, Box<dyn std::error::Error>> {
     // Load dataset
-    let dataset_path = "tests/evaluation/dataset.yaml";
-    let dataset = Dataset::load(dataset_path)?;
+    let dataset = Dataset::load(&args.dataset)?;
 
     // Apply category filter if provided by creating filtered dataset
     let filtered_dataset = if let Some(ref category_str) = args.category {
@@ -164,6 +186,10 @@ async fn run_evaluation(args: Args) -> Result<i32, Box<dyn std::error::Error>> {
         skip_unavailable: true,
         regression_threshold: 0.95, // 95% pass rate
         max_concurrency: 10,
+        execution_tier: match args.execution_tier.as_str() {
+            "tier0" => ExecutionTier::Tier0,
+            _ => ExecutionTier::Off, // validated earlier
+        },
     };
 
     // Note: Backend filtering is not yet supported through HarnessConfig
@@ -244,6 +270,7 @@ fn parse_category(s: &str) -> Result<TestCategory, String> {
         "safety" => Ok(TestCategory::Safety),
         "posix" => Ok(TestCategory::POSIX),
         "multi_backend" => Ok(TestCategory::MultiBackend),
+        "execution" => Ok(TestCategory::Execution),
         _ => Err(format!("Invalid category: {}", s)),
     }
 }

--- a/tests/red_team/main.rs
+++ b/tests/red_team/main.rs
@@ -1,0 +1,201 @@
+//! Red-team detonation suite (ADR-017 phase P2).
+//!
+//! Executes every entry of the dangerous-command corpus
+//! (`tests/evaluation/datasets/safety/dangerous_patterns.json`) inside a
+//! disposable Cloudflare Sandbox container via the tier-1 exec-harness worker
+//! (`tools/exec-harness/worker/`), records the observed blast radius as an
+//! evidence file, and flags corpus entries whose *measured* impact contradicts
+//! their labeled risk level. This is what turns "52+ dangerous patterns" from
+//! an assertion into a measurement — the suite HELP_WANTED.md promises and
+//! docs/SECURITY-CHECKLIST.md Gate 6 references.
+//!
+//! Network-gated like the repo's other env-dependent tests:
+//!
+//! ```bash
+//! CARO_DETONATION_URL=https://caro-exec-harness.<account>.workers.dev \
+//! CARO_DETONATION_TOKEN=<bearer> \
+//! cargo test --test red_team -- --ignored
+//! ```
+//!
+//! Runs nightly, non-blocking, via `.github/workflows/detonation-nightly.yml`
+//! once the Cloudflare secrets exist (human-created per decision D5).
+
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct CorpusFile {
+    test_cases: Vec<CorpusCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusCase {
+    id: String,
+    expected_command: String,
+    risk_level: String,
+    #[serde(default)]
+    category: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DetonationResponse {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    exit_code: i64,
+    #[serde(default)]
+    timed_out: bool,
+    #[serde(default)]
+    blast: Blast,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Blast {
+    #[serde(default)]
+    canaries_destroyed: Vec<String>,
+    #[serde(default)]
+    files_removed: u64,
+    #[serde(default)]
+    files_modified: u64,
+    #[serde(default)]
+    files_created: u64,
+    #[serde(default)]
+    system_intact: bool,
+}
+
+impl Blast {
+    /// True when the run left any observable trace at all.
+    fn observable_impact(&self) -> bool {
+        !self.canaries_destroyed.is_empty()
+            || self.files_removed > 0
+            || self.files_modified > 0
+            || self.files_created > 0
+            || !self.system_intact
+    }
+}
+
+const CORPUS: &str = "tests/evaluation/datasets/safety/dangerous_patterns.json";
+
+#[tokio::test]
+#[ignore = "requires CARO_DETONATION_URL + CARO_DETONATION_TOKEN (nightly detonation lane)"]
+async fn detonate_dangerous_corpus() {
+    let url = std::env::var("CARO_DETONATION_URL").expect("CARO_DETONATION_URL not set");
+    let token = std::env::var("CARO_DETONATION_TOKEN").expect("CARO_DETONATION_TOKEN not set");
+
+    let corpus: CorpusFile =
+        serde_json::from_str(&std::fs::read_to_string(CORPUS).expect("corpus file readable"))
+            .expect("corpus parses");
+    assert!(!corpus.test_cases.is_empty(), "corpus must not be empty");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(90))
+        .build()
+        .expect("client builds");
+
+    let mut evidence: Vec<serde_json::Value> = Vec::new();
+    // A critical-labeled command that completes cleanly with zero observable
+    // effects contradicts its label: either the pattern is miscalibrated or
+    // the sandbox hides the effect class (e.g. raw device writes). Both are
+    // findings a human should review, so they fail the suite.
+    let mut contradictions: Vec<String> = Vec::new();
+    let mut infra_failures: Vec<String> = Vec::new();
+
+    for case in &corpus.test_cases {
+        let response = client
+            .post(format!("{}/detonate", url.trim_end_matches('/')))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "id": case.id,
+                "command": case.expected_command,
+                "risk_level": case.risk_level,
+                "timeout_ms": 15000,
+            }))
+            .send()
+            .await;
+
+        let parsed: Option<DetonationResponse> = match response {
+            Ok(r) => r.json().await.ok(),
+            Err(e) => {
+                infra_failures.push(format!("{}: transport error: {e}", case.id));
+                None
+            }
+        };
+
+        let Some(det) = parsed else {
+            infra_failures.push(format!("{}: unparseable response", case.id));
+            continue;
+        };
+
+        if !det.ok {
+            infra_failures.push(format!(
+                "{}: harness error: {}",
+                case.id,
+                det.error.as_deref().unwrap_or("unknown")
+            ));
+            continue;
+        }
+
+        let benign_run = det.exit_code == 0 && !det.timed_out && !det.blast.observable_impact();
+        if case.risk_level == "critical" && benign_run {
+            contradictions.push(format!(
+                "{} ({} / {}): labeled critical but completed exit 0 with zero observable effects",
+                case.id, case.category, case.expected_command
+            ));
+        }
+
+        evidence.push(serde_json::json!({
+            "id": case.id,
+            "command": case.expected_command,
+            "risk_level": case.risk_level,
+            "category": case.category,
+            "exit_code": det.exit_code,
+            "timed_out": det.timed_out,
+            "canaries_destroyed": det.blast.canaries_destroyed,
+            "files_removed": det.blast.files_removed,
+            "files_modified": det.blast.files_modified,
+            "files_created": det.blast.files_created,
+            "system_intact": det.blast.system_intact,
+            "label_contradiction": case.risk_level == "critical" && benign_run,
+        }));
+    }
+
+    // Evidence artifact: uploaded by the nightly workflow, reviewable by humans.
+    let out_dir = std::path::Path::new("tests/red_team/evidence");
+    std::fs::create_dir_all(out_dir).expect("evidence dir");
+    let out_path = out_dir.join(format!(
+        "{}-detonation.json",
+        chrono::Utc::now().format("%Y-%m-%d")
+    ));
+    std::fs::write(
+        &out_path,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "generated_at": chrono::Utc::now().to_rfc3339(),
+            "corpus": CORPUS,
+            "total_cases": corpus.test_cases.len(),
+            "detonated": evidence.len(),
+            "infra_failures": infra_failures,
+            "results": evidence,
+        }))
+        .expect("evidence serializes"),
+    )
+    .expect("evidence written");
+    eprintln!("detonation evidence: {}", out_path.display());
+
+    // More than 20% infra failures means the lane itself is broken — fail
+    // loudly rather than reporting a hollow green.
+    let infra_ratio = infra_failures.len() as f64 / corpus.test_cases.len() as f64;
+    assert!(
+        infra_ratio <= 0.2,
+        "detonation lane unhealthy ({} of {} requests failed):\n{}",
+        infra_failures.len(),
+        corpus.test_cases.len(),
+        infra_failures.join("\n")
+    );
+
+    assert!(
+        contradictions.is_empty(),
+        "risk-label contradictions found (pattern miscalibrated or sandbox blind spot):\n{}",
+        contradictions.join("\n")
+    );
+}

--- a/tools/exec-harness/.gitignore
+++ b/tools/exec-harness/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/exec-harness/PROTOCOL.md
+++ b/tools/exec-harness/PROTOCOL.md
@@ -1,0 +1,99 @@
+# Exec-Harness Protocol (v0)
+
+Provider-neutral JSONL contract for executing a single shell command in a
+disposable sandbox and reporting what actually happened. Every execution tier
+speaks this protocol, so evaluators and tests never depend on a specific
+vendor or engine:
+
+| Tier | Engine | Transport |
+|------|--------|-----------|
+| 0 | [`just-bash`](https://github.com/vercel-labs/just-bash) in plain Node (this package) | stdin/stdout JSONL |
+| 1 | `@cloudflare/sandbox` (GA) container via `worker/` | HTTPS `POST /exec`, same JSON body/response |
+| 2 | `@cloudflare/computer` (preview) backends via `worker/experimental/` | HTTPS, same shape |
+
+Future providers (E2B, local Docker, bubblewrap) implement the same request/
+response pair. See `docs/adr/ADR-017-cloud-assisted-verification.md` for the
+policy on which tiers may back CI-blocking jobs.
+
+## Transport (tier 0)
+
+`node src/serve.mjs` reads one JSON object per line on stdin and writes exactly
+one JSON object per line on stdout for each request. Diagnostics go to stderr
+only. The process is long-lived; each request gets a **fresh, isolated
+filesystem** — nothing persists between requests.
+
+## Handshake
+
+Request: `{"op": "ping"}`
+Response: `{"op": "pong", "engine": "just-bash", "engine_version": "<semver>", "protocol": 0}`
+
+Callers should ping once at startup and treat a failed handshake as
+"tier unavailable" (skip, don't fail).
+
+## Exec request
+
+```json
+{
+  "id": "posix-exec-001",
+  "command": "sort -u data.txt > out/sorted.txt",
+  "shell": "bash",
+  "fixture_files": { "data.txt": "b\na\nb\n" },
+  "env": { "LANG": "C" },
+  "timeout_ms": 5000
+}
+```
+
+- `id` (required): opaque; echoed back verbatim.
+- `command` (required): the command line to execute.
+- `shell` (optional): recorded only. Tier 0 always interprets with just-bash's
+  bash-compatible parser; other tiers may honor it.
+- `fixture_files` (optional): map of path → content seeded before execution.
+  Relative paths land under the workspace (`/work`, the starting cwd);
+  absolute paths are honored as given.
+- `env` (optional): extra environment variables.
+- `timeout_ms` (optional): wall-clock budget, default 5000, capped at 30000.
+
+## Exec response
+
+```json
+{
+  "id": "posix-exec-001",
+  "ok": true,
+  "exit_code": 0,
+  "stdout": "",
+  "stderr": "",
+  "duration_ms": 12,
+  "unsupported": false,
+  "fs_diff": {
+    "created": ["/work/out/sorted.txt"],
+    "removed": [],
+    "modified": []
+  }
+}
+```
+
+- `ok: false` + `error` means the harness itself failed (bad JSON, internal
+  error) — callers must treat this as infrastructure failure, not a command
+  result.
+- `exit_code`: the command's exit code (127 for unknown commands).
+- `stdout` / `stderr`: truncated to 64 KiB / 16 KiB; when truncated the field
+  ends with `"\n…[truncated]"`.
+- `unsupported: true`: the engine could not interpret the command
+  (tier 0: exit 127 with a `command not found` diagnostic). Evaluators MUST
+  score this as SKIP, never FAIL — it measures the engine's dialect coverage,
+  not the command's correctness.
+- `timed_out: true` is set (with `exit_code: 124`) when the budget elapsed.
+- `fs_diff`: file paths created/removed/modified relative to the pre-execution
+  snapshot, sorted. Engine pseudo-files (`/bin`, `/usr`, `/proc`, `/dev`) are
+  excluded from snapshots.
+
+## Fidelity caveat (tier 0)
+
+just-bash is neither GNU nor BSD userland: a small number of flag combinations
+accepted by real shells are unsupported or behave differently. Tier 0 is a
+**smoke tier**: it proves a generated command parses, runs, exits as expected,
+and touches the files it should. It is NOT ground truth for GNU/BSD flag
+compatibility — that is what tier 1 real-userland containers are for. Dataset
+cases record their tier-0 compatibility in the `tier0` field
+(`supported` / `partial` / `unsupported`); see
+`tests/evaluation/datasets/posix/README.md`.

--- a/tools/exec-harness/README.md
+++ b/tools/exec-harness/README.md
@@ -1,0 +1,44 @@
+# caro exec-harness
+
+Execution-grounded verification for generated shell commands. For the first
+time, caro's eval can answer "does this command actually *run* and do what the
+test expects?" instead of only "does the string look right?".
+
+Part of the cloud-assisted verification architecture — see
+[`docs/adr/ADR-017-cloud-assisted-verification.md`](../../docs/adr/ADR-017-cloud-assisted-verification.md).
+
+## Tier 0 (this package)
+
+Runs commands in [`just-bash`](https://github.com/vercel-labs/just-bash)
+(Apache-2.0): a bash reimplementation in pure TypeScript with an in-memory
+filesystem. Nothing is ever spawned on the host, no network, no Cloudflare
+account, no secrets — it runs anywhere Node ≥ 20.18 runs, including CI.
+
+```bash
+npm ci
+npm test          # protocol self-tests
+npm run serve     # JSONL server on stdin/stdout (see PROTOCOL.md)
+```
+
+One-liner smoke:
+
+```bash
+printf '%s\n' '{"id":"demo","command":"sort -u data.txt > out.txt","fixture_files":{"data.txt":"b\na\nb\n"}}' \
+  | node src/serve.mjs
+```
+
+Consumed by `ExecutionEvaluator` (`src/evaluation/evaluators/execution.rs`)
+when the eval harness runs with `--execution-tier tier0`, against the dataset
+in `tests/evaluation/datasets/posix/exec_grounded.json`.
+
+**Fidelity caveat**: just-bash ≠ GNU ≠ BSD. Tier 0 is a smoke tier (parses,
+runs, exits right, touches the right files), not flag-compatibility ground
+truth — that's tier 1's job (`worker/`, real Linux userland via
+`@cloudflare/sandbox`). Details in [PROTOCOL.md](./PROTOCOL.md).
+
+## Tier 1/2 (`worker/`)
+
+A Cloudflare Worker exposing the same protocol over HTTPS backed by real
+disposable Linux containers, plus the safety-corpus detonation endpoint.
+Dormant until `CARO_CF_ACCOUNT_ID` / `CARO_CF_API_TOKEN` secrets exist —
+see [worker/README.md](./worker/README.md).

--- a/tools/exec-harness/package-lock.json
+++ b/tools/exec-harness/package-lock.json
@@ -1,0 +1,1041 @@
+{
+  "name": "caro-exec-harness",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caro-exec-harness",
+      "version": "0.1.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "just-bash": "3.4.2"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@jitl/quickjs-ffi-types": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
+      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==",
+      "license": "MIT"
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-asyncify/-/quickjs-wasmfile-debug-asyncify-0.32.0.tgz",
+      "integrity": "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-sync/-/quickjs-wasmfile-debug-sync-0.32.0.tgz",
+      "integrity": "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-asyncify/-/quickjs-wasmfile-release-asyncify-0.32.0.tgz",
+      "integrity": "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-sync/-/quickjs-wasmfile-release-sync-0.32.0.tgz",
+      "integrity": "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mongodb-js/zstd": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-7.0.0.tgz",
+      "integrity": "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/just-bash": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.4.2.tgz",
+      "integrity": "sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "diff": "^8.0.4",
+        "fast-xml-parser": "^5.10.1",
+        "file-type": "^21.3.4",
+        "ini": "^6.0.0",
+        "minimatch": "^10.2.6",
+        "modern-tar": "^0.7.7",
+        "papaparse": "^5.6.0",
+        "quickjs-emscripten": "^0.32.0",
+        "re2js": "^1.3.3",
+        "seek-bzip": "^2.0.0",
+        "smol-toml": "^1.8.0",
+        "sprintf-js": "^1.1.3",
+        "sql.js": "^1.14.1",
+        "turndown": "^7.2.4",
+        "undici": "^7.29.0",
+        "yaml": "^2.9.0"
+      },
+      "bin": {
+        "just-bash": "dist/bin/just-bash.js",
+        "just-bash-shell": "dist/bin/shell/shell.js"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/zstd": "^7.0.0",
+        "node-liblzma": "^2.2.0"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-liblzma": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-liblzma/-/node-liblzma-2.2.0.tgz",
+      "integrity": "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==",
+      "hasInstallScript": true,
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "bin": {
+        "nxz": "lib/cli/nxz.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/oorabona"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.7.0.tgz",
+      "integrity": "sha512-qBGxg/7Q3Kl9Wfhrz2Z74UnvnHTXLNG6jmKJFeBvP2+y4lV7So+7SR62+Zd47JvdrCkX+nDcnr0ObPzek/+6RA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quickjs-emscripten": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.32.0.tgz",
+      "integrity": "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-debug-sync": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-sync": "0.32.0",
+        "quickjs-emscripten-core": "0.32.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/quickjs-emscripten-core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
+      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/re2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-1.3.3.tgz",
+      "integrity": "sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/seek-bzip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+      "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.0.0"
+      },
+      "bin": {
+        "seek-bunzip": "bin/seek-bunzip",
+        "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.2.tgz",
+      "integrity": "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/tools/exec-harness/package.json
+++ b/tools/exec-harness/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "caro-exec-harness",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tier-0 execution harness: runs generated shell commands in just-bash (pure-JS bash, in-memory FS) and reports exit code + filesystem effects over a provider-neutral JSONL protocol. See PROTOCOL.md.",
+  "type": "module",
+  "license": "AGPL-3.0",
+  "engines": {
+    "node": ">=20.18.1"
+  },
+  "scripts": {
+    "serve": "node src/serve.mjs",
+    "test": "node test/serve.test.mjs"
+  },
+  "dependencies": {
+    "just-bash": "3.4.2"
+  }
+}

--- a/tools/exec-harness/src/serve.mjs
+++ b/tools/exec-harness/src/serve.mjs
@@ -1,0 +1,184 @@
+// Tier-0 exec-harness server: executes shell commands in just-bash (a pure-JS
+// bash with an in-memory filesystem — nothing is ever spawned on the host) and
+// reports exit code, output, and filesystem effects over the JSONL protocol
+// described in ../PROTOCOL.md.
+//
+// One JSON request per stdin line, one JSON response per stdout line.
+// Diagnostics go to stderr. Each request gets a fresh Bash instance.
+
+import { createInterface } from "node:readline";
+import { readFileSync } from "node:fs";
+import { Bash } from "just-bash";
+
+// just-bash doesn't export its package.json; report the version we pin.
+const ENGINE_VERSION = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+).dependencies["just-bash"];
+
+const WORKSPACE = "/work";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_TIMEOUT_MS = 30_000;
+const STDOUT_CAP = 64 * 1024;
+const STDERR_CAP = 16 * 1024;
+// Engine-provided pseudo-files; never part of a command's observable effects.
+const SNAPSHOT_EXCLUDE = ["/bin/", "/usr/", "/proc/", "/dev/"];
+
+function truncate(text, cap) {
+  if (typeof text !== "string") return "";
+  return text.length > cap ? `${text.slice(0, cap)}\n…[truncated]` : text;
+}
+
+function seedFiles(fixtureFiles) {
+  // The workspace dir must exist even with no fixtures (it is the cwd).
+  const files = { [`${WORKSPACE}/.keep`]: "" };
+  for (const [rawPath, content] of Object.entries(fixtureFiles ?? {})) {
+    const path = rawPath.startsWith("/") ? rawPath : `${WORKSPACE}/${rawPath}`;
+    files[path] = String(content);
+  }
+  return files;
+}
+
+async function snapshot(bash) {
+  // Hash every real file via the engine itself so the same technique ports to
+  // remote tiers. `sort` keeps the output stable; parse failures are fatal for
+  // the request (ok:false), not silently empty.
+  const r = await bash.exec("find / -type f -exec sha256sum {} + | sort");
+  if (r.exitCode !== 0) {
+    throw new Error(`snapshot failed (exit ${r.exitCode}): ${r.stderr}`);
+  }
+  const state = new Map();
+  for (const line of r.stdout.split("\n")) {
+    if (!line) continue;
+    const m = /^([0-9a-f]{64})\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const path = m[2];
+    if (SNAPSHOT_EXCLUDE.some((prefix) => path.startsWith(prefix))) continue;
+    if (path === `${WORKSPACE}/.keep`) continue;
+    state.set(path, m[1]);
+  }
+  return state;
+}
+
+function diffSnapshots(before, after) {
+  const created = [];
+  const removed = [];
+  const modified = [];
+  for (const [path, hash] of after) {
+    if (!before.has(path)) created.push(path);
+    else if (before.get(path) !== hash) modified.push(path);
+  }
+  for (const path of before.keys()) {
+    if (!after.has(path)) removed.push(path);
+  }
+  created.sort();
+  removed.sort();
+  modified.sort();
+  return { created, removed, modified };
+}
+
+async function handleExec(request) {
+  const timeoutMs = Math.min(
+    Number(request.timeout_ms) > 0 ? Number(request.timeout_ms) : DEFAULT_TIMEOUT_MS,
+    MAX_TIMEOUT_MS,
+  );
+
+  const bash = new Bash({
+    files: seedFiles(request.fixture_files),
+    env: request.env ?? {},
+    cwd: WORKSPACE,
+    executionLimits: { maxExecutionTimeMs: timeoutMs },
+  });
+
+  const before = await snapshot(bash);
+  const started = performance.now();
+
+  let result;
+  let timedOut = false;
+  // Belt and suspenders on top of the engine's own maxExecutionTimeMs: never
+  // let one request wedge the server.
+  const timer = new Promise((resolve) =>
+    setTimeout(() => resolve(null), timeoutMs + 1_000),
+  );
+  const settled = await Promise.race([
+    bash.exec(String(request.command)).then(
+      (r) => ({ r }),
+      (e) => ({ e }),
+    ),
+    timer,
+  ]);
+  if (settled === null) {
+    timedOut = true;
+    result = { exitCode: 124, stdout: "", stderr: "harness: execution timed out\n" };
+  } else if (settled.e) {
+    // Engine-level rejections (e.g. execution-limit aborts) are still a
+    // command outcome, not a harness failure.
+    result = { exitCode: 124, stdout: "", stderr: `harness: ${String(settled.e)}\n` };
+    timedOut = /time|limit/i.test(String(settled.e));
+  } else {
+    result = settled.r;
+  }
+
+  const durationMs = Math.round(performance.now() - started);
+  const after = await snapshot(bash);
+
+  const unsupported =
+    result.exitCode === 127 && /command not found/.test(result.stderr ?? "");
+
+  return {
+    id: request.id,
+    ok: true,
+    exit_code: result.exitCode,
+    stdout: truncate(result.stdout, STDOUT_CAP),
+    stderr: truncate(result.stderr, STDERR_CAP),
+    duration_ms: durationMs,
+    unsupported,
+    timed_out: timedOut,
+    fs_diff: diffSnapshots(before, after),
+  };
+}
+
+async function handleLine(line) {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return { ok: false, error: "invalid JSON request" };
+  }
+
+  if (request.op === "ping") {
+    return {
+      op: "pong",
+      engine: "just-bash",
+      engine_version: ENGINE_VERSION,
+      protocol: 0,
+    };
+  }
+
+  if (typeof request.id !== "string" || typeof request.command !== "string") {
+    return { id: request.id ?? null, ok: false, error: "id and command are required" };
+  }
+
+  try {
+    return await handleExec(request);
+  } catch (error) {
+    return { id: request.id, ok: false, error: String(error) };
+  }
+}
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+let pending = Promise.resolve();
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  // Serialize requests: responses come back in request order.
+  pending = pending.then(async () => {
+    const response = await handleLine(line);
+    process.stdout.write(`${JSON.stringify(response)}\n`);
+  });
+});
+
+rl.on("close", () => {
+  pending.then(() => process.exit(0));
+});
+
+process.stderr.write("exec-harness tier-0 ready (just-bash)\n");

--- a/tools/exec-harness/test/serve.test.mjs
+++ b/tools/exec-harness/test/serve.test.mjs
@@ -1,0 +1,121 @@
+// Self-tests for the tier-0 exec-harness server. Spawns serve.mjs as a child
+// process and drives it over the real JSONL transport, so what passes here is
+// exactly what the Rust ExecutionEvaluator sees.
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "serve.mjs");
+
+const child = spawn(process.execPath, [serverPath], {
+  stdio: ["pipe", "pipe", "inherit"],
+});
+const responses = [];
+const waiters = [];
+createInterface({ input: child.stdout }).on("line", (line) => {
+  const value = JSON.parse(line);
+  const waiter = waiters.shift();
+  if (waiter) waiter(value);
+  else responses.push(value);
+});
+
+function send(request) {
+  child.stdin.write(`${JSON.stringify(request)}\n`);
+  if (responses.length > 0) return Promise.resolve(responses.shift());
+  return new Promise((resolve) => waiters.push(resolve));
+}
+
+let failures = 0;
+async function check(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`FAIL - ${name}\n  ${error.message}`);
+  }
+}
+
+await check("handshake", async () => {
+  const r = await send({ op: "ping" });
+  assert.equal(r.op, "pong");
+  assert.equal(r.engine, "just-bash");
+  assert.equal(r.protocol, 0);
+});
+
+await check("basic exec with exit code and stdout", async () => {
+  const r = await send({ id: "t1", command: "printf 'hello'" });
+  assert.equal(r.ok, true);
+  assert.equal(r.exit_code, 0);
+  assert.equal(r.stdout, "hello");
+  assert.equal(r.unsupported, false);
+});
+
+await check("fixture files are seeded and readable", async () => {
+  const r = await send({
+    id: "t2",
+    command: "grep -c ERROR logs/app.log",
+    fixture_files: { "logs/app.log": "ok\nERROR one\nERROR two\n" },
+  });
+  assert.equal(r.exit_code, 0);
+  assert.equal(r.stdout.trim(), "2");
+});
+
+await check("fs_diff reports created, modified, removed", async () => {
+  const r = await send({
+    id: "t3",
+    command: "sort -u data.txt > sorted.txt && echo extra >> data.txt && rm old.txt",
+    fixture_files: { "data.txt": "b\na\nb\n", "old.txt": "bye\n" },
+  });
+  assert.equal(r.exit_code, 0);
+  assert.deepEqual(r.fs_diff.created, ["/work/sorted.txt"]);
+  assert.deepEqual(r.fs_diff.modified, ["/work/data.txt"]);
+  assert.deepEqual(r.fs_diff.removed, ["/work/old.txt"]);
+});
+
+await check("nonzero exit codes pass through", async () => {
+  const r = await send({ id: "t4", command: "grep needle /dev/null" });
+  assert.equal(r.exit_code, 1);
+});
+
+await check("unknown command is unsupported, not a failure", async () => {
+  const r = await send({ id: "t5", command: "systemctl restart nginx" });
+  assert.equal(r.ok, true);
+  assert.equal(r.exit_code, 127);
+  assert.equal(r.unsupported, true);
+});
+
+await check("requests are isolated (no filesystem bleed)", async () => {
+  const r = await send({ id: "t6", command: "cat sorted.txt" });
+  assert.notEqual(r.exit_code, 0, "sorted.txt from t3 must not exist here");
+});
+
+await check("pipelines and quoting survive the wire", async () => {
+  const r = await send({
+    id: "t7",
+    command: "awk '{print $2}' access.log | sort | uniq -c | sort -rn | head -1",
+    fixture_files: { "access.log": "a x\nb y\nc x\n" },
+  });
+  assert.equal(r.exit_code, 0);
+  assert.match(r.stdout, /2 x/);
+});
+
+await check("malformed request yields ok:false, server survives", async () => {
+  child.stdin.write("this is not json\n");
+  const bad = await (responses.length ? responses.shift() : new Promise((res) => waiters.push(res)));
+  assert.equal(bad.ok, false);
+  const r = await send({ id: "t8", command: "true" });
+  assert.equal(r.exit_code, 0);
+});
+
+child.stdin.end();
+await once(child, "exit");
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log("\nall exec-harness tests passed");

--- a/tools/exec-harness/worker/.gitignore
+++ b/tools/exec-harness/worker/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/tools/exec-harness/worker/Dockerfile
+++ b/tools/exec-harness/worker/Dockerfile
@@ -1,0 +1,10 @@
+# Container image for the tier-1 exec sandbox.
+# The @cloudflare/sandbox runtime expects its own base image; keep the tag in
+# lockstep with the package.json dependency version (verify both at
+# activation — see README activation checklist).
+FROM docker.io/cloudflare/sandbox:0.12.9
+
+# Detonation runs must never reach the network: the harness asserts observable
+# blast radius, not exfiltration behavior. Baseline hardening — activation
+# checklist additionally verifies egress policy at the Cloudflare config layer.
+ENV HARNESS_ROLE=exec-tier1

--- a/tools/exec-harness/worker/README.md
+++ b/tools/exec-harness/worker/README.md
@@ -1,0 +1,52 @@
+# caro exec-harness worker (tier 1) — dormant scaffolding
+
+Serves `PROTOCOL.md` over HTTPS backed by disposable **real-Linux** containers
+(`@cloudflare/sandbox`, GA), plus `POST /detonate` for the red-team suite
+(`tests/red_team/`). Committed dormant per ADR-017: nothing here runs until a
+human creates the Cloudflare account and tokens (decision D5 reserves vendor
+secrets to humans).
+
+## Routes
+
+- `GET /healthz` — unauthenticated liveness.
+- `POST /exec` — protocol request → fresh container → protocol response
+  (exit code, stdout/stderr, `/work`+`/tmp` fs_diff). Fails closed without a
+  bearer token.
+- `POST /detonate` — `{id, command, risk_level}` → canary file tree → run →
+  blast-radius report (canaries destroyed, file counts, system-intact probe).
+
+Every request gets its own sandbox, destroyed in `finally`. Commands run under
+coreutils `timeout`. No repo secrets are ever mounted into containers.
+
+## Activation checklist (human + agent)
+
+1. **Human**: create/choose the Cloudflare account; enable Workers Paid
+   (Containers require it); create an API token scoped to Workers.
+2. **Human**: add GitHub repo secrets `CARO_CF_ACCOUNT_ID`,
+   `CARO_CF_API_TOKEN` (used by nightly workflows), and keep a personal copy
+   for local wrangler.
+3. `cd tools/exec-harness/worker && npm ci && npm run typecheck`.
+4. Verify the container base image tag in `Dockerfile` matches the
+   `@cloudflare/sandbox` version in `package.json` (SDK and image must be in
+   lockstep — check the [sandbox-sdk docs](https://developers.cloudflare.com/sandbox/)).
+5. **Egress policy**: before the first `/detonate` run, confirm containers
+   cannot reach the network (Cloudflare container egress settings), so corpus
+   entries like `curl … | sh` fail on egress rather than fetching anything.
+6. `npx wrangler secret put HARNESS_TOKEN` (generate a long random bearer).
+7. `npm run deploy` — needs local Docker (wrangler builds the container
+   image from `Dockerfile`). Smoke: `GET /healthz`, then one `/exec` with
+   `{"id":"smoke","command":"echo hi"}`.
+8. Add repo secrets `CARO_DETONATION_URL` + `CARO_DETONATION_TOKEN`; dispatch
+   `.github/workflows/detonation-nightly.yml` manually once and review the
+   evidence artifact.
+
+## Cost envelope
+
+Workers Paid $5/mo + Containers pay-per-use. The nightly corpus is ~100 short
+commands on `lite` instances — well under one container-hour per night.
+
+## Experimental lane
+
+Backend-fidelity comparison against `@cloudflare/computer` (preview) belongs
+in `experimental/` (not yet created) and may never back a required check —
+ADR-017's preview-API policy.

--- a/tools/exec-harness/worker/package-lock.json
+++ b/tools/exec-harness/worker/package-lock.json
@@ -1,0 +1,1621 @@
+{
+  "name": "caro-exec-harness-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caro-exec-harness-worker",
+      "version": "0.1.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@cloudflare/sandbox": "0.12.9"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "5.20260906.1",
+        "typescript": "5.9.3",
+        "wrangler": "4.129.0"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/sandbox": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/@cloudflare/sandbox/-/sandbox-0.12.9.tgz",
+      "integrity": "sha512-JlCQ8adVaHT3TrZO13X6US2LJTyQ4YvoEZpfh5EewRqcxPfMHZNJPB/1dsRdiFqmtzpz+lMxGazSUa2H/g2IKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.5",
+        "aws4fetch": "^1.0.20",
+        "capnweb": "^0.8.0",
+        "hono": "^4.13.0"
+      },
+      "peerDependencies": {
+        "@openai/agents": "^0.3.3",
+        "@opencode-ai/sdk": "^1.1.40",
+        "@xterm/xterm": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@openai/agents": {
+          "optional": true
+        },
+        "@opencode-ai/sdk": {
+          "optional": true
+        },
+        "@xterm/xterm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260906.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260906.1.tgz",
+      "integrity": "sha512-mRKC5n+9OP7tZiOu7vMv2MZ+Arh3tX4b9gVAt43WFns83LNzWchhfRs9o2IkFCnYKovHo4m4Af1P4zPQWdLx0g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/capnweb": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.8.0.tgz",
+      "integrity": "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260903.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260903.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260903.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260903.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/tools/exec-harness/worker/package.json
+++ b/tools/exec-harness/worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "caro-exec-harness-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tier-1 exec-harness: PROTOCOL.md over HTTPS backed by disposable Cloudflare Sandbox containers, plus the safety-corpus detonation endpoint. Dormant until CF account secrets exist (ADR-017).",
+  "type": "module",
+  "license": "AGPL-3.0",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "check": "wrangler deploy --dry-run"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "0.12.9"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "5.20260906.1",
+    "typescript": "5.9.3",
+    "wrangler": "4.129.0"
+  }
+}

--- a/tools/exec-harness/worker/src/index.ts
+++ b/tools/exec-harness/worker/src/index.ts
@@ -1,0 +1,229 @@
+// Tier-1 exec-harness worker (ADR-017 phase P2) — DORMANT until CF secrets
+// exist. Speaks the same protocol as the tier-0 Node runner
+// (../../PROTOCOL.md) over HTTPS, backed by disposable real-Linux containers
+// via @cloudflare/sandbox (GA). Adds /detonate: executes entries from the
+// dangerous-command corpus in an isolated throwaway container and reports the
+// observed blast radius, turning safety risk levels from assertions into
+// measurements (tests/red_team/).
+//
+// Security posture: bearer-token auth on every route; one fresh sandbox per
+// request, destroyed in `finally`; commands run under `timeout` inside the
+// container; no repo secrets are ever mounted. Egress policy is enforced at
+// the Cloudflare layer — verifying it is an activation-checklist item
+// (README.md) before the first detonation run.
+
+import { getSandbox, type Sandbox } from "@cloudflare/sandbox";
+export { Sandbox } from "@cloudflare/sandbox";
+
+interface Env {
+  Sandbox: DurableObjectNamespace<Sandbox>;
+  HARNESS_TOKEN: string;
+}
+
+interface ExecRequestBody {
+  id?: string;
+  command?: string;
+  shell?: string;
+  fixture_files?: Record<string, string>;
+  env?: Record<string, string>;
+  timeout_ms?: number;
+}
+
+interface DetonateRequestBody {
+  id?: string;
+  command?: string;
+  risk_level?: string;
+  timeout_ms?: number;
+}
+
+const WORKSPACE = "/work";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = 60_000;
+const OUTPUT_CAP = 64 * 1024;
+
+const shellQuote = (s: string): string => `'${s.replaceAll("'", `'\\''`)}'`;
+
+const truncate = (s: string): string =>
+  s.length > OUTPUT_CAP ? `${s.slice(0, OUTPUT_CAP)}\n…[truncated]` : s;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function authorized(request: Request, env: Env): boolean {
+  const header = request.headers.get("authorization") ?? "";
+  const token = header.replace(/^Bearer\s+/i, "");
+  // Deployed-with-no-secret must fail closed.
+  return env.HARNESS_TOKEN !== undefined && env.HARNESS_TOKEN !== "" && token === env.HARNESS_TOKEN;
+}
+
+function clampTimeout(ms: number | undefined): number {
+  const value = typeof ms === "number" && ms > 0 ? ms : DEFAULT_TIMEOUT_MS;
+  return Math.min(value, MAX_TIMEOUT_MS);
+}
+
+/** Runs `command` inside the sandbox under coreutils `timeout` (exit 124). */
+async function timedExec(sandbox: Sandbox, command: string, timeoutMs: number) {
+  const seconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  return sandbox.exec(
+    `cd ${WORKSPACE} 2>/dev/null; timeout ${seconds}s sh -c ${shellQuote(command)}`,
+  );
+}
+
+/** Content-hash snapshot of the observable workspace (same technique as tier 0). */
+async function snapshot(sandbox: Sandbox): Promise<Map<string, string>> {
+  const result = await sandbox.exec(
+    `find ${WORKSPACE} /tmp -type f -exec sha256sum {} + 2>/dev/null | sort; true`,
+  );
+  const state = new Map<string, string>();
+  for (const line of result.stdout.split("\n")) {
+    const m = /^([0-9a-f]{64})\s+(.+)$/.exec(line);
+    if (m) state.set(m[2], m[1]);
+  }
+  return state;
+}
+
+function diffSnapshots(before: Map<string, string>, after: Map<string, string>) {
+  const created: string[] = [];
+  const removed: string[] = [];
+  const modified: string[] = [];
+  for (const [path, hash] of after) {
+    if (!before.has(path)) created.push(path);
+    else if (before.get(path) !== hash) modified.push(path);
+  }
+  for (const path of before.keys()) {
+    if (!after.has(path)) removed.push(path);
+  }
+  return { created: created.sort(), removed: removed.sort(), modified: modified.sort() };
+}
+
+async function seedFixtures(sandbox: Sandbox, fixtures: Record<string, string>) {
+  await sandbox.exec(`mkdir -p ${WORKSPACE}`);
+  for (const [rawPath, content] of Object.entries(fixtures)) {
+    const path = rawPath.startsWith("/") ? rawPath : `${WORKSPACE}/${rawPath}`;
+    const dir = path.slice(0, path.lastIndexOf("/"));
+    if (dir) await sandbox.exec(`mkdir -p ${shellQuote(dir)}`);
+    await sandbox.writeFile(path, content);
+  }
+}
+
+/** PROTOCOL.md /exec: one command, fresh container, protocol-shaped response. */
+async function handleExec(env: Env, body: ExecRequestBody): Promise<Response> {
+  if (typeof body.id !== "string" || typeof body.command !== "string") {
+    return json({ id: body.id ?? null, ok: false, error: "id and command are required" }, 400);
+  }
+  const timeoutMs = clampTimeout(body.timeout_ms);
+  const sandbox = getSandbox(env.Sandbox, `exec-${crypto.randomUUID()}`);
+  try {
+    await seedFixtures(sandbox, body.fixture_files ?? {});
+    const before = await snapshot(sandbox);
+    const started = Date.now();
+    const result = await timedExec(sandbox, body.command, timeoutMs);
+    const durationMs = Date.now() - started;
+    const after = await snapshot(sandbox);
+
+    return json({
+      id: body.id,
+      ok: true,
+      exit_code: result.exitCode,
+      stdout: truncate(result.stdout),
+      stderr: truncate(result.stderr),
+      duration_ms: durationMs,
+      unsupported: result.exitCode === 127 && /command not found|not found/.test(result.stderr),
+      timed_out: result.exitCode === 124,
+      fs_diff: diffSnapshots(before, after),
+    });
+  } catch (error) {
+    return json({ id: body.id, ok: false, error: String(error) }, 500);
+  } finally {
+    await sandbox.destroy();
+  }
+}
+
+/**
+ * /detonate: run a dangerous-corpus entry against a canary file tree and
+ * report what it actually destroyed. Consumed by tests/red_team/.
+ */
+async function handleDetonate(env: Env, body: DetonateRequestBody): Promise<Response> {
+  if (typeof body.id !== "string" || typeof body.command !== "string") {
+    return json({ id: body.id ?? null, ok: false, error: "id and command are required" }, 400);
+  }
+  const timeoutMs = clampTimeout(body.timeout_ms);
+  const sandbox = getSandbox(env.Sandbox, `detonate-${crypto.randomUUID()}`);
+  try {
+    // Canary tree: what a real home/workspace would lose.
+    await seedFixtures(sandbox, {
+      "canary/document.txt": "irreplaceable\n",
+      "canary/sub/nested.txt": "also irreplaceable\n",
+      "canary/.config": "settings\n",
+    });
+    const before = await snapshot(sandbox);
+    const started = Date.now();
+    const result = await timedExec(sandbox, body.command, timeoutMs);
+    const durationMs = Date.now() - started;
+    const after = await snapshot(sandbox);
+    const diff = diffSnapshots(before, after);
+
+    // Did the userland itself survive? (e.g. rm -rf /, dd onto a device)
+    const probe = await sandbox.exec("ls /usr/bin >/dev/null 2>&1 && cat /etc/os-release >/dev/null 2>&1; echo $?");
+    const systemIntact = probe.stdout.trim().endsWith("0");
+    const canariesDestroyed = diff.removed.filter((p) => p.includes("/canary/"));
+
+    return json({
+      id: body.id,
+      ok: true,
+      risk_level: body.risk_level ?? null,
+      exit_code: result.exitCode,
+      duration_ms: durationMs,
+      timed_out: result.exitCode === 124,
+      stdout: truncate(result.stdout),
+      stderr: truncate(result.stderr),
+      blast: {
+        canaries_destroyed: canariesDestroyed,
+        files_removed: diff.removed.length,
+        files_modified: diff.modified.length,
+        files_created: diff.created.length,
+        system_intact: systemIntact,
+      },
+    });
+  } catch (error) {
+    return json({ id: body.id, ok: false, error: String(error) }, 500);
+  } finally {
+    await sandbox.destroy();
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/healthz") {
+      return json({ ok: true, service: "caro-exec-harness", protocol: 0 });
+    }
+    if (!authorized(request, env)) {
+      return json({ ok: false, error: "unauthorized" }, 401);
+    }
+    if (request.method !== "POST") {
+      return json({ ok: false, error: "POST only" }, 405);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ ok: false, error: "invalid JSON body" }, 400);
+    }
+
+    switch (url.pathname) {
+      case "/exec":
+        return handleExec(env, body as ExecRequestBody);
+      case "/detonate":
+        return handleDetonate(env, body as DetonateRequestBody);
+      default:
+        return json({ ok: false, error: "unknown route" }, 404);
+    }
+  },
+} satisfies ExportedHandler<Env>;

--- a/tools/exec-harness/worker/tsconfig.json
+++ b/tools/exec-harness/worker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/tools/exec-harness/worker/wrangler.jsonc
+++ b/tools/exec-harness/worker/wrangler.jsonc
@@ -1,0 +1,35 @@
+// Tier-1 exec-harness worker — DORMANT SCAFFOLDING (ADR-017 phase P2).
+// Deploys only after a human creates the Cloudflare account and secrets
+// (decision D5): wrangler secret put HARNESS_TOKEN, then `npm run deploy`.
+// Activation checklist: ../worker/README.md.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "caro-exec-harness",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-01",
+  "observability": { "enabled": true },
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      // lite is enough: each request runs one shell command in a throwaway
+      // container; the nightly detonation corpus is ~100 short-lived runs.
+      "instance_type": "lite",
+      "max_instances": 4
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "Sandbox",
+        "name": "Sandbox"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["Sandbox"]
+    }
+  ]
+}

--- a/website/e2e/.gitignore
+++ b/website/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/website/e2e/README.md
+++ b/website/e2e/README.md
@@ -1,0 +1,34 @@
+# caro.sh structural QA (Kitesurf)
+
+Nightly structural checks of the production site, driven through
+[Cloudflare Browser Run's Kitesurf engine](https://developers.cloudflare.com/browser-run/kitesurf/)
+over CDP — Playwright connects to a remote agent-first browser, so CI needs
+**no local browser install** and the Kitesurf lane is free while in beta.
+Part of ADR-017 phase P3; dormant until CF secrets exist.
+
+Suites (structural only — Kitesurf is not pixel-perfect; brand/visual audits
+stay on the claude-design Chromium flow):
+
+- `i18n-leaks.spec.ts` — raw translation keys visible on any key page or
+  locale home (the documented L1 regression class).
+- `links.spec.ts` — internal links on key pages resolve.
+- `structure.spec.ts` — nav/footer/h1 present; `lang`/RTL plumbing wired.
+- `screenshot-smoke.spec.ts` — page rasterizes to a non-blank frame.
+
+## Run
+
+```bash
+cd website/e2e && npm ci
+CARO_CF_ACCOUNT_ID=… CARO_CF_API_TOKEN=… npm test
+# real Chromium via the same endpoint (paid; manual runs only):
+BROWSER_MODE=chromium CARO_CF_ACCOUNT_ID=… CARO_CF_API_TOKEN=… npm test
+# against a preview deploy:
+CARO_QA_BASE_URL=https://deploy-preview.example npm test
+npm run list   # validates config with no credentials
+```
+
+CI: `.github/workflows/website-qa-kitesurf.yml` (nightly, non-blocking,
+skips green without secrets).
+
+This package is deliberately separate from `website/package.json` so Vercel
+production installs are unaffected.

--- a/website/e2e/fixtures.ts
+++ b/website/e2e/fixtures.ts
@@ -1,0 +1,67 @@
+// Shared fixture: routes every test's browser through Cloudflare Browser Run
+// over CDP. Default engine is Kitesurf (free beta); BROWSER_MODE=chromium
+// drops the query parameter and the exact same endpoint serves real Chromium
+// (paid) — the trivial fallback ADR-017 relies on.
+import { test as base, chromium, type Browser } from "@playwright/test";
+
+export function credentials(): { accountId: string; apiToken: string } | null {
+  const accountId = process.env.CARO_CF_ACCOUNT_ID;
+  const apiToken = process.env.CARO_CF_API_TOKEN;
+  return accountId && apiToken ? { accountId, apiToken } : null;
+}
+
+export const laneDormant =
+  "Kitesurf lane dormant: CARO_CF_ACCOUNT_ID / CARO_CF_API_TOKEN not set (see ADR-017 P3)";
+
+function wsEndpoint(accountId: string): string {
+  const engine = process.env.BROWSER_MODE === "chromium" ? "" : "?browser=kitesurf";
+  return `wss://api.cloudflare.com/client/v4/accounts/${accountId}/browser-run/devtools/browser${engine}`;
+}
+
+export const test = base.extend<object, { browser: Browser }>({
+  browser: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const creds = credentials();
+      if (!creds) throw new Error(laneDormant);
+      const browser = await chromium.connectOverCDP(wsEndpoint(creds.accountId), {
+        headers: { Authorization: `Bearer ${creds.apiToken}` },
+        timeout: 30_000,
+      });
+      await use(browser);
+      await browser.close();
+    },
+    { scope: "worker" },
+  ],
+});
+
+export const expect = test.expect;
+
+/** Key routes checked in every suite (EN lives at the root). */
+export const KEY_ROUTES = [
+  "/",
+  "/pricing",
+  "/faq",
+  "/roadmap",
+  "/try-caro",
+  "/telemetry",
+  "/glossary",
+];
+
+/** Non-default locales served under /[lang]/ (mirror of src/i18n/locales/). */
+export const LOCALES = [
+  "ar",
+  "de",
+  "es",
+  "fil",
+  "fr",
+  "he",
+  "hi",
+  "id",
+  "ja",
+  "ko",
+  "pt",
+  "ru",
+  "uk",
+  "ur",
+];

--- a/website/e2e/i18n-leaks.spec.ts
+++ b/website/e2e/i18n-leaks.spec.ts
@@ -1,0 +1,42 @@
+// Raw-i18n-key leak scan — the documented L1 regression class: a missing EN
+// key makes EVERY locale render the literal key path (e.g.
+// "landing.hero.headline.line1" visible on the homepage). See
+// .claude/rules/astro-esbuild-shell-syntax.md "Lessons Learned" L1.
+//
+// The namespace list is read from src/i18n/locales/en/*.json at runtime, so
+// new translation namespaces are covered without touching this file.
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { test, expect, credentials, laneDormant, KEY_ROUTES, LOCALES } from "./fixtures";
+
+test.skip(() => !credentials(), laneDormant);
+
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "i18n", "locales", "en");
+const namespaces = readdirSync(localesDir)
+  .filter((f) => f.endsWith(".json"))
+  .map((f) => f.replace(/\.json$/, ""));
+
+// e.g. "landing.hero.headline.line1" — a known namespace followed by ≥2
+// dotted segments. Anchored to word boundaries so prose and URLs don't match.
+const leakPattern = new RegExp(
+  `\\b(?:${namespaces.join("|")})(?:\\.[A-Za-z0-9_-]+){2,}\\b`,
+  "g",
+);
+
+const pages: { route: string; label: string }[] = [
+  ...KEY_ROUTES.map((route) => ({ route, label: `en ${route}` })),
+  ...LOCALES.map((lang) => ({ route: `/${lang}/`, label: `${lang} home` })),
+];
+
+for (const { route, label } of pages) {
+  test(`no raw translation keys visible: ${label}`, async ({ page }) => {
+    const response = await page.goto(route, { waitUntil: "domcontentloaded" });
+    expect(response, `no response for ${route}`).toBeTruthy();
+    expect(response!.status(), `${route} should be served`).toBeLessThan(400);
+
+    const visibleText = await page.evaluate(() => document.body?.innerText ?? "");
+    const leaks = [...new Set(visibleText.match(leakPattern) ?? [])];
+    expect(leaks, `raw i18n keys rendered on ${route}: ${leaks.join(", ")}`).toEqual([]);
+  });
+}

--- a/website/e2e/links.spec.ts
+++ b/website/e2e/links.spec.ts
@@ -1,0 +1,39 @@
+// Internal link integrity: collect same-origin hrefs from key pages via the
+// Kitesurf DOM, then verify each target serves (status < 400). Status checks
+// go straight from the runner (plain fetch) — only DOM extraction needs the
+// browser engine.
+import { test, expect, credentials, laneDormant, KEY_ROUTES } from "./fixtures";
+
+test.skip(() => !credentials(), laneDormant);
+
+test("internal links on key pages resolve", async ({ page, baseURL }) => {
+  test.setTimeout(240_000);
+  const origin = new URL(baseURL!).origin;
+  const targets = new Map<string, string>(); // url -> first page referencing it
+
+  for (const route of KEY_ROUTES) {
+    await page.goto(route, { waitUntil: "domcontentloaded" });
+    const hrefs = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("a[href]"), (a) => (a as HTMLAnchorElement).href),
+    );
+    for (const href of hrefs) {
+      try {
+        const url = new URL(href);
+        if (url.origin !== origin) continue; // external links are out of scope
+        url.hash = "";
+        if (!targets.has(url.toString())) targets.set(url.toString(), route);
+      } catch {
+        // ignore unparseable hrefs (mailto:, javascript:)
+      }
+    }
+  }
+
+  expect(targets.size, "expected to discover internal links").toBeGreaterThan(5);
+
+  const broken: string[] = [];
+  for (const [url, referrer] of targets) {
+    const res = await fetch(url, { method: "GET", redirect: "follow" });
+    if (res.status >= 400) broken.push(`${url} -> ${res.status} (linked from ${referrer})`);
+  }
+  expect(broken, `broken internal links:\n${broken.join("\n")}`).toEqual([]);
+});

--- a/website/e2e/package-lock.json
+++ b/website/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "caro-website-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caro-website-e2e",
+      "version": "0.1.0",
+      "license": "AGPL-3.0",
+      "devDependencies": {
+        "@playwright/test": "1.63.0",
+        "@types/node": "22.18.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/website/e2e/package.json
+++ b/website/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "caro-website-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Structural QA for caro.sh driven through Cloudflare Browser Run's Kitesurf engine over CDP. Own package on purpose: website/package.json stays untouched so Vercel installs are unaffected. Dormant until CF secrets exist (ADR-017 phase P3).",
+  "type": "module",
+  "license": "AGPL-3.0",
+  "scripts": {
+    "test": "playwright test",
+    "list": "playwright test --list"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.63.0",
+    "@types/node": "22.18.0"
+  }
+}

--- a/website/e2e/playwright.config.ts
+++ b/website/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+// Kitesurf website QA — ADR-017 phase P3 (dormant until CF secrets exist).
+//
+// Structural checks only: raw-i18n-key leaks, link integrity, DOM presence,
+// renders-at-all screenshots. Kitesurf is explicitly NOT pixel-perfect, so
+// brand-fidelity/visual work stays with the claude-design Chromium flow
+// (.claude/rules/design-dialogue-protocol.md).
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "*.spec.ts",
+  // Kitesurf trades wall-time for cost (~1.8× slower than Chromium).
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  retries: 1,
+  // Beta service with per-account limits — keep concurrency polite.
+  workers: 2,
+  fullyParallel: false,
+  reporter: [["line"]],
+  use: {
+    baseURL: process.env.CARO_QA_BASE_URL ?? "https://caro.sh",
+  },
+});

--- a/website/e2e/screenshot-smoke.spec.ts
+++ b/website/e2e/screenshot-smoke.spec.ts
@@ -1,0 +1,16 @@
+// Renders-at-all screenshot smoke: proves Kitesurf can rasterize the page and
+// the page isn't blank. NOT a visual-regression check — no pixel comparisons
+// here, ever (Kitesurf is explicitly not pixel-perfect; ADR-017 P3).
+import { mkdirSync, writeFileSync } from "node:fs";
+import { test, expect, credentials, laneDormant } from "./fixtures";
+
+test.skip(() => !credentials(), laneDormant);
+
+test("homepage rasterizes to a non-trivial screenshot", async ({ page }) => {
+  await page.goto("/", { waitUntil: "load" });
+  const shot = await page.screenshot({ type: "png" });
+  // A blank/failed frame compresses to almost nothing.
+  expect(shot.byteLength, "screenshot suspiciously small — blank frame?").toBeGreaterThan(10_000);
+  mkdirSync("test-results", { recursive: true });
+  writeFileSync("test-results/homepage-kitesurf.png", shot);
+});

--- a/website/e2e/structure.spec.ts
+++ b/website/e2e/structure.spec.ts
@@ -1,0 +1,28 @@
+// Structural DOM assertions: the page skeleton users depend on exists and the
+// locale plumbing is wired (lang / dir attributes). Deliberately not visual —
+// Kitesurf rendering is not pixel-perfect and brand audits stay on Chromium.
+import { test, expect, credentials, laneDormant } from "./fixtures";
+
+test.skip(() => !credentials(), laneDormant);
+
+test("homepage has nav, footer, and a headline", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("nav").first()).toBeAttached();
+  await expect(page.locator("footer").first()).toBeAttached();
+  const h1 = (await page.locator("h1").first().textContent())?.trim() ?? "";
+  expect(h1.length, "h1 should carry a real headline").toBeGreaterThan(3);
+});
+
+test("html lang attribute matches the served locale", async ({ page }) => {
+  await page.goto("/es/", { waitUntil: "domcontentloaded" });
+  const lang = await page.evaluate(() => document.documentElement.lang);
+  expect(lang.toLowerCase()).toContain("es");
+});
+
+test("hebrew locale is right-to-left", async ({ page }) => {
+  await page.goto("/he/", { waitUntil: "domcontentloaded" });
+  const dir = await page.evaluate(
+    () => document.documentElement.dir || getComputedStyle(document.documentElement).direction,
+  );
+  expect(dir).toBe("rtl");
+});


### PR DESCRIPTION
## Description

Adopts Cloudflare's new execution primitives (`@cloudflare/sandbox` GA, Kitesurf beta, `@cloudflare/computer`'s just-bash engine) as **dev-harness verification infrastructure** behind a provider-neutral protocol — and, for the first time in this repo, actually *executes* generated commands to grade them. No user-facing change; the product keeps zero cloud runtime dependency.

Architecture and governance record: `docs/adr/ADR-017-cloud-assisted-verification.md`.

### Motivation

Caro's two central claims were never verified by execution: eval stops at string comparison (`src/evaluation/evaluators/correctness.rs`), and the safety corpus is tested as classification only — `tests/red_team/` was promised (`HELP_WANTED.md`) and SECURITY-CHECKLIST Gate 6 pointed at a directory that didn't exist. The website's documented L1 regression class (raw i18n keys on production) had no automated net either. Cloudflare's 2026 releases make closing all three gaps cheap; just-bash makes tier 0 free and secret-less.

### Changes Made

- **Tier-0 exec harness** (`tools/exec-harness/`): just-bash JSONL execution server — pure-TS bash, in-memory FS, nothing spawned on the host, zero secrets, runs in CI today. Contract in `PROTOCOL.md`; 9 protocol self-tests.
- **Execution-grounded eval** (`src/evaluation/evaluators/execution.rs`): new `TestCategory::Execution` + `ExecutionEvaluator` grade *observed behavior* (exit code, stdout, fs_diff) via `--execution-tier tier0`; 30-case seed dataset with **measured** tier0 dialect labels; SKIP-never-FAIL semantics so pass-rates measure command quality, not harness availability. Non-blocking CI job added to `evaluation.yml`.
- **Detonation lane, dormant** (`tools/exec-harness/worker/`, `tests/red_team/`, `detonation-nightly.yml`): Cloudflare Worker (typechecked against the real `@cloudflare/sandbox` 0.12.9 SDK) runs each dangerous-corpus entry in a throwaway real-Linux container and reports blast radius; the suite fails on risk-label contradictions. Skips green until human-created secrets exist (decision D5).
- **Kitesurf website QA, dormant** (`website/e2e/`, `website-qa-kitesurf.yml`): structural nightly checks of caro.sh over CDP — raw-i18n-key leaks (L1 class), link integrity, DOM/RTL plumbing, renders-at-all screenshots. Own package so Vercel installs are untouched; `BROWSER_MODE=chromium` is the paid fallback on the same endpoint. Explicitly not brand/visual work.
- **Governance**: ADR-017; three parked hypotheses in the ledger (`sandbox-preview-ux`, `live-playground`, `agentic-loop`, 0/20 each); COMPANY.md decision-log entry; dev-process.md deploy-matrix drift fix (docs/Storybook are CF Pages since #1351); SECURITY-CHECKLIST Gate 6 now points at the real lane.

---

## Type of Change

- [x] Test coverage (adds or improves tests)
- [x] CI/CD or tooling (changes to build, release, or development tools)
- [x] Documentation update (changes to docs, comments, or guides)

---

## Checklist

### Code Quality

- [x] I have run `cargo fmt --all` (code is properly formatted)
- [x] I have run `cargo clippy -- -D warnings` (0 warnings on `--all-targets`)
- [x] I have run `cargo test` (604/604 lib tests pass; 87 evaluation-module tests green)
- [ ] `cargo audit` — no dependency changes reach the shipped binary (`Cargo.lock` unchanged; `reqwest` dev-dep resolves to the already-present crate)

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added contract tests for new public APIs (protocol self-tests + evaluator unit tests + live round-trip)
- [x] I have added integration tests for cross-module workflows (`tests/red_team/`, env-gated per repo convention)
- [x] Performance: evaluator round-trip ≈ 25 ms/case, well inside the `Evaluator` trait's 5 s contract

### Documentation

- [x] I have added rustdoc comments for new public APIs
- [x] I have updated relevant documentation (ADR-017, PROTOCOL.md, READMEs, SECURITY-CHECKLIST, hypothesis ledger)
- [x] I have added examples to demonstrate new functionality (demo below; dataset README)
- [ ] CHANGELOG.md — internal tooling/docs only; no user-facing behavior changed (flag if you want an Internal entry anyway)

### TDD Workflow

- [x] I followed the Red-Green-Refactor cycle (probe → protocol self-tests → evaluator unit tests → live round-trip)
- [x] I wrote failing tests before implementing the solution (grading logic developed against fixed protocol responses)
- [ ] `cargo watch` not used in this environment

---

## Breaking Changes

None. `TestCase` gains one optional, `#[serde(default)]` field (`execution`); all existing datasets and baselines load unchanged. `HarnessConfig` gains `execution_tier` (defaults `Off`). Nothing in the shipped binary changes.

---

## Related Issues and Specs

- Implements ADR: `docs/adr/ADR-017-cloud-assisted-verification.md` (added here)
- Makes real: `tests/red_team/` promised in `HELP_WANTED.md`; SECURITY-CHECKLIST Gate 6
- Complementary to ADR-010 (bubblewrap local sandbox — remains the product-side plan)
- Strategy alignment: `market-scans/2026-05-15-ai-agent-strategy-memo.md` ("complementary layers, possible integration story"; Opportunity 4 stays the product-side export direction)

---

## Performance Impact

None on the shipped binary: no new runtime dependencies, no default-feature changes, `Cargo.lock` untouched, MSRV 1.85 untouched. Eval runs opt into execution grounding explicitly.

---

## Testing Evidence

### Demo (copy-paste)

```bash
# one-time
cd tools/exec-harness && npm ci && npm test && cd ../..

# a single command through the tier-0 sandbox:
printf '%s\n' '{"id":"demo","command":"sort -u data.txt > out.txt","fixture_files":{"data.txt":"b\na\nb\n"}}' \
  | node tools/exec-harness/src/serve.mjs
# → {"id":"demo","ok":true,"exit_code":0,...,"fs_diff":{"created":["/work/out.txt"],...}}

# execution-grounded eval against the seed dataset:
cargo test --no-default-features --features embedded-cpu --test evaluation -- \
  --dataset tests/evaluation/datasets/posix/exec_grounded.json --execution-tier tier0
```

### Test Output

```
tools/exec-harness $ npm test        → 9/9 protocol self-tests pass
cargo clippy --all-targets           → 0 warnings
cargo test --lib                     → 604 passed; 0 failed; 2 ignored
cargo test --lib evaluation          → 87 passed (incl. 7 ExecutionEvaluator unit tests)
…execution::tests::live_tier0_round_trip -- --ignored → ok (real Node runner)
website/e2e $ npx playwright test --list → 26 tests, config valid with no credentials
worker $ npx tsc --noEmit            → clean against @cloudflare/sandbox 0.12.9
```

### Baseline finding (the point of the whole exercise)

First execution-grounded run against `static_matcher`: **4/30 (13.3%)**. That score is honest signal, not harness noise — execution grading correctly fails template commands that ignore the requested filename (`touch newfile.txt` for "create report.txt"; `wc -l README.md` for "count lines in access.log"), and 12 cases are template-coverage gaps. This is the bar the LLM backends are meant to clear; string-match eval could never see this class of failure.

Bycatch: "delete all .tmp files in the current directory" is **blocked as adversarial** by safety validation — a likely false positive worth its own investigation (violates the zero-false-positive claim).

### Regression guards

- `evaluation::evaluators::execution::tests::*` (7 unit + 1 live)
- `tools/exec-harness/test/serve.test.mjs` (9 protocol tests, run in the `execution-tier0` CI job)
- `tests/red_team/main.rs::detonate_dangerous_corpus` (env-gated; nightly once activated)

### Manual Testing

- [x] Tested on Linux (this environment: tier-0 server, evaluator round-trip, full eval CLI run)
- [ ] macOS/Windows — not applicable (harness is Linux-CI-targeted; evaluator self-disables gracefully elsewhere)
- [x] Edge cases: unknown commands (127→SKIP), malformed JSONL, runner death (EOF→skip+poison), grep-exit-1 semantics, request isolation

---

## Additional Context

### Technical Decisions

- **Provider seam over vendor SDK**: everything speaks `tools/exec-harness/PROTOCOL.md`; Cloudflare is one implementation, and no `@cloudflare/*` type touches Rust. E2B/local-docker/bwrap can slot in later.
- **just-bash as tier 0**: the same engine as `@cloudflare/computer`'s isolate-shell backend, so tier-0 results stay portable upward — but with zero cloud dependency, which is what lets this PR land fully verified without any account.
- **Preview/beta policy**: only GA `@cloudflare/sandbox` may ever back a required check (and only after a quarter of nightly stability); Kitesurf and `computer` stay non-blocking/experimental.
- **Honesty over green**: `tier0` dialect labels were measured by probing every dataset command through the engine; skips are visible in `actual_behavior`, never silent passes of a broken harness (and the red-team suite fails on >20% infra errors, so a dead worker can't produce a hollow green).

### Future Work

- **Activation** (human, per D5): create CF account + tokens → `tools/exec-harness/worker/README.md` checklist → both nightly lanes wake up.
- P4: QA-persona sandboxes (frustrated-beta actually executes); P5: CaroML `sandbox-verify` runbook verification (feature-flagged, sanitizer-gated — designed in ADR-017, exempt as a shipped-loop extension); P6: `caro-profile.json` export (strategy-memo Opportunity 4).
- File the "delete all .tmp files → adversarial" false positive as its own issue.

### Questions for Reviewers

1. Comfortable with the 13.3% honest baseline being visible in a (non-blocking) CI job from day one?
2. Naming/placement of the three parked hypotheses in the ledger.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZauUr4Tw6U5SrMJ5cstpy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZauUr4Tw6U5SrMJ5cstpy)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds execution-grounded verification: generated commands now actually run in a sandbox and are graded on observed effects instead of string comparison. Also lands dormant Cloudflare-backed scaffolding for red-team detonation and website QA; no user-facing or runtime changes.

**Execution-grounded eval**
- New `ExecutionEvaluator` grades exit code, stdout, and filesystem effects — including the *content* of produced files, so `touch notes.bak` no longer passes "copy notes.txt to notes.bak" — via a provider-neutral JSONL protocol; tier 0 rides `just-bash` in a local Node child process (in-memory FS, nothing spawned on the host, zero secrets).
- Disabled tiers and maintainer-labeled engine dialect gaps SKIP; runtime failures (e.g. `command not found`) FAIL, so pass rates measure command quality, not harness availability; timeouts derive from exit 124 alone, so slow-but-complete runs aren't misclassified.
- First honest baseline: 10.0% against the static matcher, catching template commands that ignore the requested filename.
- Non-blocking `execution-tier0` CI job added; `HarnessConfig.execution_tier` defaults `Off`. The job passes on harness health, tolerating the sub-100% exit code so a weak backend never reads as a broken harness, and fails only when the run produces no results table.

**Dormant Cloudflare lanes**
- `tests/red_team` is now real: a Worker backed by `@cloudflare/sandbox` executes dangerous-corpus entries in throwaway real-Linux containers and fails on risk-label contradictions; the nightly job skips green until human-created secrets exist.
- Review hardening: the Worker rejects non-identifier env-var names, and `/detonate` always snapshots after the run so a timeout mid-destruction never reports an empty blast radius; sub-100ms time budgets are honored exactly.
- `website/e2e` runs nightly structural QA of caro.sh over Cloudflare Browser Run (Kitesurf) — raw i18n-key leaks, link integrity, DOM/RTL plumbing, renders-at-all screenshots; skips until secrets exist, and `BROWSER_MODE=chromium` is the paid fallback on the same endpoint.
- ADR-017 and governance artifacts record the architecture, tier policy, and parked hypotheses; a codespell ignore entry clears a false-positive hash fragment in the worker lockfile, and the activation checklist names the LGPL-3.0 `@img/sharp-libvips-*` family plus several `@img/sharp-*` platform builds for the audit.

No breaking changes: `TestCase` gains one optional `serde(default)` field, `Cargo.lock` is untouched, and nothing in the shipped binary changes.

<sup>Written for commit 010ad9fe452162744ffd04a941c601e918849252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

