### PR TITLE
chore(qa): scheduled rotation 2026-09-12

### DIFF
--- a/.claude/memory/qa-bugs-backlog.md
+++ b/.claude/memory/qa-bugs-backlog.md
@@ -8,7 +8,9 @@ Active bugs filed by caro-qa-agent requiring investigation and fixes.
 
 | Issue | Priority | Domain | Summary | Status | Filed |
 |-------|----------|--------|---------|--------|-------|
-| [#1044](https://github.com/wildcard/caro/issues/1044) | P2 | docs | CLAUDE.md version banner shows 1.1.0 (GA) instead of 1.3.0 | open | 2026-05-07 |
+| [#1449](https://github.com/wildcard/caro/issues/1449) | P2 | cli | caro ai --once hangs silently with no output when embedded model is unavailable | open | 2026-09-12 |
+| [#1450](https://github.com/wildcard/caro/issues/1450) | P2 | docs | CLAUDE.md version banner shows 1.4.0 instead of 1.5.0 (re-drift) | open | 2026-09-12 |
+| [#1044](https://github.com/wildcard/caro/issues/1044) | P2 | docs | CLAUDE.md version banner shows 1.1.0 (GA) instead of 1.3.0 | **closed** ✅ | 2026-05-07 |
 
 ---
 

--- a/.claude/memory/qa-coverage-matrix.md
+++ b/.claude/memory/qa-coverage-matrix.md
@@ -1,6 +1,6 @@
 # QA Coverage Matrix
 
-**Last updated**: 2026-05-07
+**Last updated**: 2026-09-12
 
 This file drives Slot C surface selection. Pick the row with the oldest 'Last tested' value (treat 'never' as oldest). Tie-break randomly.
 
@@ -12,6 +12,7 @@ One row per pass. Update 'Last tested' column after every Slot A run.
 
 | Date | Build | --version | --help | doctor | dry-run | Notes |
 |------|-------|-----------|--------|--------|---------|-------|
+| 2026-09-12 | PASS | PASS (1.5.0) | PASS | PASS | FLAKE | FLAKE-001 reproduced (2nd total); 34/34 safety tests pass including PR #1315 evasion fix |
 | 2026-05-07 | PASS | PASS (1.3.0) | PASS | PASS | FLAKE | Model download blocked in sandbox (see flakes); first bootstrap run |
 
 ---
@@ -22,17 +23,17 @@ Slot C selects from this table. Update 'Last tested', 'Result', and 'Linked issu
 
 | # | Surface | Domain | Last tested | Result | Linked issue(s) |
 |---|---------|--------|-------------|--------|-----------------|
-| 1 | CLI smoke (build, --version, --help, doctor) | cli | 2026-05-07 | PASS | — |
-| 2 | `caro -p "..." --dry-run` command generation | cli | 2026-05-07 | FLAKE | — |
+| 1 | CLI smoke (build, --version, --help, doctor) | cli | 2026-09-12 | PASS | — |
+| 2 | `caro -p "..." --dry-run` command generation | cli | 2026-09-12 | FLAKE | FLAKE-001 (sandbox model download blocked) |
 | 3 | Telemetry consent persistence across invocations | cli | 2026-05-07 | PASS | — |
 | 4 | `caro shell-init bash/zsh/fish` | shell-integration | 2026-05-07 | PASS | — |
 | 5 | `caro init` setup wizard (--minimal, --force) | cli | 2026-05-07 | PASS | — |
-| 6 | Safety validation unit tests (cargo test safety) | safety | 2026-05-07 | PASS | — |
-| 7 | Safety CVE patterns (ruleset load, shell filters) | safety | 2026-05-07 | PASS | — |
+| 6 | Safety validation unit tests (cargo test safety) | safety | 2026-09-12 | PASS | 34/34 incl. PR #1315 evasion fix |
+| 7 | Safety CVE patterns (ruleset load, shell filters) | safety | 2026-09-12 | PASS | Covered by safety unit tests |
 | 8 | Full library test suite (cargo test --lib) | cli | 2026-05-07 | PASS | — |
 | 9 | CaroML: `caro new / check / list / jobs` | cli | 2026-05-07 | PASS | — |
-| 10 | `caro ai --once` scripted conversational mode | ai | never | — | — |
-| 11 | `caro ai --continue-session` shell widget | ai | never | — | — |
+| 10 | `caro ai --once` scripted conversational mode | ai | 2026-09-12 | FAIL | [#1449](https://github.com/wildcard/caro/issues/1449) — silent hang, zero output when model unavailable |
+| 11 | `caro ai --continue-session` shell widget | ai | never | — | Likely affected by same bug as #1449; test after fix |
 | 12 | `caro assess` system assessment | cli | never | — | — |
 | 13 | `caro suggest` command suggestions | cli | never | — | — |
 | 14 | `caro config get/set/show/reset` | cli | never | — | — |
@@ -63,7 +64,9 @@ When a filed issue reveals a new surface gap, add it here so Slot C tracks it in
 
 | Issue | Surface | Domain | Filed | Status |
 |-------|---------|--------|-------|--------|
-| [#1044](https://github.com/wildcard/caro/issues/1044) | CLAUDE.md version field alignment | docs | 2026-05-07 | open |
+| [#1449](https://github.com/wildcard/caro/issues/1449) | caro ai --once silent hang when model unavailable | ai | 2026-09-12 | open |
+| [#1450](https://github.com/wildcard/caro/issues/1450) | CLAUDE.md version field re-drift (1.4.0 vs 1.5.0) | docs | 2026-09-12 | open |
+| [#1044](https://github.com/wildcard/caro/issues/1044) | CLAUDE.md version field alignment (1.1.0 vs 1.3.0) | docs | 2026-05-07 | closed ✅ |
 
 ---
 

--- a/.claude/memory/qa-known-flakes.md
+++ b/.claude/memory/qa-known-flakes.md
@@ -13,7 +13,8 @@ Document flaky behaviours observed during QA runs. A flake observed 3+ times in 
 **Context**: Remote CI/QA sandbox where `https://huggingface.co/` returns HTTP 200 but binary blob downloads time out or are blocked at a lower network layer.  
 **Impact**: Slot A `--dry-run` smoke check cannot be completed in this environment. Use `caro --version`, `--help`, and `doctor` as proxy for binary health; use `cargo test --lib` for functional coverage.  
 **Occurrence log**:
-- 2026-05-07: observed once
+- 2026-05-07: observed once (bootstrap pass)
+- 2026-09-12: observed again (2nd total; 128 days since first; NOT within 7-day window; no reclassification)
 
 **Promotion threshold**: File regression issue if observed 3 times in 7 days OR if it reproduces on a known-good environment with a pre-downloaded model.  
 **Workaround**: Run `caro -p "..." --dry-run` from an environment with `~/.cache/caro/models/` pre-populated, or with Ollama installed as fallback backend.

--- a/.claude/memory/qa-session-log.md
+++ b/.claude/memory/qa-session-log.md
@@ -4,6 +4,56 @@ Reading order: most recent first.
 
 ---
 
+## 2026-09-12 — Scheduled run (Slot A + Slot B + Slot C)
+
+**Trigger**: scheduled cron 14:00 UTC.
+**Rotation**: A + B (110 PRs merged since 2026-05-07) + C.
+
+### Slot A — Smoke
+
+- `cargo build --release --features embedded-cpu` → **PASS** (2m 53s, no errors)
+- `caro --version` → **PASS**: `caro 1.5.0 (be07b22 2026-07-18)`
+- `caro --help` → **PASS**: all subcommands listed; new `ai`, `export`, `render`, `skill` visible
+- `caro doctor` → **PASS**: advisory only (no model downloaded, expected in fresh sandbox)
+- `caro -p 'list files in current directory' --dry-run` → **FLAKE**: FLAKE-001 reproduced (model download blocked in sandbox — 2nd total observation, 128 days since first; not within 7-day window, no reclassification)
+- Telemetry consent prompt shown on first invocation (fresh sandbox, expected)
+
+### Slot B — Recent diff
+
+110 PRs merged since 2026-05-07. Spot-checked representative surfaces:
+
+- **PR #1315** `fix(safety): P0 — close quote/escape evasion` → `cargo test --release --lib -- safety` → **PASS**: 34/34 safety unit tests including new `test_quote_escape_evasion_is_caught_base` (uses `shell-words` crate, PR verified working)
+- **PR #1298** `fix(cli): single source of truth for backend roster` → `caro --backend-info` → **PASS**: clean backend table, all backends listed with correct status
+- **PR #1304** `chore(release): v1.5.0` → binary reports correct 1.5.0 version
+- i18n batch (PRs #816-#829): flagged for future Slot C exercise (surface #31 — i18n locale smoke)
+- **PR #883** `feat(tools): MLX LoRA fine-tune pipeline` → flagged for future Slot C exercise (surface deferred — macOS-only MLX, not exercisable in Linux sandbox)
+
+### Slot C — caro ai --once (surface #10)
+
+Surface chosen: **`caro ai --once` scripted conversational mode** (oldest 'never' surface, lowest #).
+
+- `caro ai --help` → **PASS**: subcommand present with `--once`, `--new-session`, `--continue-session` flags documented
+- `caro ai --once "list files in current directory"` → **FAIL**: silent hang, zero output to stderr/stdout after 35 seconds; exits via SIGTERM (code 143)
+- `echo "list files" | caro ai --once` → **FAIL**: same silent hang
+- `cargo test --release --lib -- ai::` → **PASS**: 23/23 AI unit tests pass with mock backend (runner, session, store, privacy, shell_init all green)
+- Root cause investigation: `run_ai_once()` → `backend.generate_command().await` blocks silently during model download retry loop; no progress emitted to stderr unlike regular `caro -p ... --dry-run` path
+
+### Findings
+
+- [#1449](https://github.com/wildcard/caro/issues/1449) — `cli: caro ai --once hangs silently with no output when embedded model is unavailable` (P2)
+- [#1450](https://github.com/wildcard/caro/issues/1450) — `docs: CLAUDE.md version banner shows 1.4.0 instead of 1.5.0 (re-drift)` (P2)
+- [#1044](https://github.com/wildcard/caro/issues/1044) — closed ✅ (CLAUDE.md updated to 1.4.0; 1.5.0 drift filed as new #1450)
+
+### Followups
+
+- FLAKE-001 (model download blocked) — 2nd occurrence total. First on 2026-05-07, second today (128 days apart). Not within 7-day window; log updated but no reclassification.
+- Three previous QA PRs (#1178, #1373, #1443) still open — memory files on main only reflect bootstrap pass. Memory files will be accurate once those PRs merge.
+- MLX LoRA pipeline (PR #883) cannot be exercised in Linux sandbox — add macOS-only note to surface #19 in coverage matrix.
+- `caro ai --continue-session` (surface #11) likely affected by same silent-hang bug as `--once`; should verify after #1449 is fixed.
+- i18n locale smoke (surface #31) now has test coverage via PR #1352 — schedule for next Slot C pass.
+
+---
+
 ## 2026-05-07 — Scheduled run (Slot A + Slot C) [BOOTSTRAP]
 
 **Trigger**: manual invocation; first-ever run of caro-qa-agent (bootstrap pass).


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-sonnet-4-6`) — caro-qa-agent

---

## Summary

Scheduled daily QA rotation 2026-09-12. First run since the bootstrap pass on 2026-05-07 (128 days). Memory files were on main only from that bootstrap; three prior rotation PRs (#1178, #1373, #1443) are still open.

## Slot results

- **A — Smoke**: PASS — `1.5.0 (be07b22 2026-07-18)` builds clean in 2m 53s; `--version`, `--help`, `doctor` all pass; `--dry-run` FLAKE-001 reproduced (2nd total occurrence, 128 days since first; within-7-day window not triggered)
- **B — Recent diff**: 110 PRs merged since 2026-05-07. Spot-checked: safety unit tests (34/34 PASS, confirms PR #1315 P0 quote/escape-evasion fix works including new `test_quote_escape_evasion_is_caught_base` test); `--backend-info` roster (PASS, PR #1298 fix verified); `--version` reports correct 1.5.0 (PR #1304 release confirmed)
- **C — `caro ai --once`** (surface #10, never previously tested): FAIL — silent hang with zero output to stderr/stdout for 35+ seconds when embedded model is unavailable; exits via SIGTERM. Contrast: regular `caro -p ... --dry-run` emits WARN download-attempt messages. 23/23 AI unit tests PASS with mock backend — feature is correctly implemented for happy path; the error/progress path is the gap.

## Issues filed

- [#1449](https://github.com/wildcard/caro/issues/1449) — `cli: caro ai --once hangs silently with no output when embedded model is unavailable` (P2)
- [#1450](https://github.com/wildcard/caro/issues/1450) — `docs: CLAUDE.md version banner shows 1.4.0 instead of 1.5.0 (re-drift)` (P2) — third occurrence of this pattern; #1044 fix updated CLAUDE.md to 1.4.0 but did not add CLAUDE.md to the release-version-alignment checklist

## Memory updates

- Session log: 1 new entry (2026-09-12)
- Coverage matrix: surfaces #1, #2, #6, #7, #10 updated; Slot A smoke row added; bug-filings table updated with #1449 and #1450; #1044 marked closed
- Watch list: 2 issues added (#1449, #1450); #1044 marked closed
- Flakes: FLAKE-001 occurrence log updated (2nd observation noted; no reclassification)

<details>
<summary>Scheduled remote run disclosure</summary>

This PR was created by an automated scheduled task running in a remote Claude Code sandbox. No human was present during execution. The run was triggered by caro-qa-agent's daily schedule (14:00 UTC). All findings are based on code exercised in the sandbox from a fresh `git pull` of `main`.

```
caro QA agent — daily rotation slot A+B+C, scheduled remote run 2026-09-12
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK4jWNEXNA7fFrN7ozi5tZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK4jWNEXNA7fFrN7ozi5tZ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the QA memory files with the 2026-09-12 scheduled rotation results, the first run since the 2026-05-07 bootstrap. Smoke and recent-diff checks pass, but `caro ai --once` hangs silently when the embedded model is unavailable.

- Files two new issues from this run: #1449 for the `caro ai --once` silent hang and #1450 for the CLAUDE.md version banner re-drift.
- Marks #1044 as closed and logs the second FLAKE-001 occurrence without reclassification (not within the 7-day window).
- Updates the coverage matrix with fresh last-tested dates; surface #10 is now marked FAIL.

<sup>Written for commit 4f9f4447c6ab634e8aa83d951d23c1dd4f456dc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wildcard/caro/pull/1453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

